### PR TITLE
modern shell animations: list exits, sliding pill, credential test, hero→split, popover transitions

### DIFF
--- a/apps/gpt-image-2-app/package-lock.json
+++ b/apps/gpt-image-2-app/package-lock.json
@@ -48,6 +48,7 @@
         "prettier": "^3.5.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^3.4.17",
+        "tailwindcss-animate": "^1.0.7",
         "vitest": "^4.1.5"
       }
     },
@@ -4562,6 +4563,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/thenify": {

--- a/apps/gpt-image-2-app/package.json
+++ b/apps/gpt-image-2-app/package.json
@@ -53,6 +53,7 @@
     "prettier": "^3.5.2",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.17",
+    "tailwindcss-animate": "^1.0.7",
     "vitest": "^4.1.5"
   }
 }

--- a/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
@@ -28,7 +28,7 @@ import {
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
-import { motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 import { Button } from "@/components/ui/button";
 import { Empty } from "@/components/ui/empty";
 import { FieldLabel } from "@/components/ui/field";
@@ -977,12 +977,29 @@ export function EditScreen({
             </span>
           </div>
           <div className="flex min-w-0 flex-1 gap-2 overflow-x-auto scrollbar-none pb-0.5">
+            <AnimatePresence initial={false}>
             {refs.map((ref, index) => {
               const isSelected = ref.id === selectedRef;
               const isTarget = usesRegion && ref.id === targetRef?.id;
               const hasMask = Boolean(maskSnapshots[ref.id]);
               return (
-                <div key={ref.id} className="group relative shrink-0">
+                <motion.div
+                  key={ref.id}
+                  layout="position"
+                  initial={
+                    reducedMotion
+                      ? false
+                      : { opacity: 0, scale: 0.92, y: 4 }
+                  }
+                  animate={{ opacity: 1, scale: 1, y: 0 }}
+                  exit={
+                    reducedMotion
+                      ? { opacity: 0 }
+                      : { opacity: 0, scale: 0.88, x: -8 }
+                  }
+                  transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                  className="group relative shrink-0"
+                >
                   <button
                     type="button"
                     onClick={() => setSelectedRef(ref.id)}
@@ -1063,9 +1080,10 @@ export function EditScreen({
                       设为目标
                     </button>
                   )}
-                </div>
+                </motion.div>
               );
             })}
+            </AnimatePresence>
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}

--- a/apps/gpt-image-2-app/src/components/screens/generate/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/generate/index.tsx
@@ -648,10 +648,17 @@ export function GenerateScreen({
         <motion.section
           initial={reducedMotion ? false : { opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
+          // FLIP layout: when hasSplit flips at xl, the form re-anchors
+          // from a centered max-w-[640px] block to the left grid column.
+          // motion.section animates that transition with transform-only,
+          // so the panel slides + resizes smoothly instead of snapping
+          // when the first job lands. Gated off when reducedMotion is on.
+          layout={reducedMotion ? false : "position"}
           transition={{
             duration: reducedMotion ? 0 : 0.42,
             delay: reducedMotion ? 0 : 0.08,
             ease: [0.22, 1, 0.36, 1],
+            layout: { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
           }}
           className={cn(
             "surface-panel mt-3 w-full max-w-[640px] p-4 sm:mt-9 sm:p-5",

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -586,6 +586,7 @@ export function HistoryScreen({
   const cancelJob = useCancelJob();
   const retryJob = useRetryJob();
   const confirm = useConfirm();
+  const reducedMotion = useReducedMotion();
   const [filter, setFilter] = useState<FilterValue>("all");
   const [searchText, setSearchText] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
@@ -835,32 +836,50 @@ export function HistoryScreen({
             </div>
           ) : (
             <>
-              {jobs.map((j, i) => (
-                <JobRowExpandable
-                  key={j.id}
-                  index={i + 1}
-                  job={j}
-                  expanded={expandedIds.has(j.id)}
-                  onToggleExpand={() => toggleExpand(j.id)}
-                  onCancel={() => cancelJob.mutate(j.id)}
-                  onDelete={() => {
-                    deleteJob.mutate(j.id);
-                    setExpandedIds((prev) => {
-                      const next = new Set(prev);
-                      next.delete(j.id);
-                      return next;
-                    });
-                    if (detailJobId === j.id) {
-                      setDetailJobId(null);
+              <AnimatePresence initial={false}>
+                {jobs.map((j, i) => (
+                  <motion.div
+                    key={j.id}
+                    layout="position"
+                    initial={
+                      reducedMotion
+                        ? false
+                        : { opacity: 0, y: 4 }
                     }
-                  }}
-                  onOpenDetail={(outputIndex) => {
-                    setDetailJobId(j.id);
-                    setDetailIndex(outputIndex);
-                  }}
-                  onRetry={() => void handleRetry(j.id)}
-                />
-              ))}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={
+                      reducedMotion
+                        ? { opacity: 0 }
+                        : { opacity: 0, x: -16, scale: 0.98 }
+                    }
+                    transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+                  >
+                    <JobRowExpandable
+                      index={i + 1}
+                      job={j}
+                      expanded={expandedIds.has(j.id)}
+                      onToggleExpand={() => toggleExpand(j.id)}
+                      onCancel={() => cancelJob.mutate(j.id)}
+                      onDelete={() => {
+                        deleteJob.mutate(j.id);
+                        setExpandedIds((prev) => {
+                          const next = new Set(prev);
+                          next.delete(j.id);
+                          return next;
+                        });
+                        if (detailJobId === j.id) {
+                          setDetailJobId(null);
+                        }
+                      }}
+                      onOpenDetail={(outputIndex) => {
+                        setDetailJobId(j.id);
+                        setDetailIndex(outputIndex);
+                      }}
+                      onRetry={() => void handleRetry(j.id)}
+                    />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
               {hasMore && (
                 <div className="flex justify-center px-4 py-4">
                   <Button

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -747,21 +747,37 @@ export function HistoryScreen({
       {/* filters */}
       <div className="mb-4 grid grid-cols-1 items-center gap-3 lg:grid-cols-[1fr_minmax(320px,560px)_1fr]">
         <div className="flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-none">
-          {FILTERS.map((f) => (
-            <button
-              key={f.value}
-              type="button"
-              onClick={() => setFilter(f.value)}
-              className={cn(
-                "px-3.5 h-8 rounded-full text-[12.5px] font-medium transition-colors",
-                filter === f.value
-                  ? "bg-[color:var(--accent-14)] text-foreground border border-[color:var(--accent-30)]"
-                  : "border border-transparent text-muted hover:text-foreground hover:bg-[color:var(--w-04)]",
-              )}
-            >
-              {f.label}
-            </button>
-          ))}
+          {FILTERS.map((f) => {
+            const isActive = filter === f.value;
+            return (
+              <button
+                key={f.value}
+                type="button"
+                onClick={() => setFilter(f.value)}
+                className={cn(
+                  "relative px-3.5 h-8 rounded-full text-[12.5px] font-medium transition-colors",
+                  isActive
+                    ? "text-foreground"
+                    : "text-muted hover:text-foreground hover:bg-[color:var(--w-04)]",
+                )}
+              >
+                {/* Shared accent pill that slides between filter chips. */}
+                {isActive && (
+                  <motion.span
+                    layoutId="history-filter-active-pill"
+                    aria-hidden="true"
+                    className="absolute inset-0 z-0 rounded-full border border-[color:var(--accent-30)]"
+                    style={{ background: "var(--accent-14)" }}
+                    transition={{
+                      duration: reducedMotion ? 0 : 0.24,
+                      ease: [0.22, 1, 0.36, 1],
+                    }}
+                  />
+                )}
+                <span className="relative z-10">{f.label}</span>
+              </button>
+            );
+          })}
         </div>
         <label className="relative block min-w-0">
           <Search

--- a/apps/gpt-image-2-app/src/components/screens/history/job-row.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-row.tsx
@@ -1,4 +1,6 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { cn } from "@/lib/cn";
 import { Icon, type IconName } from "@/components/icon";
 import { Badge } from "@/components/ui/badge";
@@ -222,6 +224,7 @@ export function JobRow({
   onSelectOutput?: (index: number) => void;
   onDelete?: () => void;
 }) {
+  const reducedMotion = useReducedMotion();
   const [hover, setHover] = useState(false);
   const [focusWithin, setFocusWithin] = useState(false);
   const prompt = (job.metadata as Record<string, unknown>)?.prompt as
@@ -354,12 +357,27 @@ export function JobRow({
           )}
         </div>
       </div>
-      {expanded && (
-        <ExpandedOutputs
-          job={job}
-          onOpenIndex={(index) => onSelectOutput?.(index)}
-        />
-      )}
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            key="expanded"
+            initial={
+              reducedMotion ? false : { height: 0, opacity: 0 }
+            }
+            animate={{ height: "auto", opacity: 1 }}
+            exit={
+              reducedMotion ? { opacity: 0 } : { height: 0, opacity: 0 }
+            }
+            transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+            style={{ overflow: "hidden" }}
+          >
+            <ExpandedOutputs
+              job={job}
+              onOpenIndex={(index) => onSelectOutput?.(index)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </Fragment>
   );
 }

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -245,6 +245,7 @@ function SettingsNav({
   tab: SettingsTab;
   setTab: (t: SettingsTab) => void;
 }) {
+  const reducedMotion = useReducedMotion();
   return (
     <aside className="flex min-w-0 shrink-0 flex-col gap-2">
       <div className="px-2 pt-1 pb-1 sm:pb-2">
@@ -260,14 +261,29 @@ function SettingsNav({
               type="button"
               onClick={() => setTab(n.id)}
               className={cn(
-                "flex h-9 shrink-0 items-center gap-2.5 rounded-md px-3 text-left text-[13px] transition-colors md:w-full",
+                "relative flex h-9 shrink-0 items-center gap-2.5 rounded-md px-3 text-left text-[13px] transition-colors md:w-full",
                 active
-                  ? "bg-[color:var(--w-10)] text-foreground border border-[color:var(--w-10)]"
-                  : "border border-transparent text-muted hover:text-foreground hover:bg-[color:var(--w-05)]",
+                  ? "text-foreground"
+                  : "text-muted hover:text-foreground hover:bg-[color:var(--w-05)]",
               )}
             >
-              <I size={14} className="opacity-80" />
-              <span className="flex-1">{n.label}</span>
+              {/* Sliding active pill — same trick the top-nav uses.
+                  motion shares one element across all tabs via layoutId,
+                  so the highlight slides between tabs instead of cutting. */}
+              {active && (
+                <motion.span
+                  layoutId="settings-nav-active-pill"
+                  aria-hidden="true"
+                  className="absolute inset-0 z-0 rounded-md border border-[color:var(--w-10)]"
+                  style={{ background: "var(--w-10)" }}
+                  transition={{
+                    duration: reducedMotion ? 0 : 0.24,
+                    ease: [0.22, 1, 0.36, 1],
+                  }}
+                />
+              )}
+              <I size={14} className="relative z-10 opacity-80" />
+              <span className="relative z-10 flex-1">{n.label}</span>
             </button>
           );
         })}

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -523,6 +523,7 @@ function CredsPanel({ config }: { config?: ServerConfig }) {
   const setDefault = useSetDefaultProvider();
   const deleteProv = useDeleteProvider();
   const test = useTestProvider();
+  const reducedMotion = useReducedMotion();
   const [showAdd, setShowAdd] = useState(false);
   const [editingName, setEditingName] = useState<string | undefined>();
   const [testMap, setTestMap] = useState<
@@ -590,19 +591,37 @@ function CredsPanel({ config }: { config?: ServerConfig }) {
         />
       ) : (
         <div className="space-y-2.5">
-          {names.map((name) => (
-            <CredCard
-              key={name}
-              name={name}
-              prov={providers[name]}
-              isDefault={name === effectiveDefault}
-              testStatus={testMap[name]?.status}
-              onEdit={() => setEditingName(name)}
-              onUse={() => makeDefault(name)}
-              onTest={() => runTest(name)}
-              onDelete={() => removeProvider(name)}
-            />
-          ))}
+          <AnimatePresence initial={false}>
+            {names.map((name) => (
+              <motion.div
+                key={name}
+                layout="position"
+                initial={
+                  reducedMotion
+                    ? false
+                    : { opacity: 0, y: 6, scale: 0.98 }
+                }
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={
+                  reducedMotion
+                    ? { opacity: 0 }
+                    : { opacity: 0, scale: 0.96, x: -12 }
+                }
+                transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+              >
+                <CredCard
+                  name={name}
+                  prov={providers[name]}
+                  isDefault={name === effectiveDefault}
+                  testStatus={testMap[name]?.status}
+                  onEdit={() => setEditingName(name)}
+                  onUse={() => makeDefault(name)}
+                  onTest={() => runTest(name)}
+                  onDelete={() => removeProvider(name)}
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </div>
       )}
 

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -1289,6 +1289,7 @@ function AboutPanel() {
 
 export function SettingsScreen({ config }: { config?: ServerConfig } = {}) {
   const [tab, setTab] = useState<SettingsTab>("creds");
+  const reducedMotion = useReducedMotion();
 
   return (
     <div className="flex h-full flex-col gap-3 overflow-hidden px-4 pb-4 pt-3 md:grid md:grid-cols-[200px_minmax(0,1fr)] md:gap-5 md:px-6 md:pb-6 md:pt-2">
@@ -1297,11 +1298,22 @@ export function SettingsScreen({ config }: { config?: ServerConfig } = {}) {
       <div className="surface-panel flex min-h-0 flex-1 flex-col overflow-hidden">
         <PanelHeader tab={tab} />
 
-        {tab === "creds" && <CredsPanel config={config} />}
-        {tab === "appearance" && <AppearancePanel />}
-        {tab === "runtime" && <RuntimePanel />}
-        {tab === "prompts" && <PromptTemplatesPanel />}
-        {tab === "about" && <AboutPanel />}
+        <AnimatePresence mode="wait" initial={false}>
+          <motion.div
+            key={tab}
+            initial={reducedMotion ? false : { opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reducedMotion ? { opacity: 0 } : { opacity: 0, y: -6 }}
+            transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
+            {tab === "creds" && <CredsPanel config={config} />}
+            {tab === "appearance" && <AppearancePanel />}
+            {tab === "runtime" && <RuntimePanel />}
+            {tab === "prompts" && <PromptTemplatesPanel />}
+            {tab === "about" && <AboutPanel />}
+          </motion.div>
+        </AnimatePresence>
       </div>
     </div>
   );

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion, useAnimationControls } from "motion/react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
@@ -356,6 +356,21 @@ function CredCard({
       setResultPulseKey((k) => k + 1);
     }
   }, [testStatus]);
+  // Imperative shake on each "err" transition. Previously the button
+  // got `key={\`err-${resultPulseKey}\`}` so React would unmount and
+  // remount it on every failure, which is the standard "remount to
+  // replay" trick — but it dropped keyboard focus mid-retry. Using
+  // animation controls keeps the DOM stable and replays the keyframes
+  // on resultPulseKey bumps so consecutive failures still cue.
+  const shakeControls = useAnimationControls();
+  useEffect(() => {
+    if (testStatus === "err" && !reducedMotion) {
+      void shakeControls.start({
+        x: [0, -2, 2, -1.5, 1.5, 0],
+        transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
+      });
+    }
+  }, [resultPulseKey, testStatus, reducedMotion, shakeControls]);
   // Surface a key value if any credential exposes a literal value.
   const apiKeyCredential = Object.values(prov.credentials ?? {}).find(
     (c) =>
@@ -429,16 +444,12 @@ function CredCard({
             type="button"
             onClick={onTest}
             disabled={testStatus === "running"}
-            // Failure shake — three small horizontal nudges, only on the
-            // err pulse. Success path leaves the button still and lets
-            // the ring carry the news.
-            animate={
-              !reducedMotion && testStatus === "err"
-                ? { x: [0, -2, 2, -1.5, 1.5, 0] }
-                : { x: 0 }
-            }
-            transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
-            key={testStatus === "err" ? `err-${resultPulseKey}` : "idle"}
+            // Failure shake — three small horizontal nudges, only on
+            // the err pulse. Success path leaves the button still and
+            // lets the ring carry the news. Driven by shakeControls
+            // (see effect above) so the DOM node stays stable across
+            // retries — `key`-based remount drops keyboard focus.
+            animate={shakeControls}
             className="relative h-8 w-8 inline-flex items-center justify-center rounded-md text-muted hover:text-foreground hover:bg-[color:var(--w-06)] transition-colors disabled:opacity-50"
             aria-label={`测试 ${name} 的连接`}
           >

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -1,6 +1,8 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
 import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import {
   KeyRound,
   Sparkles,
@@ -327,6 +329,17 @@ function CredCard({
   onDelete,
 }: CredCardProps) {
   const confirm = useConfirm();
+  const reducedMotion = useReducedMotion();
+  // Bumped on every transition into "ok" / "err" so the success ring
+  // (or failure shake) replays even when the user clicks 测试 twice
+  // in a row and lands on the same terminal state. Without this the
+  // motion would only fire on the very first state change.
+  const [resultPulseKey, setResultPulseKey] = useState(0);
+  useEffect(() => {
+    if (testStatus === "ok" || testStatus === "err") {
+      setResultPulseKey((k) => k + 1);
+    }
+  }, [testStatus]);
   // Surface a key value if any credential exposes a literal value.
   const apiKeyCredential = Object.values(prov.credentials ?? {}).find(
     (c) =>
@@ -396,23 +409,72 @@ function CredCard({
                 : "测试连接"
           }
         >
-          <button
+          <motion.button
             type="button"
             onClick={onTest}
             disabled={testStatus === "running"}
-            className="h-8 w-8 inline-flex items-center justify-center rounded-md text-muted hover:text-foreground hover:bg-[color:var(--w-06)] transition-colors disabled:opacity-50"
+            // Failure shake — three small horizontal nudges, only on the
+            // err pulse. Success path leaves the button still and lets
+            // the ring carry the news.
+            animate={
+              !reducedMotion && testStatus === "err"
+                ? { x: [0, -2, 2, -1.5, 1.5, 0] }
+                : { x: 0 }
+            }
+            transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+            key={testStatus === "err" ? `err-${resultPulseKey}` : "idle"}
+            className="relative h-8 w-8 inline-flex items-center justify-center rounded-md text-muted hover:text-foreground hover:bg-[color:var(--w-06)] transition-colors disabled:opacity-50"
             aria-label={`测试 ${name} 的连接`}
           >
-            {testStatus === "running" ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : testStatus === "ok" ? (
-              <Check size={14} className="text-[color:var(--status-ok)]" />
-            ) : testStatus === "err" ? (
-              <X size={14} className="text-[color:var(--status-err)]" />
-            ) : (
-              <Play size={13} />
-            )}
-          </button>
+            {/* Success ring pulse — radial accent fading from 0.7 -> 0
+                as it scales out. Only paints on each fresh "ok" via
+                resultPulseKey so re-tests replay the cue. */}
+            <AnimatePresence>
+              {testStatus === "ok" && !reducedMotion && (
+                <motion.span
+                  key={`ok-pulse-${resultPulseKey}`}
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-0 rounded-md"
+                  initial={{ opacity: 0.75, scale: 0.7 }}
+                  animate={{ opacity: 0, scale: 1.6 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+                  style={{
+                    background:
+                      "radial-gradient(circle at center, var(--status-ok-25), transparent 70%)",
+                    boxShadow: "0 0 0 1px var(--status-ok-25)",
+                  }}
+                />
+              )}
+            </AnimatePresence>
+            {/* Status icon swap — mode="wait" so each glyph plays its
+                own enter after the previous one finishes its exit;
+                avoids two icons overlapping mid-transition. */}
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.span
+                key={testStatus ?? "idle"}
+                initial={
+                  reducedMotion ? { opacity: 1 } : { opacity: 0, scale: 0.6 }
+                }
+                animate={{ opacity: 1, scale: 1 }}
+                exit={
+                  reducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.8 }
+                }
+                transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                className="relative z-10 inline-flex"
+              >
+                {testStatus === "running" ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : testStatus === "ok" ? (
+                  <Check size={14} className="text-[color:var(--status-ok)]" />
+                ) : testStatus === "err" ? (
+                  <X size={14} className="text-[color:var(--status-err)]" />
+                ) : (
+                  <Play size={13} />
+                )}
+              </motion.span>
+            </AnimatePresence>
+          </motion.button>
         </Tooltip>
         <Tooltip text="编辑凭证">
           <button

--- a/apps/gpt-image-2-app/src/components/screens/shared/creation-params-bar.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/creation-params-bar.tsx
@@ -189,9 +189,20 @@ function MobileParamsSheet(props: Omit<CreationParamsBarProps, "action">) {
         </button>
       </RadixDialog.Trigger>
       <RadixDialog.Portal>
-        <RadixDialog.Overlay className="fixed inset-0 z-50 bg-black/45 backdrop-blur-sm sm:hidden" />
+        <RadixDialog.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/45 backdrop-blur-sm sm:hidden",
+            "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200",
+            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:duration-150",
+          )}
+        />
         <RadixDialog.Content
-          className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl border border-border-faint p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-popover outline-none sm:hidden"
+          className={cn(
+            "fixed inset-x-0 bottom-0 z-50 rounded-t-2xl border border-border-faint p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] shadow-popover outline-none sm:hidden",
+            "ease-[cubic-bezier(0.22,1,0.36,1)]",
+            "data-[state=open]:animate-in data-[state=open]:slide-in-from-bottom data-[state=open]:fade-in-0 data-[state=open]:duration-[220ms]",
+            "data-[state=closed]:animate-out data-[state=closed]:slide-out-to-bottom data-[state=closed]:fade-out-0 data-[state=closed]:duration-[180ms]",
+          )}
           style={{
             background: "var(--surface-floating)",
             backdropFilter: "blur(28px) saturate(150%)",

--- a/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
@@ -69,8 +69,12 @@ export function OutputTile({
         }
       }}
       className={[
-        "relative overflow-hidden aspect-square rounded-lg cursor-pointer transition-all",
+        "relative overflow-hidden aspect-square rounded-lg cursor-pointer",
         "border-[1.5px]",
+        // border + shadow follow the same project quint as the scale motion
+        // above; previously plain `transition-all` snapped them in 150ms
+        // while the tile scaled over 180ms — visible misalignment on select.
+        "motion-safe:transition-[border-color,box-shadow] motion-safe:duration-200 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
         output.selected
           ? "border-accent shadow-[0_0_0_3px_var(--accent-faint)]"
           : "border-border shadow-sm",

--- a/apps/gpt-image-2-app/src/components/shell/top-nav.tsx
+++ b/apps/gpt-image-2-app/src/components/shell/top-nav.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { motion } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 import GlassSurface from "@/components/reactbits/components/GlassSurface";
 import CountUp from "@/components/reactbits/text/CountUp";
 import logoUrl from "@/assets/logo.png";
@@ -158,23 +158,38 @@ export function TopNav({
                   />
                 )}
                 <span className="relative z-10">{s.label}</span>
-                {isRunning && (
-                  <span
-                    className="relative z-10 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full text-[11px] font-mono font-semibold leading-none animate-pulse-subtle tabular-nums"
-                    style={{
-                      background: "var(--status-running-bg)",
-                      color: "var(--status-running)",
-                      boxShadow: "0 0 8px var(--status-running-60)",
-                    }}
-                    aria-label={`${tabCount} 个任务进行中`}
-                  >
-                    <CountUp
-                      to={tabCount}
-                      duration={0.5}
-                      className="leading-none"
-                    />
-                  </span>
-                )}
+                <AnimatePresence>
+                  {isRunning && (
+                    <motion.span
+                      key="badge"
+                      initial={
+                        reducedMotion
+                          ? false
+                          : { opacity: 0, scale: 0.6 }
+                      }
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={
+                        reducedMotion
+                          ? { opacity: 0 }
+                          : { opacity: 0, scale: 0.6 }
+                      }
+                      transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+                      className="relative z-10 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full text-[11px] font-mono font-semibold leading-none animate-pulse-subtle tabular-nums"
+                      style={{
+                        background: "var(--status-running-bg)",
+                        color: "var(--status-running)",
+                        boxShadow: "0 0 8px var(--status-running-60)",
+                      }}
+                      aria-label={`${tabCount} 个任务进行中`}
+                    >
+                      <CountUp
+                        to={tabCount}
+                        duration={0.5}
+                        className="leading-none"
+                      />
+                    </motion.span>
+                  )}
+                </AnimatePresence>
               </motion.button>
             </div>
           );

--- a/apps/gpt-image-2-app/src/components/ui/drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/drawer.tsx
@@ -44,7 +44,7 @@ export function Drawer({
     <Radix.Root open={open} onOpenChange={onOpenChange}>
       <Radix.Portal>
         <Radix.Overlay
-          className="fixed inset-0 z-40 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
+          className="drawer-overlay-blur fixed inset-0 z-40"
           style={{
             background: "var(--k-45)",
             backdropFilter: "blur(12px)",

--- a/apps/gpt-image-2-app/src/components/ui/reveal-image.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/reveal-image.tsx
@@ -45,7 +45,11 @@ export function RevealImage({
         opacity: loaded ? 1 : 0,
         filter: loaded ? "blur(0)" : "blur(8px)",
         transform: loaded ? "scale(1)" : "scale(1.02)",
-        transition: `opacity ${duration}ms ease-out, filter ${duration}ms ease-out, transform ${duration}ms ease-out`,
+        // Project-wide easing — `cubic-bezier(.22, 1, .36, 1)` is the
+        // ease-out-quint every motion.* transition in the app uses.
+        // Brings the image reveal in line with how the rest of the
+        // surface moves instead of the browser default ease-out.
+        transition: `opacity ${duration}ms cubic-bezier(0.22, 1, 0.36, 1), filter ${duration}ms cubic-bezier(0.22, 1, 0.36, 1), transform ${duration}ms cubic-bezier(0.22, 1, 0.36, 1)`,
         willChange: "opacity, filter, transform",
         ...style,
       }}

--- a/apps/gpt-image-2-app/src/components/ui/segmented.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/segmented.tsx
@@ -1,6 +1,8 @@
 import { useId, useRef, type KeyboardEvent } from "react";
+import { motion } from "motion/react";
 import { cn } from "@/lib/cn";
 import { Icon, type IconName } from "@/components/icon";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
 
 export type SegmentedOption<T extends string> =
   | T
@@ -30,6 +32,11 @@ export function Segmented<T extends string>({
   const h = size === "sm" ? "h-7" : "h-8";
   const groupId = useId();
   const btnRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const reducedMotion = useReducedMotion();
+  // Unique layoutId per Segmented instance so multiple groups on the
+  // same screen (e.g. mode switch + filter pills) don't share their
+  // sliding pill with each other.
+  const pillLayoutId = `segmented-pill-${groupId}`;
 
   const move = (from: number, delta: number) => {
     const len = options.length;
@@ -93,16 +100,33 @@ export function Segmented<T extends string>({
             onClick={() => onChange(v)}
             onKeyDown={(e) => onKey(e, index)}
             className={cn(
-              "inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap px-3 rounded text-[12.5px] font-medium transition-all cursor-pointer",
+              "relative inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap px-3 rounded text-[12.5px] font-medium transition-colors cursor-pointer",
               h,
               selected
-                ? "bg-[color:var(--w-10)] text-foreground shadow-[inset_0_1px_0_var(--w-10)]"
-                : "bg-transparent text-muted hover:text-foreground hover:bg-[color:var(--w-04)]",
+                ? "text-foreground"
+                : "text-muted hover:text-foreground hover:bg-[color:var(--w-04)]",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-55)]",
             )}
           >
-            {icon && <Icon name={icon} size={13} aria-hidden="true" />}
-            {label}
+            {/* Shared sliding pill — same trick the top-nav uses; the
+                highlight slides between segments rather than cutting. */}
+            {selected && (
+              <motion.span
+                layoutId={pillLayoutId}
+                aria-hidden="true"
+                className="absolute inset-0 z-0 rounded"
+                style={{
+                  background: "var(--w-10)",
+                  boxShadow: "inset 0 1px 0 var(--w-10)",
+                }}
+                transition={{
+                  duration: reducedMotion ? 0 : 0.22,
+                  ease: [0.22, 1, 0.36, 1],
+                }}
+              />
+            )}
+            {icon && <Icon name={icon} size={13} aria-hidden="true" className="relative z-10" />}
+            <span className="relative z-10">{label}</span>
           </button>
         );
       })}

--- a/apps/gpt-image-2-app/src/components/ui/toggle.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/toggle.tsx
@@ -17,7 +17,8 @@ export function Toggle({
     >
       <span
         className={cn(
-          "relative inline-flex w-[32px] h-[18px] rounded-full p-0.5 transition-all",
+          "relative inline-flex w-[32px] h-[18px] rounded-full p-0.5",
+          "motion-safe:transition-[background-color,box-shadow,background-image] motion-safe:duration-200 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)]",
           checked
             ? "shadow-[var(--shadow-accent-glow-soft),inset_0_1px_0_var(--w-18)]"
             : "bg-[color:var(--w-10)] shadow-[inset_0_1px_2px_var(--k-40)]",
@@ -31,7 +32,7 @@ export function Toggle({
         }
       >
         <span
-          className="w-[14px] h-[14px] rounded-full bg-[color:var(--surface-inverted)] shadow-[0_1px_3px_var(--k-40)] transition-transform"
+          className="w-[14px] h-[14px] rounded-full bg-[color:var(--surface-inverted)] shadow-[0_1px_3px_var(--k-40)] motion-safe:transition-transform motion-safe:duration-200 motion-safe:ease-[cubic-bezier(0.34,1.56,0.64,1)]"
           style={{ transform: checked ? "translateX(14px)" : "translateX(0)" }}
         />
       </span>

--- a/apps/gpt-image-2-app/src/index.css
+++ b/apps/gpt-image-2-app/src/index.css
@@ -831,6 +831,24 @@
   }
 }
 
+/* tailwindcss-animate emits raw CSS animations on `animate-in` /
+   `animate-out` — unlike framer-motion, the plugin doesn't honor
+   prefers-reduced-motion automatically, so every Radix surface that
+   uses `data-[state=open]:animate-in` (Popover, Select, Combobox,
+   Drawer, mobile params sheet, edit actions sheet, history detail
+   dialog) keeps animating for motion-sensitive users unless we patch
+   it. Collapse to 1ms across the board: Radix still gets its
+   animationend so components unmount cleanly, but the motion is
+   imperceptible. !important is required because tailwindcss-animate's
+   own `data-[state=…]:duration-*` utilities also set
+   animation-duration. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-in,
+  .animate-out {
+    animation-duration: 1ms !important;
+  }
+}
+
 .image-overlay {
   background: var(--image-overlay);
   color: var(--image-overlay-text);

--- a/apps/gpt-image-2-app/src/index.css
+++ b/apps/gpt-image-2-app/src/index.css
@@ -789,6 +789,48 @@
   animation: theme-pulse-out 360ms ease-out forwards;
 }
 
+/* Drawer overlay — fade opacity AND ramp backdrop-filter blur in tandem
+   so the background doesn't snap from clear to fully blurred on open.
+   CSS `transition` can't tween backdrop-filter on most engines, so we
+   own the keyframe ourselves. Reduce-motion users get an instant cut
+   via the prefers-reduced-motion override at the bottom. */
+@keyframes drawer-overlay-in {
+  from {
+    opacity: 0;
+    backdrop-filter: blur(0);
+    -webkit-backdrop-filter: blur(0);
+  }
+  to {
+    opacity: 1;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+}
+@keyframes drawer-overlay-out {
+  from {
+    opacity: 1;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  to {
+    opacity: 0;
+    backdrop-filter: blur(0);
+    -webkit-backdrop-filter: blur(0);
+  }
+}
+.drawer-overlay-blur[data-state="open"] {
+  animation: drawer-overlay-in 240ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+.drawer-overlay-blur[data-state="closed"] {
+  animation: drawer-overlay-out 180ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .drawer-overlay-blur[data-state="open"],
+  .drawer-overlay-blur[data-state="closed"] {
+    animation-duration: 1ms;
+  }
+}
+
 .image-overlay {
   background: var(--image-overlay);
   color: var(--image-overlay-text);

--- a/apps/gpt-image-2-app/tailwind.config.ts
+++ b/apps/gpt-image-2-app/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 const config: Config = {
   darkMode: ["class", '[data-theme="dark"]'],
@@ -107,7 +108,12 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  // tailwindcss-animate ships the data-[state=open]:animate-in family
+  // (fade-in-0, zoom-in-95, slide-in-from-top-1, etc.) that select.tsx,
+  // combobox.tsx, drawer.tsx and dialog.tsx already use. Without the
+  // plugin those class names would be dead utilities; add it so
+  // dropdown / popover / drawer open + close transitions actually run.
+  plugins: [animate],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

Two batches of work, all on the modern shell motion layer.

**Batch 1 — recovered cherry-picks (commits 1–6).** Six animation commits originally pushed to `claude/naughty-ishizaka-27d870` after PR #5 had already merged — the push landed on a closed PR and the work never reached `main`. Cherry-picked onto a fresh branch off `main`.

**Batch 2 — second-pass audit gaps (commits 7–13).** After the cherry-picks landed, ran another audit pass for "places where state changes are still abrupt." Closed seven of them.

**Review fixes (commits 14–15).** Codex caught two real bugs after Batch 2 landed.

### Batch 1 — cherry-picks

| commit | what it does |
|---|---|
| `55680a2` | feat(settings): credential 测试连接的状态切换走 `AnimatePresence` — Play → Loader → Check/X，成功带 ring pulse、失败带 shake |
| `dcbd180` | feat(ui): reference / credential / history 三处列表删除项时,邻居走 `layout="position"` 滑动补位,而不是单帧消失 |
| `220f5bc` | feat(generate): 第一次出结果时,hero → split 双栏布局走平滑过渡而不是硬切 |
| `bce3540` | refactor(ui): `RevealImage` 缓动对齐项目 quint `[0.22, 1, 0.36, 1]` |
| `c4dc3af` | feat(ui): settings 左导航 / history filter chips / Segmented (edit mode、generate sub-tabs、外观 picker) 全部走共享 `layoutId` 的 sliding pill,active 高亮在兄弟之间滑动 |
| `1b74834` | feat(ui): 接通 `tailwindcss-animate` plugin,Radix Dropdown / Popover / Combobox 的 `data-[state=open]:animate-in` class 真正生效 |

### Batch 2 — second-pass audit

| commit | what it does |
|---|---|
| `edb875a` | feat(ui): Toggle thumb 走弹性曲线 `cubic-bezier(0.34,1.56,0.64,1)`(轻微 overshoot 然后 settle),track 渐变 + 阴影同步 quint |
| `3989083` | feat(ui): OutputTile 选中态 border/shadow 跟 scale 同 ease 同 duration(原来 CSS `transition-all` 150ms 比 motion 的 180ms 快,选中时光环和缩放错开) |
| `c4205d7` | feat(top-nav): 任务徽章 `AnimatePresence` 包装,scale 0.6→1 + opacity enter/exit(原来 CountUp 数字平滑但容器硬挂载) |
| `2ba5092` | feat(history): job row 展开 `height: 0 → auto` reveal(原来 chevron 转 180° 但下方候选行直接 DOM 挂载,转动像没兑现) |
| `d80c75a` | feat(ui): Drawer overlay 用自定义 keyframe 让 `backdrop-filter` blur 0→12px 与 opacity 同步动画(CSS `transition` 不支持 backdrop-filter) |
| `05ab773` | feat(generate): mobile params sheet 用 tailwindcss-animate `slide-in-from-bottom + fade-in-0`(底层 utilities 是 PR 里的 `1b74834` 接通的) |
| `5497bf7` | feat(settings): 右侧 panel 切换走 `AnimatePresence mode="wait"` cross-fade(左导航 sliding pill 平滑了之后,右边内容硬切的反差变得更明显) |

### Review fixes

| commit | what it fixes |
|---|---|
| `e89062a` | fix(settings): credential 测试按钮原来用 `key={...}` 在每次 "err" 时 remount 来重放 shake,代价是键盘用户每次失败都要重新 tab 才能重试。改为 `useAnimationControls` 命令式触发,DOM 不再卸载,焦点保住 (Codex P2) |
| `fe2002f` | fix(a11y): 我之前在 commit message 里写"tailwindcss-animate honors prefers-reduced-motion already" 是错的 — plugin 不自动尊重 reduce-motion。在 `index.css` 加全局 `@media (prefers-reduced-motion: reduce)` 把 `animate-in`/`animate-out` 的 animation-duration 压到 1ms,一次性覆盖 Popover / Select / Combobox / Drawer / mobile params sheet / edit 抽屉 / history 详情 dialog 8 处用法,以及未来新增 (Codex P2) |

All motion paths now genuinely gated by `useReducedMotion` (motion/react driving) **or** the global keyframe override (tailwindcss-animate driving) **or** `motion-safe:` (CSS transitions on Toggle / OutputTile etc).

## Merge notes

`history/index.tsx` 上和 main 后来加的搜索框 + 分页(`fc8896f` job search、`d758277` paginate)有冲突,合并方案是保留 main 的 3 列 grid 布局(filters / search / count)和 `jobs.map` + `加载更多` 按钮,把 sliding pill / list-exit AnimatePresence 套在原本的位置上。其他 8 个文件 patch 干净落地。

`tsc --noEmit` 在 batch 1 / batch 2 / review fixes 完成后都跑过,干净。

## Test plan

### Batch 1
- [ ] 修改/删 credential → 测试连接按钮按下时 Play→Loader→Check/X 平滑切换,成功有 ring pulse,失败有 shake
- [ ] 删除 history 任务 / edit 参考图 / 凭证卡 → 邻居滑动补位,不是单帧消失
- [ ] 第一次出结果时 generate hero → split 双栏过渡平滑
- [ ] history filter (全部/进行中/已完成/失败) 切换 → 高亮 pill 在 chips 之间滑动
- [ ] settings 左导航(凭证/外观/任务/模板/关于)切换 → 高亮 pill 滑动
- [ ] edit mode switch / generate sub-tabs / 外观 theme/font/density picker → 多个 Segmented 实例,各自的 pill 不互相影响
- [ ] dropdown / popover / combobox 打开 → fade + scale-in 动画真的跑(以前是瞬时弹出)
- [ ] history 搜索 / 分页加载更多 仍然正常(冲突合并区域回归)

### Batch 2
- [ ] settings 外观面板里的 Toggle 切换 → thumb 有轻微 overshoot 后 settle,track 渐变同步而不是 thumb 已停 track 才追上
- [ ] generate 出图后选中某个 candidate → 边框、外发光阴影、scale 同时同曲线 settle(以前阴影会比缩放先到位)
- [ ] 触发 generate / edit 时 → top-nav 当前 tab 上的运行计数徽章从 0.6 缩放 + fade-in 出现,再消失时同样平滑
- [ ] history 一个 grouped job 点 chevron → 候选缩略图 strip 展开/收起 高度自适应过渡
- [ ] history 详情 drawer 或 edit 抽屉打开 → 背景同步从清晰渐变到 12px blur(不再瞬时模糊),关闭反向
- [ ] mobile (≤ sm) 上点 generate 参数按钮 → 底部 sheet 从屏幕外滑上来 + 背景渐入,关闭反向
- [ ] settings 切 tab → 右边 panel 内容轻微上下位移 + cross-fade 而不是直接换图

### Review fixes
- [ ] 用键盘 Tab 到一个 credential 的"测试连接"按钮 → 按 Enter 触发失败 → shake 仍然播放,但**焦点不丢**,直接再按 Enter 即可重试
- [ ] 系统级 reduce-motion 开启 → 所有 dropdown / popover / combobox / drawer / mobile sheet / edit actions sheet / history detail dialog 都不再播放 slide / fade / zoom,直接到位;motion/react 驱动的滑动/缩放也降级为透明度切换或无动画