### PR TITLE
feat: 统一图片操作系统 — 右键菜单 / Hover Toolbar / Quick Look / Drag-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +762,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -975,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1237,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1462,6 +1522,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1687,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -1733,6 +1804,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2101,6 +2183,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core",
  "zune-jpeg",
 ]
@@ -2713,6 +2796,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -2864,6 +2948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +3030,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3340,6 +3445,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -4513,6 +4627,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "http-range",
+ "image",
  "jni",
  "libc",
  "log",
@@ -4625,6 +4740,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4888,6 +5018,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5208,6 +5352,17 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5555,6 +5710,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.3",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5683,6 +5908,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "winapi"
@@ -6250,6 +6481,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6319,6 +6568,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1734,7 @@ name = "gpt-image-2-app"
 version = "0.4.0"
 dependencies = [
  "gpt-image-2-core",
+ "image",
  "serde",
  "serde_json",
  "tauri",
@@ -2215,6 +2232,8 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
  "image-webp",
  "moxcms",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,19 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
@@ -1023,6 +1036,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "drag"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e90b4a25ace5ce0561534b073943594cbcd21af936e64d09aec444568411f8c"
+dependencies = [
+ "core-graphics 0.24.0",
+ "dunce",
+ "gdk",
+ "gdkx11",
+ "gtk",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "raw-window-handle",
+ "serde",
+ "thiserror 2.0.18",
+ "windows 0.52.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -1688,6 +1723,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-drag",
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -2794,9 +2830,38 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2821,6 +2886,41 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -4552,7 +4652,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block2",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",
@@ -4575,7 +4675,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4659,7 +4759,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4750,6 +4850,21 @@ checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
 dependencies = [
  "arboard",
  "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-drag"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729ca0ce4b1169869d3405216d3c09a524f41ea5e2eec89f917cd6623f8a70ca"
+dependencies = [
+ "base64 0.22.1",
+ "drag",
  "serde",
  "serde_json",
  "tauri",
@@ -4856,7 +4971,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4881,7 +4996,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4942,7 +5057,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -5881,10 +5996,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -5905,7 +6020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5963,6 +6078,18 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-implement 0.52.0",
+ "windows-interface 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5985,12 +6112,34 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -6002,8 +6151,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -6022,9 +6171,53 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6066,6 +6259,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -6080,6 +6282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6542,7 +6754,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/apps/gpt-image-2-app/package-lock.json
+++ b/apps/gpt-image-2-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gpt-image-2-app",
       "version": "0.4.0",
       "dependencies": {
+        "@crabnebula/tauri-plugin-drag": "^2.1.0",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -356,6 +357,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@crabnebula/tauri-plugin-drag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@crabnebula/tauri-plugin-drag/-/tauri-plugin-drag-2.1.0.tgz",
+      "integrity": "sha512-LnUXAZwQt1cdMoGDLJ6ogW9wFCYServCZXlGadS7CA+CZ9eXS7L+Q7QyQW6g/zGw9YI2MwKFqf1aSNBGyWw+OA==",
+      "dependencies": {
+        "@tauri-apps/api": "^2.0.0"
       }
     },
     "node_modules/@dimforge/rapier3d-compat": {

--- a/apps/gpt-image-2-app/package-lock.json
+++ b/apps/gpt-image-2-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
+        "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-select": "^2.2.6",
@@ -1028,6 +1029,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
@@ -1171,6 +1200,64 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/apps/gpt-image-2-app/package.json
+++ b/apps/gpt-image-2-app/package.json
@@ -13,6 +13,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@crabnebula/tauri-plugin-drag": "^2.1.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/apps/gpt-image-2-app/package.json
+++ b/apps/gpt-image-2-app/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-select": "^2.2.6",

--- a/apps/gpt-image-2-app/src-tauri/Cargo.toml
+++ b/apps/gpt-image-2-app/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tauri = { version = "2.0.0", features = ["protocol-asset", "image-png"] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-drag = "2"
 tauri-plugin-notification = "2.0.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-single-instance = "2.4.1"

--- a/apps/gpt-image-2-app/src-tauri/Cargo.toml
+++ b/apps/gpt-image-2-app/src-tauri/Cargo.toml
@@ -22,6 +22,10 @@ gpt-image-2-core = { path = "../../../crates/gpt-image-2-core", version = "0.4.0
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tauri = { version = "2.0.0", features = ["protocol-asset", "image-png"] }
+# Generic image decoder so `copy_image_to_clipboard` works on JPEG/WEBP/GIF
+# outputs too — `tauri::image::Image::from_bytes` only handles PNG/ICO under
+# the enabled feature set.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-drag = "2"
 tauri-plugin-notification = "2.0.0"

--- a/apps/gpt-image-2-app/src-tauri/Cargo.toml
+++ b/apps/gpt-image-2-app/src-tauri/Cargo.toml
@@ -21,7 +21,8 @@ tauri-build = { version = "2.0.0", features = [] }
 gpt-image-2-core = { path = "../../../crates/gpt-image-2-core", version = "0.4.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
-tauri = { version = "2.0.0", features = ["protocol-asset"] }
+tauri = { version = "2.0.0", features = ["protocol-asset", "image-png"] }
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2.0.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-single-instance = "2.4.1"

--- a/apps/gpt-image-2-app/src-tauri/capabilities/default.json
+++ b/apps/gpt-image-2-app/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
     "core:window:allow-start-dragging",
     "notification:default",
     "updater:default",
-    "process:allow-restart"
+    "process:allow-restart",
+    "clipboard-manager:allow-write-image",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/apps/gpt-image-2-app/src-tauri/capabilities/default.json
+++ b/apps/gpt-image-2-app/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "updater:default",
     "process:allow-restart",
     "clipboard-manager:allow-write-image",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "drag:default"
   ]
 }

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -12,10 +12,10 @@ use gpt_image_2_core::{
     AppConfig, CredentialRef, HistoryListOptions, KEYCHAIN_SERVICE, NotificationConfig,
     ProviderConfig, default_config_path, default_keychain_account, delete_history_job,
     dispatch_task_notifications, history_db_path, jobs_dir, list_active_history_jobs,
-    list_history_jobs_page, load_app_config, notification_status_allowed,
-    preserve_notification_secrets, read_keychain_secret, redact_app_config,
-    restore_deleted_history_job, run_json, save_app_config, shared_config_dir, show_history_job,
-    soft_delete_history_job, upsert_history_job, write_keychain_secret,
+    list_expired_deleted_history_jobs, list_history_jobs_page, load_app_config,
+    notification_status_allowed, preserve_notification_secrets, read_keychain_secret,
+    redact_app_config, restore_deleted_history_job, run_json, save_app_config, shared_config_dir,
+    show_history_job, soft_delete_history_job, upsert_history_job, write_keychain_secret,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -2310,39 +2310,35 @@ fn hard_delete_job(job_id: String) -> Result<(), String> {
     Ok(())
 }
 
-/// Walk `jobs_dir/.trash` and permanently remove entries older than 5 minutes.
-/// Run once on a startup tick + periodically afterward so a soft-delete made
-/// shortly before quit (entry < 5min old at the next launch) still gets
-/// finalized inside the new session, not punted to the launch after that.
+/// Permanently remove soft-deleted history rows whose 5-minute undo window
+/// has elapsed, deleting both the database row and the corresponding
+/// `jobs_dir/.trash/<id>` directory.
+///
+/// Cutoff is anchored to the SQLite `deleted_at` column (set by
+/// `soft_delete_history_job`), NOT the trash directory's filesystem mtime
+/// — `fs::rename` doesn't update mtime, so a long-lived job soft-deleted
+/// just now would otherwise look ancient and get hard-deleted immediately,
+/// completely defeating the undo window.
 fn cleanup_orphan_trash() {
-    let trash_root = jobs_trash_dir();
-    if !trash_root.is_dir() {
-        return;
-    }
-    let cutoff = std::time::Duration::from_secs(5 * 60);
-    let now = SystemTime::now();
-    let entries = match fs::read_dir(&trash_root) {
-        Ok(e) => e,
+    const RETENTION_SECS: u64 = 5 * 60;
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let threshold = now_secs.saturating_sub(RETENTION_SECS);
+
+    let expired = match list_expired_deleted_history_jobs(threshold) {
+        Ok(ids) => ids,
         Err(_) => return,
     };
-    for entry in entries.flatten() {
-        let Ok(metadata) = entry.metadata() else {
-            continue;
-        };
-        let Ok(modified) = metadata.modified() else {
-            continue;
-        };
-        let Ok(elapsed) = now.duration_since(modified) else {
-            continue;
-        };
-        if elapsed <= cutoff {
-            continue;
+
+    let trash_root = jobs_trash_dir();
+    for job_id in expired {
+        let trash_path = trash_root.join(&job_id);
+        if trash_path.exists() {
+            let _ = fs::remove_dir_all(&trash_path);
         }
-        let path = entry.path();
-        let _ = fs::remove_dir_all(&path);
-        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-            let _ = delete_history_job(name);
-        }
+        let _ = delete_history_job(&job_id);
     }
 }
 

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -13,13 +13,14 @@ use gpt_image_2_core::{
     ProviderConfig, default_config_path, default_keychain_account, delete_history_job,
     dispatch_task_notifications, history_db_path, jobs_dir, list_active_history_jobs,
     list_history_jobs_page, load_app_config, notification_status_allowed,
-    preserve_notification_secrets, read_keychain_secret, redact_app_config, run_json,
-    save_app_config, shared_config_dir, show_history_job, upsert_history_job,
-    write_keychain_secret,
+    preserve_notification_secrets, read_keychain_secret, redact_app_config,
+    restore_deleted_history_job, run_json, save_app_config, shared_config_dir, show_history_job,
+    soft_delete_history_job, upsert_history_job, write_keychain_secret,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tauri::{Emitter, Manager};
+use tauri_plugin_clipboard_manager::ClipboardExt;
 
 fn app_error(error: gpt_image_2_core::AppError) -> String {
     format!("{}: {}", error.code, error.message)
@@ -1464,6 +1465,7 @@ fn history_list(
         cursor,
         status,
         query,
+        include_deleted: false,
     })
     .map_err(app_error)?;
     Ok(json!({
@@ -2194,6 +2196,153 @@ fn downloads_export_dir() -> Result<PathBuf, String> {
     Ok(home.join("Downloads").join("GPT Image 2"))
 }
 
+fn jobs_trash_dir() -> PathBuf {
+    jobs_dir().join(".trash")
+}
+
+/// Resolve a raw user-supplied path against the asset-protocol scope. Reading
+/// outside `jobs_dir` or the system temp dir is rejected so a malicious
+/// `read_image_bytes` payload can't exfiltrate arbitrary files.
+fn resolve_within_allowed_scope(input: &Path) -> Result<PathBuf, String> {
+    let canonical_target = input
+        .canonicalize()
+        .map_err(|error| format!("无法解析路径：{error}"))?;
+    let canonical_jobs = jobs_dir()
+        .canonicalize()
+        .unwrap_or_else(|_| jobs_dir());
+    if canonical_target.starts_with(&canonical_jobs) {
+        return Ok(canonical_target);
+    }
+    let temp = std::env::temp_dir();
+    let canonical_temp = temp.canonicalize().unwrap_or(temp);
+    if canonical_target.starts_with(&canonical_temp) {
+        return Ok(canonical_target);
+    }
+    Err("不允许读取该路径。".to_string())
+}
+
+#[tauri::command]
+async fn read_image_bytes(path: String) -> Result<Vec<u8>, String> {
+    let raw = PathBuf::from(&path);
+    if !raw.is_file() {
+        return Err("文件不存在或不是文件。".to_string());
+    }
+    let resolved = resolve_within_allowed_scope(&raw)?;
+    fs::read(&resolved).map_err(|error| format!("读取失败：{error}"))
+}
+
+#[tauri::command]
+async fn copy_image_to_clipboard(
+    path: String,
+    prompt: Option<String>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    let raw = PathBuf::from(&path);
+    if !raw.is_file() {
+        return Err("图片文件不存在，可能已被移动或删除。".to_string());
+    }
+    let resolved = resolve_within_allowed_scope(&raw)?;
+    let bytes = fs::read(&resolved).map_err(|error| format!("读取失败：{error}"))?;
+    let image = tauri::image::Image::from_bytes(&bytes)
+        .map_err(|error| format!("解析图片失败：{error}"))?;
+    app.clipboard()
+        .write_image(&image)
+        .map_err(|error| format!("写入剪贴板失败：{error}"))?;
+    if let Some(text) = prompt {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            app.clipboard()
+                .write_text(trimmed.to_string())
+                .map_err(|error| format!("写入提示词失败：{error}"))?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+fn soft_delete_job(job_id: String) -> Result<(), String> {
+    let job_root = jobs_dir().join(&job_id);
+    if job_root.exists() {
+        let trash_root = jobs_trash_dir();
+        fs::create_dir_all(&trash_root)
+            .map_err(|error| format!("创建回收目录失败：{error}"))?;
+        let trash_path = trash_root.join(&job_id);
+        if trash_path.exists() {
+            // Defensive: a previous soft-delete may have left an entry behind.
+            let _ = fs::remove_dir_all(&trash_path);
+        }
+        fs::rename(&job_root, &trash_path)
+            .map_err(|error| format!("移动到回收目录失败：{error}"))?;
+    }
+    soft_delete_history_job(&job_id).map_err(app_error)?;
+    Ok(())
+}
+
+#[tauri::command]
+fn restore_deleted_job(job_id: String) -> Result<(), String> {
+    let trash_path = jobs_trash_dir().join(&job_id);
+    if trash_path.exists() {
+        let dest = jobs_dir().join(&job_id);
+        if dest.exists() {
+            return Err("恢复失败：目标位置已存在同名任务。".to_string());
+        }
+        fs::rename(&trash_path, &dest)
+            .map_err(|error| format!("从回收目录恢复失败：{error}"))?;
+    }
+    restore_deleted_history_job(&job_id).map_err(app_error)?;
+    Ok(())
+}
+
+#[tauri::command]
+fn hard_delete_job(job_id: String) -> Result<(), String> {
+    let trash_path = jobs_trash_dir().join(&job_id);
+    if trash_path.exists() {
+        fs::remove_dir_all(&trash_path)
+            .map_err(|error| format!("清空回收目录失败：{error}"))?;
+    }
+    let main_path = jobs_dir().join(&job_id);
+    if main_path.exists() {
+        let _ = fs::remove_dir_all(&main_path);
+    }
+    delete_history_job(&job_id).map_err(app_error)?;
+    Ok(())
+}
+
+/// Walk `jobs_dir/.trash` and permanently remove entries older than 5 minutes.
+/// Called once at app startup so undo timeouts that were dropped by a sudden
+/// quit don't leak disk forever.
+fn cleanup_orphan_trash_on_start() {
+    let trash_root = jobs_trash_dir();
+    if !trash_root.is_dir() {
+        return;
+    }
+    let cutoff = std::time::Duration::from_secs(5 * 60);
+    let now = SystemTime::now();
+    let entries = match fs::read_dir(&trash_root) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        let Ok(elapsed) = now.duration_since(modified) else {
+            continue;
+        };
+        if elapsed <= cutoff {
+            continue;
+        }
+        let path = entry.path();
+        let _ = fs::remove_dir_all(&path);
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            let _ = delete_history_job(name);
+        }
+    }
+}
+
 fn output_paths_from_job(job: &Value) -> Vec<String> {
     let mut paths = job
         .get("outputs")
@@ -2448,6 +2597,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             let window = app
                 .get_webview_window("main")
@@ -2458,6 +2608,11 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
+        .setup(|_app| {
+            // Spawn off-thread so a slow filesystem walk can't delay startup.
+            thread::spawn(cleanup_orphan_trash_on_start);
+            Ok(())
+        })
         .manage(JobQueueState::default())
         .invoke_handler(tauri::generate_handler![
             config_path,
@@ -2489,6 +2644,11 @@ pub fn run() {
             reveal_path,
             export_files_to_downloads,
             export_job_to_downloads,
+            read_image_bytes,
+            copy_image_to_clipboard,
+            soft_delete_job,
+            restore_deleted_job,
+            hard_delete_job,
         ])
         .run(tauri::generate_context!())
         .expect("error while running gpt-image-2-app");

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -2207,9 +2207,7 @@ fn resolve_within_allowed_scope(input: &Path) -> Result<PathBuf, String> {
     let canonical_target = input
         .canonicalize()
         .map_err(|error| format!("无法解析路径：{error}"))?;
-    let canonical_jobs = jobs_dir()
-        .canonicalize()
-        .unwrap_or_else(|_| jobs_dir());
+    let canonical_jobs = jobs_dir().canonicalize().unwrap_or_else(|_| jobs_dir());
     if canonical_target.starts_with(&canonical_jobs) {
         return Ok(canonical_target);
     }
@@ -2264,8 +2262,7 @@ fn soft_delete_job(job_id: String) -> Result<(), String> {
     let job_root = jobs_dir().join(&job_id);
     if job_root.exists() {
         let trash_root = jobs_trash_dir();
-        fs::create_dir_all(&trash_root)
-            .map_err(|error| format!("创建回收目录失败：{error}"))?;
+        fs::create_dir_all(&trash_root).map_err(|error| format!("创建回收目录失败：{error}"))?;
         let trash_path = trash_root.join(&job_id);
         if trash_path.exists() {
             // Defensive: a previous soft-delete may have left an entry behind.
@@ -2286,8 +2283,7 @@ fn restore_deleted_job(job_id: String) -> Result<(), String> {
         if dest.exists() {
             return Err("恢复失败：目标位置已存在同名任务。".to_string());
         }
-        fs::rename(&trash_path, &dest)
-            .map_err(|error| format!("从回收目录恢复失败：{error}"))?;
+        fs::rename(&trash_path, &dest).map_err(|error| format!("从回收目录恢复失败：{error}"))?;
     }
     restore_deleted_history_job(&job_id).map_err(app_error)?;
     Ok(())
@@ -2297,8 +2293,7 @@ fn restore_deleted_job(job_id: String) -> Result<(), String> {
 fn hard_delete_job(job_id: String) -> Result<(), String> {
     let trash_path = jobs_trash_dir().join(&job_id);
     if trash_path.exists() {
-        fs::remove_dir_all(&trash_path)
-            .map_err(|error| format!("清空回收目录失败：{error}"))?;
+        fs::remove_dir_all(&trash_path).map_err(|error| format!("清空回收目录失败：{error}"))?;
     }
     let main_path = jobs_dir().join(&job_id);
     if main_path.exists() {
@@ -2309,9 +2304,10 @@ fn hard_delete_job(job_id: String) -> Result<(), String> {
 }
 
 /// Walk `jobs_dir/.trash` and permanently remove entries older than 5 minutes.
-/// Called once at app startup so undo timeouts that were dropped by a sudden
-/// quit don't leak disk forever.
-fn cleanup_orphan_trash_on_start() {
+/// Run once on a startup tick + periodically afterward so a soft-delete made
+/// shortly before quit (entry < 5min old at the next launch) still gets
+/// finalized inside the new session, not punted to the launch after that.
+fn cleanup_orphan_trash() {
     let trash_root = jobs_trash_dir();
     if !trash_root.is_dir() {
         return;
@@ -2341,6 +2337,18 @@ fn cleanup_orphan_trash_on_start() {
             let _ = delete_history_job(name);
         }
     }
+}
+
+/// Long-lived worker that re-runs `cleanup_orphan_trash` on a fixed cadence.
+/// Started once from `setup` so undo windows that elapse mid-session also get
+/// finalized (not just the ones that elapsed across a quit/restart).
+fn spawn_trash_cleanup_worker() {
+    thread::spawn(|| {
+        loop {
+            cleanup_orphan_trash();
+            thread::sleep(std::time::Duration::from_secs(60));
+        }
+    });
 }
 
 fn output_paths_from_job(job: &Value) -> Vec<String> {
@@ -2610,8 +2618,10 @@ pub fn run() {
             }
         }))
         .setup(|_app| {
-            // Spawn off-thread so a slow filesystem walk can't delay startup.
-            thread::spawn(cleanup_orphan_trash_on_start);
+            // Off-thread so a slow filesystem walk can't delay startup, and
+            // periodic so undo windows that elapse mid-session still get
+            // finalized without waiting for the next app launch.
+            spawn_trash_cleanup_worker();
             Ok(())
         })
         .manage(JobQueueState::default())

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -2598,6 +2598,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_drag::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             let window = app
                 .get_webview_window("main")

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -2241,8 +2241,15 @@ async fn copy_image_to_clipboard(
     }
     let resolved = resolve_within_allowed_scope(&raw)?;
     let bytes = fs::read(&resolved).map_err(|error| format!("读取失败：{error}"))?;
-    let image = tauri::image::Image::from_bytes(&bytes)
-        .map_err(|error| format!("解析图片失败：{error}"))?;
+    // Decode via the `image` crate so JPEG / WEBP / GIF outputs round-trip
+    // — `tauri::image::Image::from_bytes` only supports PNG/ICO with the
+    // currently enabled feature set, which would otherwise hard-regress
+    // Copy Image on any non-PNG job.
+    let decoded =
+        image::load_from_memory(&bytes).map_err(|error| format!("解析图片失败：{error}"))?;
+    let rgba = decoded.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    let image = tauri::image::Image::new_owned(rgba.into_raw(), width, height);
     app.clipboard()
         .write_image(&image)
         .map_err(|error| format!("写入剪贴板失败：{error}"))?;

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -17,10 +17,13 @@ import { EditScreen } from "@/components/screens/edit";
 import { HistoryScreen } from "@/components/screens/history";
 import { SettingsScreen } from "@/components/screens/settings";
 import { useConfig } from "@/hooks/use-config";
+import { useDisableWebviewContextMenu } from "@/hooks/use-disable-webview-contextmenu";
+import { useImageShortcuts } from "@/hooks/use-image-shortcuts";
 import { useJobNotifications } from "@/hooks/use-job-notifications";
 import { useJobs } from "@/hooks/use-jobs";
 import { useGlobalShortcuts } from "@/hooks/use-shortcuts";
 import { useTweaks } from "@/hooks/use-tweaks";
+import { TextSelectionContextMenu } from "@/components/ui/text-selection-context-menu";
 import {
   checkForAppUpdate,
   installAppUpdate,
@@ -121,6 +124,8 @@ export default function App() {
     },
   });
   useJobNotifications(jobs, openJob);
+  useDisableWebviewContextMenu();
+  useImageShortcuts();
 
   useEffect(() => {
     if (!shouldAutoCheckForUpdates()) return;
@@ -308,6 +313,7 @@ export default function App() {
             closeButton
             richColors
           />
+          <TextSelectionContextMenu />
         </div>
       </WindowChrome>
     </div>

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -6,6 +6,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 import { Toaster, toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ClassicShell } from "@/components/legacy/classic-shell";
@@ -326,16 +327,29 @@ export default function App() {
               </div>
             </div>
           )}
+          <TextSelectionContextMenu />
+          <QuickLookHost />
+        </div>
+      </WindowChrome>
+      {/*
+        Sonner doesn't internally portal its toaster to <body>, so when it
+        renders inside a stacking context (`div.desktop` / `div.relative`)
+        its `z-index` gets clamped to that context's stacking position —
+        and Radix Drawer / Quick Look (which DO portal to <body>) end up
+        on top regardless of how high we crank the value. Mounting the
+        Toaster via a Portal to <body> puts it in the root stacking
+        context where the z-index 9999 in index.css actually wins.
+      */}
+      {typeof document !== "undefined" &&
+        createPortal(
           <Toaster
             position="top-right"
             theme={legacyInterface ? tweaks.theme : "dark"}
             closeButton
             richColors
-          />
-          <TextSelectionContextMenu />
-          <QuickLookHost />
-        </div>
-      </WindowChrome>
+          />,
+          document.body,
+        )}
     </div>
   );
 }

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -17,6 +17,7 @@ import { EditScreen } from "@/components/screens/edit";
 import { HistoryScreen } from "@/components/screens/history";
 import { SettingsScreen } from "@/components/screens/settings";
 import { useConfig } from "@/hooks/use-config";
+import { useConfirm } from "@/hooks/use-confirm";
 import { useDisableWebviewContextMenu } from "@/hooks/use-disable-webview-contextmenu";
 import { useImageShortcuts } from "@/hooks/use-image-shortcuts";
 import { useJobNotifications } from "@/hooks/use-job-notifications";
@@ -25,6 +26,7 @@ import { useGlobalShortcuts } from "@/hooks/use-shortcuts";
 import { useTweaks } from "@/hooks/use-tweaks";
 import { TextSelectionContextMenu } from "@/components/ui/text-selection-context-menu";
 import { QuickLookHost } from "@/components/ui/quick-look";
+import { setActionsConfirm } from "@/lib/image-actions/confirm-action";
 import { setActionsNavigator } from "@/lib/image-actions/navigation";
 import {
   checkForAppUpdate,
@@ -98,6 +100,7 @@ export default function App() {
   } = useConfig();
   const { data: jobs } = useJobs();
   const { tweaks } = useTweaks();
+  const confirm = useConfirm();
 
   const setScreen = useCallback((s: ScreenId) => {
     setScreenState(s);
@@ -135,6 +138,13 @@ export default function App() {
   useEffect(() => {
     setActionsNavigator(setScreen);
   }, [setScreen]);
+
+  // And the confirm dialog so destructive executors (Delete) can prompt
+  // before tearing down a multi-output job.
+  useEffect(() => {
+    setActionsConfirm(confirm);
+    return () => setActionsConfirm(null);
+  }, [confirm]);
 
   useEffect(() => {
     if (!shouldAutoCheckForUpdates()) return;
@@ -321,6 +331,10 @@ export default function App() {
             theme={legacyInterface ? tweaks.theme : "dark"}
             closeButton
             richColors
+            // Stay above drawers (z-50) and Quick Look overlay (z-[60]) so
+            // action feedback isn't hidden behind the surface that triggered
+            // the action.
+            style={{ zIndex: 200 }}
           />
           <TextSelectionContextMenu />
           <QuickLookHost />

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -331,10 +331,6 @@ export default function App() {
             theme={legacyInterface ? tweaks.theme : "dark"}
             closeButton
             richColors
-            // Stay above drawers (z-50) and Quick Look overlay (z-[60]) so
-            // action feedback isn't hidden behind the surface that triggered
-            // the action.
-            style={{ zIndex: 200 }}
           />
           <TextSelectionContextMenu />
           <QuickLookHost />

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -24,6 +24,7 @@ import { useJobs } from "@/hooks/use-jobs";
 import { useGlobalShortcuts } from "@/hooks/use-shortcuts";
 import { useTweaks } from "@/hooks/use-tweaks";
 import { TextSelectionContextMenu } from "@/components/ui/text-selection-context-menu";
+import { QuickLookHost } from "@/components/ui/quick-look";
 import {
   checkForAppUpdate,
   installAppUpdate,
@@ -314,6 +315,7 @@ export default function App() {
             richColors
           />
           <TextSelectionContextMenu />
+          <QuickLookHost />
         </div>
       </WindowChrome>
     </div>

--- a/apps/gpt-image-2-app/src/App.tsx
+++ b/apps/gpt-image-2-app/src/App.tsx
@@ -25,6 +25,7 @@ import { useGlobalShortcuts } from "@/hooks/use-shortcuts";
 import { useTweaks } from "@/hooks/use-tweaks";
 import { TextSelectionContextMenu } from "@/components/ui/text-selection-context-menu";
 import { QuickLookHost } from "@/components/ui/quick-look";
+import { setActionsNavigator } from "@/lib/image-actions/navigation";
 import {
   checkForAppUpdate,
   installAppUpdate,
@@ -127,6 +128,13 @@ export default function App() {
   useJobNotifications(jobs, openJob);
   useDisableWebviewContextMenu();
   useImageShortcuts();
+
+  // Hand the screen setter to image-action executors so "Use as Reference"
+  // / "Edit with Prompt" / "Reveal Job in History" can navigate after their
+  // backend bookkeeping completes.
+  useEffect(() => {
+    setActionsNavigator(setScreen);
+  }, [setScreen]);
 
   useEffect(() => {
     if (!shouldAutoCheckForUpdates()) return;

--- a/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
@@ -649,6 +649,9 @@ export function EditScreen({
           return;
         }
         addRefFiles([file], "picker");
+        if (payload.prompt && payload.prompt.trim().length > 0) {
+          setPrompt(payload.prompt);
+        }
         toast.success("已发送到编辑", {
           id: toastId,
           description: "已作为新的参考图添加。",

--- a/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/edit/index.tsx
@@ -96,6 +96,7 @@ import {
   type SendToEditPayload,
 } from "@/lib/job-navigation";
 import { insertPromptAtCursor } from "@/lib/prompt-templates";
+import { imageAssetFromOutput } from "@/lib/image-actions/asset";
 import {
   isTauriRuntime,
   useGlobalImagePaste,
@@ -1604,6 +1605,15 @@ export function EditScreen({
                         >
                           <OutputTile
                             output={output}
+                            asset={imageAssetFromOutput({
+                              jobId: jobId!,
+                              outputIndex: output.index,
+                              src: output.url ?? "",
+                              path:
+                                api.outputPath(jobId!, output.index) ?? null,
+                              prompt: prompt || undefined,
+                              command: "images edit",
+                            })}
                             downloadLabel={copy.saveImageLabel}
                             onSelect={() => setSelectedOutput(output.index)}
                             onDownload={() =>

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -32,7 +32,9 @@ import {
 import { Empty } from "@/components/ui/empty";
 import { Button } from "@/components/ui/button";
 import { RevealImage } from "@/components/ui/reveal-image";
+import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import SpotlightCard from "@/components/reactbits/components/SpotlightCard";
+import { imageAssetFromOutput } from "@/lib/image-actions/asset";
 import { useConfirm } from "@/hooks/use-confirm";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import type { Job, JobStatus } from "@/lib/types";
@@ -447,19 +449,29 @@ function JobRowExpandable({
                   >
                     {outputIndexes.map((outputIndex, i) => {
                       const url = jobOutputUrl(job, outputIndex);
+                      const path = jobOutputPath(job, outputIndex);
                       const letter = String.fromCharCode(65 + i);
+                      const asset = imageAssetFromOutput({
+                        jobId: job.id,
+                        outputIndex,
+                        src: url ?? "",
+                        path: path ?? null,
+                        prompt: prompt || undefined,
+                        command: job.command,
+                        job,
+                      });
                       return (
-                        <button
-                          key={outputIndex}
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onOpenDetail(outputIndex);
-                          }}
-                          className="group relative aspect-square w-full rounded-lg overflow-hidden ring-1 ring-[color:var(--w-08)] hover:ring-[color:var(--accent-45)] transition-all hover:scale-[1.015]"
-                          title={`查看第 ${letter} 张`}
-                          aria-label={`查看第 ${letter} 张`}
-                        >
+                        <ImageContextMenu key={outputIndex} asset={asset}>
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onOpenDetail(outputIndex);
+                            }}
+                            className="group relative aspect-square w-full rounded-lg overflow-hidden ring-1 ring-[color:var(--w-08)] hover:ring-[color:var(--accent-45)] transition-all hover:scale-[1.015]"
+                            title={`查看第 ${letter} 张`}
+                            aria-label={`查看第 ${letter} 张`}
+                          >
                           <SpotlightCard
                             spotlightColor="rgba(var(--accent-rgb), 0.30)"
                             className="!rounded-lg !p-0 !bg-transparent !border-0 !w-full !h-full absolute inset-0"
@@ -482,7 +494,8 @@ function JobRowExpandable({
                               {letter}
                             </span>
                           </SpotlightCard>
-                        </button>
+                          </button>
+                        </ImageContextMenu>
                       );
                     })}
                   </div>

--- a/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Drawer } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
+import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import { openQuickLook } from "@/components/ui/quick-look";
 import TiltedCard from "@/components/reactbits/components/TiltedCard";
 import { copyText, openPath, revealPath, saveImages } from "@/lib/user-actions";
@@ -305,27 +306,29 @@ export function JobImageDetailDrawer({
           {/* Big image — TiltedCard for the brand "liquid" hover-tilt feel,
             wrapped in a button so click still escalates to fullscreen zoom. */}
           <div className="relative flex min-w-0 items-center justify-center overflow-hidden">
-            {url && !imageFailed ? (
-              <button
-                type="button"
-                onClick={openZoom}
-                className="mx-auto block w-full max-w-[340px] cursor-zoom-in rounded-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-55)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
-                aria-label={`查看第 ${letter} 张大图`}
-              >
-                <TiltedCard
-                  imageSrc={url}
-                  altText={`第 ${letter} 张`}
-                  containerWidth="100%"
-                  containerHeight={DETAIL_IMAGE_SIZE}
-                  imageWidth={DETAIL_IMAGE_SIZE}
-                  imageHeight={DETAIL_IMAGE_SIZE}
-                  rotateAmplitude={8}
-                  scaleOnHover={1.04}
-                  showMobileWarning={false}
-                  showTooltip={false}
-                  onImageError={() => setImageFailed(true)}
-                />
-              </button>
+            {url && !imageFailed && activeAsset ? (
+              <ImageContextMenu asset={activeAsset}>
+                <button
+                  type="button"
+                  onClick={openZoom}
+                  className="mx-auto block w-full max-w-[340px] cursor-zoom-in rounded-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-55)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
+                  aria-label={`查看第 ${letter} 张大图`}
+                >
+                  <TiltedCard
+                    imageSrc={url}
+                    altText={`第 ${letter} 张`}
+                    containerWidth="100%"
+                    containerHeight={DETAIL_IMAGE_SIZE}
+                    imageWidth={DETAIL_IMAGE_SIZE}
+                    imageHeight={DETAIL_IMAGE_SIZE}
+                    rotateAmplitude={8}
+                    scaleOnHover={1.04}
+                    showMobileWarning={false}
+                    showTooltip={false}
+                    onImageError={() => setImageFailed(true)}
+                  />
+                </button>
+              </ImageContextMenu>
             ) : (
               <div className="h-[340px] w-full overflow-hidden rounded-lg border border-[color:var(--w-08)] bg-[color:var(--w-02)]">
                 <PlaceholderImage
@@ -363,7 +366,8 @@ export function JobImageDetailDrawer({
               {outputIndexes.map((outputIndex, i) => {
                 const tUrl = jobOutputUrl(job, outputIndex);
                 const isActive = outputIndex === activeOutputIndex;
-                return (
+                const thumbAsset = peerAssets[i] ?? activeAsset;
+                const button = (
                   <button
                     key={outputIndex}
                     type="button"
@@ -407,6 +411,13 @@ export function JobImageDetailDrawer({
                       {String.fromCharCode(65 + i)}
                     </span>
                   </button>
+                );
+                return thumbAsset ? (
+                  <ImageContextMenu key={outputIndex} asset={thumbAsset}>
+                    {button}
+                  </ImageContextMenu>
+                ) : (
+                  button
                 );
               })}
             </div>

--- a/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Drawer } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
+import { Tooltip } from "@/components/ui/tooltip";
 import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import { openQuickLook } from "@/components/ui/quick-look";
 import TiltedCard from "@/components/reactbits/components/TiltedCard";
@@ -190,115 +191,110 @@ export function JobImageDetailDrawer({
         description={prompt ? prompt.slice(0, 80) : "（无提示词）"}
         width={520}
         footer={
-          <div className="flex w-full min-w-0 flex-wrap items-center gap-2">
+          <div className="flex w-full min-w-0 items-center gap-1.5">
             {canShowFileLocation && (
               <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon="copy"
-                  disabled={!path}
-                  onClick={() => {
-                    if (path) void copyText(path, "图片路径");
-                  }}
-                >
-                  复制路径
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon="folder"
-                  disabled={!path}
-                  onClick={() => {
-                    if (path) void revealPath(path);
-                  }}
-                >
-                  打开位置
-                </Button>
+                <Tooltip text="复制路径">
+                  <Button
+                    variant="ghost"
+                    size="iconSm"
+                    icon="copy"
+                    aria-label="复制路径"
+                    disabled={!path}
+                    onClick={() => {
+                      if (path) void copyText(path, "图片路径");
+                    }}
+                  />
+                </Tooltip>
+                <Tooltip text="在 Finder 中显示">
+                  <Button
+                    variant="ghost"
+                    size="iconSm"
+                    icon="folder"
+                    aria-label="在 Finder 中显示"
+                    disabled={!path}
+                    onClick={() => {
+                      if (path) void revealPath(path);
+                    }}
+                  />
+                </Tooltip>
               </>
             )}
             {onRerun && job && (
-              <Button
-                variant="ghost"
-                size="sm"
-                icon="reload"
-                onClick={handleRerun}
-                title="用相同的 prompt 和参数预填到生成屏"
-              >
-                再来一次
-              </Button>
+              <Tooltip text="再来一次（用相同参数预填生成屏）">
+                <Button
+                  variant="ghost"
+                  size="iconSm"
+                  icon="reload"
+                  aria-label="再来一次"
+                  onClick={handleRerun}
+                />
+              </Tooltip>
             )}
             {onRetry &&
               job &&
               (job.status === "failed" || job.status === "cancelled") && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  icon="reload"
-                  onClick={() => onRetry(job.id)}
-                  title="原样重新提交这个任务"
-                >
-                  重试
-                </Button>
+                <Tooltip text="重试（原样重新提交）">
+                  <Button
+                    variant="secondary"
+                    size="iconSm"
+                    icon="reload"
+                    aria-label="重试"
+                    onClick={() => onRetry(job.id)}
+                  />
+                </Tooltip>
               )}
             {onSendToEdit && job && (
-              <Button
-                variant="secondary"
-                size="sm"
-                icon="edit"
-                disabled={!path && !url}
-                onClick={() => onSendToEdit(job, activeOutputIndex)}
-                title="把当前图片添加为编辑参考图"
-              >
-                发送到编辑
-              </Button>
+              <Tooltip text="发送到编辑（作为参考图）">
+                <Button
+                  variant="secondary"
+                  size="iconSm"
+                  icon="edit"
+                  aria-label="发送到编辑"
+                  disabled={!path && !url}
+                  onClick={() => onSendToEdit(job, activeOutputIndex)}
+                />
+              </Tooltip>
             )}
             <div className="min-w-2 flex-1" />
             {onDelete && job && (
-              <Button
-                variant="ghost"
-                size="sm"
-                icon="trash"
-                onClick={async () => {
-                  const summary = prompt
-                    ? prompt.length > 60
-                      ? `${prompt.slice(0, 60)}…`
-                      : prompt
-                    : "（无提示词）";
-                  const ok = await confirm({
-                    title: "删除整个任务记录",
-                    description: (
-                      <>
-                        将删除任务{" "}
-                        <span className="text-foreground font-medium">
-                          「{summary}」
-                        </span>
-                        。图片文件不会被删除。
-                      </>
-                    ),
-                    confirmText: "删除",
-                    variant: "danger",
-                  });
-                  if (!ok) return;
-                  onDelete(job.id);
-                  onClose();
-                }}
-              >
-                删除
-              </Button>
+              <Tooltip text="删除任务">
+                <Button
+                  variant="ghost"
+                  size="iconSm"
+                  icon="trash"
+                  aria-label="删除任务"
+                  onClick={async () => {
+                    const outputCount = job.outputs?.length ?? 1;
+                    const description =
+                      outputCount > 1
+                        ? `这是包含 ${outputCount} 张图的任务，删除会移除整个任务记录和全部 ${outputCount} 张图，无法分别删除单张。`
+                        : "这会删除这张图和它的任务记录。图片文件会移到回收站。";
+                    const ok = await confirm({
+                      title: "删除任务？",
+                      description,
+                      confirmText: "删除任务",
+                      variant: "danger",
+                    });
+                    if (!ok) return;
+                    onDelete(job.id);
+                    onClose();
+                  }}
+                />
+              </Tooltip>
             )}
-            <Button
-              variant="primary"
-              size="sm"
-              icon="download"
-              className="ml-auto"
-              disabled={!path}
-              onClick={() => {
-                if (path) void saveImages([path], "图片");
-              }}
-            >
-              {copy.saveImageLabel}
-            </Button>
+            <Tooltip text={copy.saveImageLabel}>
+              <Button
+                variant="primary"
+                size="iconSm"
+                icon="download"
+                aria-label={copy.saveImageLabel}
+                disabled={!path}
+                onClick={() => {
+                  if (path) void saveImages([path], "图片");
+                }}
+              />
+            </Tooltip>
           </div>
         }
       >

--- a/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from "react";
-import * as Radix from "@radix-ui/react-dialog";
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Drawer } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
-import { RevealImage } from "@/components/ui/reveal-image";
+import { openQuickLook } from "@/components/ui/quick-look";
 import TiltedCard from "@/components/reactbits/components/TiltedCard";
 import { copyText, openPath, revealPath, saveImages } from "@/lib/user-actions";
 import { useConfirm } from "@/hooks/use-confirm";
@@ -16,6 +15,8 @@ import {
   jobOutputPath,
   jobOutputUrl,
 } from "@/lib/job-outputs";
+import { imageAssetFromOutput } from "@/lib/image-actions/asset";
+import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "@/components/screens/shared/placeholder-image";
 
 type Props = {
@@ -66,7 +67,6 @@ export function JobImageDetailDrawer({
   onSendToEdit,
 }: Props) {
   const confirm = useConfirm();
-  const [zoomOpen, setZoomOpen] = useState(false);
   const [imageFailed, setImageFailed] = useState(false);
   const [thumbFailed, setThumbFailed] = useState<Set<number>>(new Set());
   const copy = runtimeCopy();
@@ -135,21 +135,44 @@ export function JobImageDetailDrawer({
     onChangeIndex(outputIndexes[(activePosition + 1) % outputCount]);
   };
 
-  useEffect(() => {
-    if (!zoomOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "ArrowLeft") {
-        event.preventDefault();
-        goPrev();
-      }
-      if (event.key === "ArrowRight") {
-        event.preventDefault();
-        goNext();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activePosition, outputCount, outputIndexes, zoomOpen]);
+  // QuickLook owns its own ArrowLeft/ArrowRight handling; the drawer no
+  // longer needs a parallel keyboard listener.
+
+  const peerAssets: ImageAsset[] = job
+    ? outputIndexes.map((idx) =>
+        imageAssetFromOutput({
+          jobId: job.id,
+          outputIndex: idx,
+          src: jobOutputUrl(job, idx) ?? "",
+          path: jobOutputPath(job, idx) ?? null,
+          prompt: prompt || undefined,
+          command: job.command,
+          job,
+        }),
+      )
+    : [];
+  const activeAsset =
+    peerAssets[activePosition] ??
+    (job && url
+      ? imageAssetFromOutput({
+          jobId: job.id,
+          outputIndex: activeOutputIndex,
+          src: url,
+          path: path ?? null,
+          prompt: prompt || undefined,
+          command: job.command,
+          job,
+        })
+      : null);
+
+  const openZoom = () => {
+    if (!activeAsset) return;
+    openQuickLook({
+      asset: activeAsset,
+      peers: peerAssets.length > 1 ? peerAssets : undefined,
+      onChange: (next) => onChangeIndex(next.outputIndex),
+    });
+  };
 
   return (
     <>
@@ -285,7 +308,7 @@ export function JobImageDetailDrawer({
             {url && !imageFailed ? (
               <button
                 type="button"
-                onClick={() => setZoomOpen(true)}
+                onClick={openZoom}
                 className="mx-auto block w-full max-w-[340px] cursor-zoom-in rounded-[15px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-55)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
                 aria-label={`查看第 ${letter} 张大图`}
               >
@@ -449,108 +472,6 @@ export function JobImageDetailDrawer({
           </section>
         </div>
       </Drawer>
-
-      {/* Fullscreen image zoom — opened by clicking the big image. Plain
-        Radix Dialog so we can size it 90vw/90vh without the standard
-        <Dialog> wrapper's max-width. */}
-      <Radix.Root open={zoomOpen} onOpenChange={setZoomOpen}>
-        <Radix.Portal>
-          <Radix.Overlay
-            className="fixed inset-0 z-[60] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
-            style={{
-              background: "var(--k-70)",
-              backdropFilter: "blur(8px)",
-              WebkitBackdropFilter: "blur(8px)",
-            }}
-          />
-          <Radix.Content
-            aria-describedby={undefined}
-            className="fixed left-1/2 top-1/2 z-[61] -translate-x-1/2 -translate-y-1/2 max-w-[92vw] max-h-[92vh] outline-none data-[state=open]:animate-in data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:zoom-out-95"
-          >
-            <Radix.Title className="sr-only">
-              {outputCount > 1 ? `作品 ${letter}` : "作品详情"}
-            </Radix.Title>
-            {url && !imageFailed && (
-              <RevealImage
-                src={url}
-                alt={`第 ${letter} 张大图`}
-                decoding="async"
-                duration={500}
-                className="block max-w-[92vw] max-h-[92vh] object-contain rounded-lg shadow-[var(--shadow-floating)]"
-              />
-            )}
-            {outputCount > 1 && (
-              <>
-                <button
-                  type="button"
-                  onClick={goPrev}
-                  aria-label="上一张"
-                  className="absolute left-3 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] text-foreground backdrop-blur transition-colors hover:bg-[color:var(--surface-floating-strong)]"
-                  style={{ boxShadow: "var(--shadow-floating)" }}
-                >
-                  <ChevronLeft size={20} />
-                </button>
-                <button
-                  type="button"
-                  onClick={goNext}
-                  aria-label="下一张"
-                  className="absolute right-3 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] text-foreground backdrop-blur transition-colors hover:bg-[color:var(--surface-floating-strong)]"
-                  style={{ boxShadow: "var(--shadow-floating)" }}
-                >
-                  <ChevronRight size={20} />
-                </button>
-                <div className="absolute bottom-3 left-1/2 flex max-w-[78vw] -translate-x-1/2 items-center gap-1.5 overflow-x-auto rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] p-1.5 backdrop-blur scrollbar-none">
-                  {job &&
-                    outputIndexes.map((idx, i) => {
-                      const thumbUrl = jobOutputUrl(job, idx);
-                      const isActive = idx === activeOutputIndex;
-                      return (
-                        <button
-                          key={idx}
-                          type="button"
-                          onClick={() => onChangeIndex(idx)}
-                          className={cn(
-                            "h-10 w-10 shrink-0 overflow-hidden rounded-full border transition-all",
-                            isActive
-                              ? "border-[color:var(--accent)] opacity-100"
-                              : "border-transparent opacity-55 hover:opacity-90",
-                          )}
-                          aria-label={`切换到第 ${i + 1} 张`}
-                        >
-                          {thumbUrl ? (
-                            <img
-                              src={thumbUrl}
-                              alt=""
-                              loading="lazy"
-                              decoding="async"
-                              className="h-full w-full object-cover"
-                              draggable={false}
-                            />
-                          ) : (
-                            <PlaceholderImage
-                              seed={idx + i + 41}
-                              variant={`zoom-thumb-${job.id}`}
-                            />
-                          )}
-                        </button>
-                      );
-                    })}
-                </div>
-              </>
-            )}
-            <Radix.Close asChild>
-              <button
-                type="button"
-                aria-label="关闭"
-                className="absolute -top-2 -right-2 h-9 w-9 rounded-full inline-flex items-center justify-center bg-[color:var(--surface-floating)] backdrop-blur border border-[color:var(--surface-floating-border)] text-foreground hover:bg-[color:var(--surface-floating-strong)] transition-colors"
-                style={{ boxShadow: "var(--shadow-floating)" }}
-              >
-                <X size={16} />
-              </button>
-            </Radix.Close>
-          </Radix.Content>
-        </Radix.Portal>
-      </Radix.Root>
     </>
   );
 }

--- a/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
@@ -6,7 +6,10 @@ import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import { ImageHoverToolbar } from "@/components/ui/image-hover-toolbar";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { imageDragProps } from "@/lib/image-actions/drag-out";
-import { setFocusedImage } from "@/lib/image-actions/focused-image";
+import {
+  clearFocusedImageIfMatches,
+  setFocusedImage,
+} from "@/lib/image-actions/focused-image";
 import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "./placeholder-image";
 
@@ -57,7 +60,16 @@ export function OutputTile({
         setHover(true);
         if (asset) setFocusedImage(asset);
       }}
-      onMouseLeave={() => setHover(false)}
+      onMouseLeave={() => {
+        setHover(false);
+        // Clear the global focused-image when the pointer leaves so global
+        // shortcuts (Space / ⌘C / ⌘⌫) don't keep targeting a stale tile.
+        // `output.selected` opts in to "sticky" focus — selected tiles
+        // remain the keyboard target after the pointer wanders off.
+        if (asset && !output.selected) {
+          clearFocusedImageIfMatches(asset.jobId, asset.outputIndex);
+        }
+      }}
       onFocusCapture={() => {
         setFocusWithin(true);
         if (asset) setFocusedImage(asset);
@@ -65,6 +77,9 @@ export function OutputTile({
       onBlurCapture={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           setFocusWithin(false);
+          if (asset && !output.selected) {
+            clearFocusedImageIfMatches(asset.jobId, asset.outputIndex);
+          }
         }
       }}
       onClick={onSelect}

--- a/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
@@ -3,7 +3,9 @@ import { AnimatePresence, motion } from "motion/react";
 import { Icon } from "@/components/icon";
 import { RevealImage } from "@/components/ui/reveal-image";
 import { ImageContextMenu } from "@/components/ui/image-context-menu";
+import { ImageHoverToolbar } from "@/components/ui/image-hover-toolbar";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { setFocusedImage } from "@/lib/image-actions/focused-image";
 import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "./placeholder-image";
 
@@ -49,9 +51,15 @@ export function OutputTile({
 
   const tile = (
     <motion.div
-      onMouseEnter={() => setHover(true)}
+      onMouseEnter={() => {
+        setHover(true);
+        if (asset) setFocusedImage(asset);
+      }}
       onMouseLeave={() => setHover(false)}
-      onFocusCapture={() => setFocusWithin(true)}
+      onFocusCapture={() => {
+        setFocusWithin(true);
+        if (asset) setFocusedImage(asset);
+      }}
       onBlurCapture={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
           setFocusWithin(false);
@@ -148,61 +156,70 @@ export function OutputTile({
         </div>
         {output.selected && <Icon name="check" size={12} />}
       </div>
-      <AnimatePresence>
-        {(hover || focusWithin || output.selected) && (
-          <motion.div
-            className="absolute top-2 right-2 z-20 flex gap-1"
-            initial={reducedMotion ? false : { opacity: 0, y: -3, scale: 0.98 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={
-              reducedMotion
-                ? { opacity: 0 }
-                : { opacity: 0, y: -2, scale: 0.98 }
-            }
-            transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
-          >
-            {onOpen && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpen();
-                }}
-                title="打开图片"
-                aria-label="打开图片"
-                className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
-              >
-                <Icon name="external" size={13} />
-              </button>
-            )}
-            {onSendToEdit && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSendToEdit();
-                }}
-                title="发送到编辑"
-                aria-label="发送到编辑"
-                className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
-              >
-                <Icon name="edit" size={13} />
-              </button>
-            )}
-            {onDownload && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDownload();
-                }}
-                title={downloadLabel}
-                aria-label={downloadLabel}
-                className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
-              >
-                <Icon name="download" size={13} />
-              </button>
-            )}
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {asset ? (
+        <ImageHoverToolbar
+          asset={asset}
+          visible={hover || focusWithin || Boolean(output.selected)}
+        />
+      ) : (
+        <AnimatePresence>
+          {(hover || focusWithin || output.selected) && (
+            <motion.div
+              className="absolute top-2 right-2 z-20 flex gap-1"
+              initial={
+                reducedMotion ? false : { opacity: 0, y: -3, scale: 0.98 }
+              }
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={
+                reducedMotion
+                  ? { opacity: 0 }
+                  : { opacity: 0, y: -2, scale: 0.98 }
+              }
+              transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
+            >
+              {onOpen && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpen();
+                  }}
+                  title="打开图片"
+                  aria-label="打开图片"
+                  className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
+                >
+                  <Icon name="external" size={13} />
+                </button>
+              )}
+              {onSendToEdit && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSendToEdit();
+                  }}
+                  title="发送到编辑"
+                  aria-label="发送到编辑"
+                  className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
+                >
+                  <Icon name="edit" size={13} />
+                </button>
+              )}
+              {onDownload && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDownload();
+                  }}
+                  title={downloadLabel}
+                  aria-label={downloadLabel}
+                  className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
+                >
+                  <Icon name="download" size={13} />
+                </button>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      )}
     </motion.div>
   );
 

--- a/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { Icon } from "@/components/icon";
 import { RevealImage } from "@/components/ui/reveal-image";
+import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "./placeholder-image";
 
 type OutputMeta = {
@@ -19,6 +21,7 @@ export function OutputTile({
   onOpen,
   onSendToEdit,
   downloadLabel = "保存图片",
+  asset,
 }: {
   output: OutputMeta;
   onSelect?: () => void;
@@ -26,6 +29,12 @@ export function OutputTile({
   onOpen?: () => void;
   onSendToEdit?: () => void;
   downloadLabel?: string;
+  /**
+   * When provided, the tile is wrapped in an `ImageContextMenu` so right-click
+   * surfaces the runtime-aware action set. The legacy/classic shells leave
+   * this undefined and keep the existing hover-only behavior.
+   */
+  asset?: ImageAsset;
 }) {
   const reducedMotion = useReducedMotion();
   const [hover, setHover] = useState(false);
@@ -38,7 +47,7 @@ export function OutputTile({
     setImageFailed(false);
   }, [output.url]);
 
-  return (
+  const tile = (
     <motion.div
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
@@ -196,4 +205,9 @@ export function OutputTile({
       </AnimatePresence>
     </motion.div>
   );
+
+  if (asset) {
+    return <ImageContextMenu asset={asset}>{tile}</ImageContextMenu>;
+  }
+  return tile;
 }

--- a/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/shared/output-tile.tsx
@@ -5,6 +5,7 @@ import { RevealImage } from "@/components/ui/reveal-image";
 import { ImageContextMenu } from "@/components/ui/image-context-menu";
 import { ImageHoverToolbar } from "@/components/ui/image-hover-toolbar";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import { imageDragProps } from "@/lib/image-actions/drag-out";
 import { setFocusedImage } from "@/lib/image-actions/focused-image";
 import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "./placeholder-image";
@@ -49,6 +50,7 @@ export function OutputTile({
     setImageFailed(false);
   }, [output.url]);
 
+  const dragProps = asset ? imageDragProps(asset) : { draggable: false };
   const tile = (
     <motion.div
       onMouseEnter={() => {
@@ -122,6 +124,7 @@ export function OutputTile({
           decoding="async"
           className="w-full h-full object-cover"
           onError={() => setImageFailed(true)}
+          {...dragProps}
         />
       ) : (
         <PlaceholderImage

--- a/apps/gpt-image-2-app/src/components/ui/context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/context-menu.tsx
@@ -1,0 +1,133 @@
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+} from "react";
+import * as RadixContextMenu from "@radix-ui/react-context-menu";
+import { cn } from "@/lib/cn";
+
+/**
+ * GlassContextMenu — Radix ContextMenu with the same liquid-glass surface as
+ * GlassPopover (see ui/popover.tsx). Used by ImageContextMenu and any other
+ * "right-click reveals options" pattern in the app.
+ */
+
+export const ContextMenu = RadixContextMenu.Root;
+export const ContextMenuTrigger = RadixContextMenu.Trigger;
+export const ContextMenuPortal = RadixContextMenu.Portal;
+export const ContextMenuGroup = RadixContextMenu.Group;
+export const ContextMenuLabel = RadixContextMenu.Label;
+export const ContextMenuSub = RadixContextMenu.Sub;
+export const ContextMenuRadioGroup = RadixContextMenu.RadioGroup;
+
+const surfaceClasses = cn(
+  "z-50 min-w-[200px] rounded-xl border outline-none p-1",
+  "data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+  "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+);
+
+const surfaceStyle = {
+  background: "var(--surface-floating)",
+  borderColor: "var(--surface-floating-border)",
+  backdropFilter: "blur(28px) saturate(150%)",
+  WebkitBackdropFilter: "blur(28px) saturate(150%)",
+  boxShadow: "var(--shadow-floating)",
+} as const;
+
+export const ContextMenuContent = forwardRef<
+  ElementRef<typeof RadixContextMenu.Content>,
+  ComponentPropsWithoutRef<typeof RadixContextMenu.Content>
+>(({ className, ...rest }, ref) => (
+  <RadixContextMenu.Portal>
+    <RadixContextMenu.Content
+      ref={ref}
+      className={cn(surfaceClasses, className)}
+      style={surfaceStyle}
+      {...rest}
+    />
+  </RadixContextMenu.Portal>
+));
+ContextMenuContent.displayName = "ContextMenuContent";
+
+export const ContextMenuSubContent = forwardRef<
+  ElementRef<typeof RadixContextMenu.SubContent>,
+  ComponentPropsWithoutRef<typeof RadixContextMenu.SubContent>
+>(({ className, ...rest }, ref) => (
+  <RadixContextMenu.Portal>
+    <RadixContextMenu.SubContent
+      ref={ref}
+      className={cn(surfaceClasses, className)}
+      style={surfaceStyle}
+      {...rest}
+    />
+  </RadixContextMenu.Portal>
+));
+ContextMenuSubContent.displayName = "ContextMenuSubContent";
+
+const itemClasses = cn(
+  "relative flex select-none items-center justify-between gap-3",
+  "rounded-md px-2.5 py-1.5 text-[13px] outline-none cursor-default",
+  "text-[color:var(--text)]",
+  "data-[highlighted]:bg-[color:var(--bg-hover)] data-[highlighted]:text-[color:var(--text)]",
+  "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+);
+
+export const ContextMenuItem = forwardRef<
+  ElementRef<typeof RadixContextMenu.Item>,
+  ComponentPropsWithoutRef<typeof RadixContextMenu.Item> & {
+    destructive?: boolean;
+  }
+>(({ className, destructive, ...rest }, ref) => (
+  <RadixContextMenu.Item
+    ref={ref}
+    className={cn(
+      itemClasses,
+      destructive &&
+        "text-[color:var(--status-err)] data-[highlighted]:bg-[color:var(--status-err-bg)] data-[highlighted]:text-[color:var(--status-err)]",
+      className,
+    )}
+    {...rest}
+  />
+));
+ContextMenuItem.displayName = "ContextMenuItem";
+
+export const ContextMenuSubTrigger = forwardRef<
+  ElementRef<typeof RadixContextMenu.SubTrigger>,
+  ComponentPropsWithoutRef<typeof RadixContextMenu.SubTrigger>
+>(({ className, ...rest }, ref) => (
+  <RadixContextMenu.SubTrigger
+    ref={ref}
+    className={cn(itemClasses, className)}
+    {...rest}
+  />
+));
+ContextMenuSubTrigger.displayName = "ContextMenuSubTrigger";
+
+export const ContextMenuSeparator = forwardRef<
+  ElementRef<typeof RadixContextMenu.Separator>,
+  ComponentPropsWithoutRef<typeof RadixContextMenu.Separator>
+>(({ className, ...rest }, ref) => (
+  <RadixContextMenu.Separator
+    ref={ref}
+    className={cn("my-1 h-px", className)}
+    style={{ background: "var(--border-faint)" }}
+    {...rest}
+  />
+));
+ContextMenuSeparator.displayName = "ContextMenuSeparator";
+
+export const ContextMenuShortcut = forwardRef<
+  HTMLSpanElement,
+  ComponentPropsWithoutRef<"span">
+>(({ className, ...rest }, ref) => (
+  <span
+    ref={ref}
+    className={cn(
+      "ml-auto pl-4 text-[11px] tabular-nums text-[color:var(--text-faint)]",
+      className,
+    )}
+    {...rest}
+  />
+));
+ContextMenuShortcut.displayName = "ContextMenuShortcut";

--- a/apps/gpt-image-2-app/src/components/ui/context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/context-menu.tsx
@@ -21,7 +21,10 @@ export const ContextMenuSub = RadixContextMenu.Sub;
 export const ContextMenuRadioGroup = RadixContextMenu.RadioGroup;
 
 const surfaceClasses = cn(
-  "z-50 min-w-[200px] rounded-xl border outline-none p-1",
+  // z-[70] keeps the menu above Drawer (z-50) and Quick Look overlay
+  // (z-[60-61]) so right-click on the zoomed image / inside drawers still
+  // shows actions.
+  "z-[70] min-w-[200px] rounded-xl border outline-none p-1",
   "data-[state=open]:animate-in data-[state=closed]:animate-out",
   "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
   "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",

--- a/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
@@ -73,10 +73,9 @@ export function ImageContextMenu({ asset, children, inlineTrigger }: Props) {
                 disabled={
                   action.isEnabled ? !action.isEnabled(ctx) : false
                 }
-                onSelect={(event) => {
-                  // Prevent Radix's automatic menu close from racing the
-                  // async executor in some clipboard-related flows.
-                  event.preventDefault();
+                onSelect={() => {
+                  // Let Radix close the menu on its own; the executor runs
+                  // async in the background.
                   void run(action.id);
                 }}
               >

--- a/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
@@ -15,13 +15,6 @@ import { IMAGE_ACTION_TRIGGER_ATTR } from "@/hooks/use-disable-webview-contextme
 type Props = {
   asset: ImageAsset;
   children: ReactNode;
-  /**
-   * When true, the wrapper does not render a Trigger element of its own and
-   * relies on a parent element marked with `data-image-action-trigger` to
-   * absorb the right-click. Useful when wrapping bare `<img>` tags that
-   * already have a positioned overlay parent.
-   */
-  inlineTrigger?: boolean;
 };
 
 /**
@@ -34,7 +27,7 @@ type Props = {
  * neither the webview's native menu nor the text-selection menu shows up
  * when the user right-clicks an image.
  */
-export function ImageContextMenu({ asset, children, inlineTrigger }: Props) {
+export function ImageContextMenu({ asset, children }: Props) {
   const { ctx, groups, run } = useImageActions({
     asset,
     surface: "context-menu",
@@ -59,8 +52,18 @@ export function ImageContextMenu({ asset, children, inlineTrigger }: Props) {
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild={!inlineTrigger} {...triggerProps}>
-        {children}
+      {/*
+        Wrap children in a `display: contents` div instead of using
+        asChild-into-the-actual-child. Radix's `asChild` Slot merges its
+        own onContextMenu/onMouseDown/onPointerDown handlers into the
+        immediate child — when that child is a `<button onClick>` (e.g.
+        the detail drawer's "click big image to zoom" button), the merged
+        pointer-down handlers can swallow the primary-click activation.
+        Wrapping in a `display: contents` <div> keeps the right-click
+        bubbling working and leaves the inner button's click flow alone.
+      */}
+      <ContextMenuTrigger asChild {...triggerProps}>
+        <div style={{ display: "contents" }}>{children}</div>
       </ContextMenuTrigger>
       <ContextMenuContent>
         {groups.map((bucket, index) => (

--- a/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-context-menu.tsx
@@ -1,0 +1,97 @@
+import { useMemo, type ReactNode } from "react";
+import { Icon } from "@/components/icon";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { useImageActions } from "@/lib/image-actions/use-image-actions";
+import type { ImageAsset } from "@/lib/image-actions/types";
+import { IMAGE_ACTION_TRIGGER_ATTR } from "@/hooks/use-disable-webview-contextmenu";
+
+type Props = {
+  asset: ImageAsset;
+  children: ReactNode;
+  /**
+   * When true, the wrapper does not render a Trigger element of its own and
+   * relies on a parent element marked with `data-image-action-trigger` to
+   * absorb the right-click. Useful when wrapping bare `<img>` tags that
+   * already have a positioned overlay parent.
+   */
+  inlineTrigger?: boolean;
+};
+
+/**
+ * Right-click any image surface to expose the runtime-aware action set:
+ * Copy / Save / Reveal / Open with / Delete (plus Use as Reference / Edit /
+ * Reveal Job in C4 and Drag-out / Share / Copy with Prompt in C5).
+ *
+ * The Radix Trigger calls `preventDefault` on contextmenu, which causes the
+ * global `useDisableWebviewContextMenu` handler to skip its own work — so
+ * neither the webview's native menu nor the text-selection menu shows up
+ * when the user right-clicks an image.
+ */
+export function ImageContextMenu({ asset, children, inlineTrigger }: Props) {
+  const { ctx, groups, run } = useImageActions({
+    asset,
+    surface: "context-menu",
+  });
+
+  // Render nothing fancy if the registry yields zero actions for this asset
+  // (defensive — should never happen with the C2 registry but keeps the tree
+  // valid if a future capability matrix excludes everything).
+  const hasAnyAction = useMemo(
+    () => groups.some((bucket) => bucket.actions.length > 0),
+    [groups],
+  );
+
+  if (!hasAnyAction) {
+    return <>{children}</>;
+  }
+
+  const triggerProps = { [IMAGE_ACTION_TRIGGER_ATTR]: true } as Record<
+    string,
+    boolean
+  >;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild={!inlineTrigger} {...triggerProps}>
+        {children}
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {groups.map((bucket, index) => (
+          <div key={bucket.group}>
+            {index > 0 ? <ContextMenuSeparator /> : null}
+            {bucket.actions.map((action) => (
+              <ContextMenuItem
+                key={action.id}
+                destructive={action.destructive}
+                disabled={
+                  action.isEnabled ? !action.isEnabled(ctx) : false
+                }
+                onSelect={(event) => {
+                  // Prevent Radix's automatic menu close from racing the
+                  // async executor in some clipboard-related flows.
+                  event.preventDefault();
+                  void run(action.id);
+                }}
+              >
+                <span className="flex items-center gap-2">
+                  <Icon name={action.icon} size={14} />
+                  <span>{action.label(ctx)}</span>
+                </span>
+                {action.shortcut ? (
+                  <ContextMenuShortcut>{action.shortcut}</ContextMenuShortcut>
+                ) : null}
+              </ContextMenuItem>
+            ))}
+          </div>
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
@@ -1,0 +1,131 @@
+import type { CSSProperties, MouseEvent } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { Icon } from "@/components/icon";
+import { useReducedMotion } from "@/hooks/use-reduced-motion";
+import type {
+  ImageAction,
+  ImageActionId,
+  ImageAsset,
+} from "@/lib/image-actions/types";
+import { useImageActions } from "@/lib/image-actions/use-image-actions";
+
+export type ImageHoverToolbarProps = {
+  asset: ImageAsset;
+  visible?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  /**
+   * Bypass the registry's slot order and render only the listed action ids.
+   * Useful for surfaces (legacy classic-shell tiles, the edit drawer thumb
+   * strip) that want a tighter subset.
+   */
+  slots?: ImageActionId[];
+};
+
+const DEFAULT_SLOTS: ImageActionId[] = [
+  "quick-look",
+  "use-as-reference",
+  "copy-image",
+  "save-as",
+];
+
+/**
+ * Five-slot hover toolbar overlay rendered on top of an image surface. The
+ * first four slots are filled by the registered actions whose ids match the
+ * configured slot list (in order, skipping any that are unavailable for the
+ * current runtime / asset). The fifth slot is a `…` button that synthesizes
+ * a contextmenu event to open the same `ImageContextMenu` Trigger that the
+ * tile is wrapped in, so users always have a path to the full action set.
+ */
+export function ImageHoverToolbar({
+  asset,
+  visible = true,
+  className,
+  style,
+  slots = DEFAULT_SLOTS,
+}: ImageHoverToolbarProps) {
+  const reducedMotion = useReducedMotion();
+  const { ctx, available, run } = useImageActions({
+    asset,
+    surface: "hover-toolbar",
+  });
+
+  const slotActions = slots
+    .map((id) => available.find((action) => action.id === id))
+    .filter((action): action is ImageAction => Boolean(action));
+
+  if (slotActions.length === 0 && !visible) return null;
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className={
+            "absolute top-2 right-2 z-20 flex gap-1" +
+            (className ? ` ${className}` : "")
+          }
+          style={style}
+          initial={reducedMotion ? false : { opacity: 0, y: -3, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={
+            reducedMotion ? { opacity: 0 } : { opacity: 0, y: -2, scale: 0.98 }
+          }
+          transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
+        >
+          {slotActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              title={action.label(ctx)}
+              aria-label={action.label(ctx)}
+              disabled={
+                action.isEnabled ? !action.isEnabled(ctx) : false
+              }
+              onClick={(event) => {
+                event.stopPropagation();
+                event.preventDefault();
+                void run(action.id);
+              }}
+              className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none disabled:opacity-40"
+            >
+              <Icon name={action.icon} size={13} />
+            </button>
+          ))}
+          <button
+            type="button"
+            title="更多"
+            aria-label="更多"
+            onClick={(event) => openContextMenuFromButton(event)}
+            className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none"
+          >
+            <Icon name="dots" size={13} />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * Walk up from the button to the closest `data-image-action-trigger` and
+ * synthesize a contextmenu event on it. Radix ContextMenu's Trigger is
+ * already listening — this is the cleanest way to "open the menu
+ * programmatically" without exposing imperative API surface.
+ */
+function openContextMenuFromButton(event: MouseEvent<HTMLButtonElement>) {
+  event.stopPropagation();
+  event.preventDefault();
+  const target = (event.currentTarget as HTMLElement).closest(
+    "[data-image-action-trigger]",
+  );
+  if (!target) return;
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  const synthetic = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+    clientX: rect.right,
+    clientY: rect.bottom,
+    button: 2,
+  });
+  target.dispatchEvent(synthetic);
+}

--- a/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
@@ -40,7 +40,7 @@ const DEFAULT_SLOTS: ImageActionId[] = [
 const FLASH_DURATION_MS = 600;
 const FLASHABLE_ACTIONS = new Set<ImageActionId>([
   "copy-image",
-  "copy-image-with-prompt",
+  "copy-prompt",
   "save-as",
 ]);
 

--- a/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, MouseEvent } from "react";
+import { useState, type CSSProperties, type MouseEvent } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { Icon } from "@/components/icon";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
@@ -37,6 +37,13 @@ const DEFAULT_SLOTS: ImageActionId[] = [
  * a contextmenu event to open the same `ImageContextMenu` Trigger that the
  * tile is wrapped in, so users always have a path to the full action set.
  */
+const FLASH_DURATION_MS = 600;
+const FLASHABLE_ACTIONS = new Set<ImageActionId>([
+  "copy-image",
+  "copy-image-with-prompt",
+  "save-as",
+]);
+
 export function ImageHoverToolbar({
   asset,
   visible = true,
@@ -49,6 +56,9 @@ export function ImageHoverToolbar({
     asset,
     surface: "hover-toolbar",
   });
+  const [flashedActionId, setFlashedActionId] = useState<ImageActionId | null>(
+    null,
+  );
 
   const slotActions = slots
     .map((id) => available.find((action) => action.id === id))
@@ -72,25 +82,71 @@ export function ImageHoverToolbar({
           }
           transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
         >
-          {slotActions.map((action) => (
-            <button
-              key={action.id}
-              type="button"
-              title={action.label(ctx)}
-              aria-label={action.label(ctx)}
-              disabled={
-                action.isEnabled ? !action.isEnabled(ctx) : false
-              }
-              onClick={(event) => {
-                event.stopPropagation();
-                event.preventDefault();
-                void run(action.id);
-              }}
-              className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none disabled:opacity-40"
-            >
-              <Icon name={action.icon} size={13} />
-            </button>
-          ))}
+          {slotActions.map((action) => {
+            const isFlashing = flashedActionId === action.id;
+            return (
+              <button
+                key={action.id}
+                type="button"
+                title={action.label(ctx)}
+                aria-label={action.label(ctx)}
+                disabled={
+                  action.isEnabled ? !action.isEnabled(ctx) : false
+                }
+                onClick={async (event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  await run(action.id);
+                  // Flash a ✓ + a brief outline pulse on actions that
+                  // benefit from a "yes, that worked" beat — copy/save —
+                  // otherwise sonner's toast is already enough.
+                  if (FLASHABLE_ACTIONS.has(action.id)) {
+                    setFlashedActionId(action.id);
+                    window.setTimeout(
+                      () =>
+                        setFlashedActionId((current) =>
+                          current === action.id ? null : current,
+                        ),
+                      FLASH_DURATION_MS,
+                    );
+                  }
+                }}
+                className="touch-target image-overlay flex h-8 w-8 items-center justify-center rounded-[4px] border-none disabled:opacity-40 relative"
+                style={
+                  isFlashing
+                    ? {
+                        boxShadow:
+                          "0 0 0 2px var(--accent), 0 0 12px var(--accent-faint)",
+                      }
+                    : undefined
+                }
+              >
+                <AnimatePresence mode="wait" initial={false}>
+                  <motion.span
+                    key={isFlashing ? "check" : "icon"}
+                    initial={
+                      reducedMotion
+                        ? false
+                        : { scale: 0.7, opacity: 0 }
+                    }
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={
+                      reducedMotion
+                        ? { opacity: 0 }
+                        : { scale: 1.2, opacity: 0 }
+                    }
+                    transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                    className="inline-flex items-center justify-center"
+                  >
+                    <Icon
+                      name={isFlashing ? "check" : action.icon}
+                      size={13}
+                    />
+                  </motion.span>
+                </AnimatePresence>
+              </button>
+            );
+          })}
           <button
             type="button"
             title="更多"

--- a/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/image-hover-toolbar.tsx
@@ -96,11 +96,11 @@ export function ImageHoverToolbar({
                 onClick={async (event) => {
                   event.stopPropagation();
                   event.preventDefault();
-                  await run(action.id);
+                  const succeeded = await run(action.id);
                   // Flash a ✓ + a brief outline pulse on actions that
                   // benefit from a "yes, that worked" beat — copy/save —
                   // otherwise sonner's toast is already enough.
-                  if (FLASHABLE_ACTIONS.has(action.id)) {
+                  if (succeeded && FLASHABLE_ACTIONS.has(action.id)) {
                     setFlashedActionId(action.id);
                     window.setTimeout(
                       () =>

--- a/apps/gpt-image-2-app/src/components/ui/quick-look.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/quick-look.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from "react";
+import * as Radix from "@radix-ui/react-dialog";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { RevealImage } from "@/components/ui/reveal-image";
+import { ImageContextMenu } from "@/components/ui/image-context-menu";
+import { cn } from "@/lib/cn";
+import type { ImageAsset } from "@/lib/image-actions/types";
+
+export type QuickLookPayload = {
+  asset: ImageAsset;
+  /**
+   * Optional sibling images (e.g. multi-output edit results). When provided,
+   * left/right arrow buttons + a thumbnail strip + ArrowLeft/ArrowRight
+   * keyboard shortcuts navigate among them.
+   */
+  peers?: ImageAsset[];
+  /**
+   * Called when the user navigates to a different peer. The host updates its
+   * own focused asset to match.
+   */
+  onChange?: (next: ImageAsset) => void;
+};
+
+type Listener = (payload: QuickLookPayload) => void;
+let openListener: Listener | null = null;
+
+/**
+ * Imperatively open the Quick Look overlay. Used by:
+ *   - Space key from `useImageShortcuts` (single asset, no peers)
+ *   - Detail drawer "click big image" path (peers + onChange)
+ *   - Hover toolbar Quick Look icon (single asset)
+ *
+ * No-op if `<QuickLookHost />` isn't mounted yet (e.g. during early boot).
+ */
+export function openQuickLook(payload: QuickLookPayload) {
+  openListener?.(payload);
+}
+
+/**
+ * Mount once at app root. Renders a fullscreen Radix Dialog backing the
+ * Quick Look UX, identical visual style to the detail drawer's previous
+ * inline zoom dialog (which is removed in this commit).
+ *
+ * Esc closes (Radix default). Arrow keys navigate when peers are provided.
+ */
+export function QuickLookHost() {
+  const [state, setState] = useState<QuickLookPayload | null>(null);
+  const open = state != null;
+
+  useEffect(() => {
+    openListener = setState;
+    return () => {
+      if (openListener === setState) openListener = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open || !state) return;
+    if (!state.peers || state.peers.length <= 1) return;
+    const peers = state.peers;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      event.preventDefault();
+      const idx = peers.findIndex(
+        (p) =>
+          p.jobId === state.asset.jobId &&
+          p.outputIndex === state.asset.outputIndex,
+      );
+      if (idx < 0) return;
+      const delta = event.key === "ArrowRight" ? 1 : -1;
+      const next = peers[(idx + delta + peers.length) % peers.length];
+      state.onChange?.(next);
+      setState({ ...state, asset: next });
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, state]);
+
+  if (!open || !state) return null;
+
+  const { asset, peers, onChange } = state;
+  const peerCount = peers?.length ?? 0;
+  const activePosition =
+    peers?.findIndex(
+      (p) =>
+        p.jobId === asset.jobId && p.outputIndex === asset.outputIndex,
+    ) ?? -1;
+
+  const goPrev = () => {
+    if (!peers || peers.length <= 1) return;
+    const next = peers[(activePosition - 1 + peers.length) % peers.length];
+    onChange?.(next);
+    setState({ ...state, asset: next });
+  };
+  const goNext = () => {
+    if (!peers || peers.length <= 1) return;
+    const next = peers[(activePosition + 1) % peers.length];
+    onChange?.(next);
+    setState({ ...state, asset: next });
+  };
+
+  return (
+    <Radix.Root open onOpenChange={(o) => !o && setState(null)}>
+      <Radix.Portal>
+        <Radix.Overlay
+          className="fixed inset-0 z-[60] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
+          style={{
+            background: "var(--k-70)",
+            backdropFilter: "blur(8px)",
+            WebkitBackdropFilter: "blur(8px)",
+          }}
+        />
+        <Radix.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-[61] -translate-x-1/2 -translate-y-1/2 max-w-[92vw] max-h-[92vh] outline-none data-[state=open]:animate-in data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:zoom-out-95"
+        >
+          <Radix.Title className="sr-only">作品详情</Radix.Title>
+          <ImageContextMenu asset={asset}>
+            <RevealImage
+              src={asset.src}
+              alt="作品详情"
+              decoding="async"
+              duration={500}
+              className="block max-w-[92vw] max-h-[92vh] object-contain rounded-lg shadow-[var(--shadow-floating)]"
+            />
+          </ImageContextMenu>
+          {peerCount > 1 ? (
+            <>
+              <button
+                type="button"
+                onClick={goPrev}
+                aria-label="上一张"
+                className="absolute left-3 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] text-foreground backdrop-blur transition-colors hover:bg-[color:var(--surface-floating-strong)]"
+                style={{ boxShadow: "var(--shadow-floating)" }}
+              >
+                <ChevronLeft size={20} />
+              </button>
+              <button
+                type="button"
+                onClick={goNext}
+                aria-label="下一张"
+                className="absolute right-3 top-1/2 inline-flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] text-foreground backdrop-blur transition-colors hover:bg-[color:var(--surface-floating-strong)]"
+                style={{ boxShadow: "var(--shadow-floating)" }}
+              >
+                <ChevronRight size={20} />
+              </button>
+              <div className="absolute bottom-3 left-1/2 flex max-w-[78vw] -translate-x-1/2 items-center gap-1.5 overflow-x-auto rounded-full border border-[color:var(--surface-floating-border)] bg-[color:var(--surface-floating)] p-1.5 backdrop-blur scrollbar-none">
+                {peers!.map((peer, i) => {
+                  const isActive =
+                    peer.jobId === asset.jobId &&
+                    peer.outputIndex === asset.outputIndex;
+                  return (
+                    <button
+                      key={`${peer.jobId}-${peer.outputIndex}`}
+                      type="button"
+                      onClick={() => {
+                        onChange?.(peer);
+                        setState({ ...state, asset: peer });
+                      }}
+                      className={cn(
+                        "h-10 w-10 shrink-0 overflow-hidden rounded-full border transition-all",
+                        isActive
+                          ? "border-[color:var(--accent)] opacity-100"
+                          : "border-transparent opacity-55 hover:opacity-90",
+                      )}
+                      aria-label={`切换到第 ${i + 1} 张`}
+                    >
+                      <img
+                        src={peer.src}
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        className="h-full w-full object-cover"
+                        draggable={false}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          ) : null}
+          <Radix.Close asChild>
+            <button
+              type="button"
+              aria-label="关闭"
+              className="absolute -top-2 -right-2 h-9 w-9 rounded-full inline-flex items-center justify-center bg-[color:var(--surface-floating)] backdrop-blur border border-[color:var(--surface-floating-border)] text-foreground hover:bg-[color:var(--surface-floating-strong)] transition-colors"
+              style={{ boxShadow: "var(--shadow-floating)" }}
+            >
+              <X size={16} />
+            </button>
+          </Radix.Close>
+        </Radix.Content>
+      </Radix.Portal>
+    </Radix.Root>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
@@ -1,32 +1,43 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { toast } from "sonner";
 import { cn } from "@/lib/cn";
+
+export type SelectionCapture =
+  | {
+      kind: "input";
+      element: HTMLInputElement | HTMLTextAreaElement;
+      selectionStart: number;
+      selectionEnd: number;
+      selectedText: string;
+    }
+  | { kind: "document"; selectedText: string };
 
 type SelectionMenuState = {
   x: number;
   y: number;
-  hasEditableTarget: boolean;
-  hasSelection: boolean;
+  capture: SelectionCapture;
 };
 
 type Listener = (state: SelectionMenuState) => void;
 let activeListener: Listener | null = null;
 
 /**
- * Imperative entry point used by `useDisableWebviewContextMenu`. The hook
- * decides when (input/textarea/contenteditable target, or any element with a
- * non-empty selection), this component renders the actual menu.
+ * Imperative entry point used by `useDisableWebviewContextMenu`. Captures
+ * the live selection (input/textarea offset pair, or window.getSelection
+ * text) so menu actions don't fight with selection-loss when the menu
+ * itself takes focus.
  */
 export function openTextSelectionMenu(state: SelectionMenuState) {
   activeListener?.(state);
 }
 
 /**
- * Tiny self-rendered "Cut / Copy / Paste / Select All" menu. Shown when the
- * user right-clicks on editable surfaces or text selections — replacing the
- * webview's native menu after `useDisableWebviewContextMenu` suppresses it.
- *
- * Mounted once at app root.
+ * Replaces the webview's native Cut/Copy/Paste/Select All menu on editable
+ * surfaces and over plain text selections. Implemented entirely on top of
+ * `navigator.clipboard` and the captured selection — `document.execCommand`
+ * is unreliable in modern WebKit when the menu portal pulls focus away
+ * from the source element.
  */
 export function TextSelectionContextMenu() {
   const [state, setState] = useState<SelectionMenuState | null>(null);
@@ -59,6 +70,71 @@ export function TextSelectionContextMenu() {
   if (!state) return null;
 
   const close = () => setState(null);
+  const { capture } = state;
+  const hasSelection = capture.selectedText.length > 0;
+  const isEditable = capture.kind === "input";
+
+  const onCopy = async () => {
+    if (!hasSelection) return close();
+    try {
+      await navigator.clipboard.writeText(capture.selectedText);
+    } catch (error) {
+      toast.error("复制失败", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+    close();
+  };
+
+  const onCut = async () => {
+    if (capture.kind !== "input" || !hasSelection) return close();
+    const { element, selectionStart, selectionEnd, selectedText } = capture;
+    try {
+      await navigator.clipboard.writeText(selectedText);
+    } catch (error) {
+      toast.error("剪切失败", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+      return close();
+    }
+    replaceInputRange(element, selectionStart, selectionEnd, "");
+    close();
+  };
+
+  const onPaste = async () => {
+    if (capture.kind !== "input") return close();
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      // User denied clipboard access (or macOS prompt was dismissed).
+      // No toast — Apple's own prompt is enough signal.
+      return close();
+    }
+    const { element, selectionStart, selectionEnd } = capture;
+    replaceInputRange(element, selectionStart, selectionEnd, text);
+    close();
+  };
+
+  const onSelectAll = () => {
+    if (capture.kind === "input") {
+      capture.element.focus();
+      capture.element.select();
+    } else {
+      // contenteditable / generic: re-select via Range API
+      const range = document.createRange();
+      const target = document.activeElement ?? document.body;
+      try {
+        range.selectNodeContents(target);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      } catch {
+        /* ignore — node not selectable */
+      }
+    }
+    close();
+  };
 
   return createPortal(
     <div
@@ -75,56 +151,62 @@ export function TextSelectionContextMenu() {
         boxShadow: "var(--shadow-floating)",
       }}
     >
-      {state.hasEditableTarget ? (
+      {isEditable ? (
         <MenuButton
           label="剪切"
           shortcut="⌘X"
-          disabled={!state.hasSelection}
-          onSelect={() => {
-            document.execCommand("cut");
-            close();
-          }}
+          disabled={!hasSelection}
+          onSelect={onCut}
         />
       ) : null}
       <MenuButton
         label="复制"
         shortcut="⌘C"
-        disabled={!state.hasSelection}
-        onSelect={() => {
-          document.execCommand("copy");
-          close();
-        }}
+        disabled={!hasSelection}
+        onSelect={onCopy}
       />
-      {state.hasEditableTarget ? (
-        <MenuButton
-          label="粘贴"
-          shortcut="⌘V"
-          onSelect={async () => {
-            try {
-              const text = await navigator.clipboard.readText();
-              document.execCommand("insertText", false, text);
-            } catch {
-              document.execCommand("paste");
-            }
-            close();
-          }}
-        />
+      {isEditable ? (
+        <MenuButton label="粘贴" shortcut="⌘V" onSelect={onPaste} />
       ) : null}
       <div
         className="my-1 h-px"
         style={{ background: "var(--border-faint)" }}
       />
-      <MenuButton
-        label="全选"
-        shortcut="⌘A"
-        onSelect={() => {
-          document.execCommand("selectAll");
-          close();
-        }}
-      />
+      <MenuButton label="全选" shortcut="⌘A" onSelect={onSelectAll} />
     </div>,
     document.body,
   );
+}
+
+/**
+ * React-friendly value mutation: triggers React's onChange handler by
+ * dispatching a native `input` event after using the prototype's value
+ * setter (otherwise React's synthetic-event tracking ignores the change).
+ */
+function replaceInputRange(
+  element: HTMLInputElement | HTMLTextAreaElement,
+  start: number,
+  end: number,
+  insert: string,
+) {
+  const before = element.value.slice(0, start);
+  const after = element.value.slice(end);
+  const next = before + insert + after;
+  const proto = Object.getPrototypeOf(element);
+  const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
+  if (setter) {
+    setter.call(element, next);
+  } else {
+    element.value = next;
+  }
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+  const caret = start + insert.length;
+  element.focus();
+  try {
+    element.setSelectionRange(caret, caret);
+  } catch {
+    /* some input types (number, color) don't support setSelectionRange */
+  }
 }
 
 type MenuButtonProps = {

--- a/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { cn } from "@/lib/cn";
+
+const VIEWPORT_PADDING = 8;
 
 export type SelectionCapture =
   | {
@@ -41,6 +43,12 @@ export function openTextSelectionMenu(state: SelectionMenuState) {
  */
 export function TextSelectionContextMenu() {
   const [state, setState] = useState<SelectionMenuState | null>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+    ready: boolean;
+  } | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     activeListener = setState;
@@ -67,7 +75,37 @@ export function TextSelectionContextMenu() {
     };
   }, [state]);
 
-  if (!state) return null;
+  // Reset to the click position synchronously when a new state arrives so
+  // the first frame paints near the cursor (off-screen clamping happens in
+  // the next pass once we've measured the menu).
+  useLayoutEffect(() => {
+    if (!state) {
+      setPosition(null);
+      return;
+    }
+    setPosition({ top: state.y, left: state.x, ready: false });
+  }, [state]);
+
+  // After the menu paints, measure its real size and clamp into the
+  // viewport. Avoids the right-click-near-the-edge "menu is half off-screen"
+  // problem the user hit.
+  useLayoutEffect(() => {
+    if (!state || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    let left = state.x;
+    let top = state.y;
+    if (left + rect.width + VIEWPORT_PADDING > window.innerWidth) {
+      left = window.innerWidth - rect.width - VIEWPORT_PADDING;
+    }
+    if (top + rect.height + VIEWPORT_PADDING > window.innerHeight) {
+      top = window.innerHeight - rect.height - VIEWPORT_PADDING;
+    }
+    if (left < VIEWPORT_PADDING) left = VIEWPORT_PADDING;
+    if (top < VIEWPORT_PADDING) top = VIEWPORT_PADDING;
+    setPosition({ top, left, ready: true });
+  }, [state]);
+
+  if (!state || !position) return null;
 
   const close = () => setState(null);
   const { capture } = state;
@@ -138,12 +176,17 @@ export function TextSelectionContextMenu() {
 
   return createPortal(
     <div
+      ref={menuRef}
       role="menu"
       onMouseDown={(event) => event.stopPropagation()}
       className="fixed z-[1000] min-w-[180px] overflow-hidden rounded-xl border p-1 outline-none"
       style={{
-        top: state.y,
-        left: state.x,
+        top: position.top,
+        left: position.left,
+        // Hide the first paint at the user's cursor position so they don't
+        // see the menu pop, then jump to the clamped location. Once
+        // useLayoutEffect commits the measured position, opacity flips on.
+        opacity: position.ready ? 1 : 0,
         background: "var(--surface-floating)",
         borderColor: "var(--surface-floating-border)",
         backdropFilter: "blur(28px) saturate(150%)",

--- a/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
@@ -179,9 +179,13 @@ export function TextSelectionContextMenu() {
 }
 
 /**
- * React-friendly value mutation: triggers React's onChange handler by
- * dispatching a native `input` event after using the prototype's value
- * setter (otherwise React's synthetic-event tracking ignores the change).
+ * Insert / replace text inside an input or textarea.
+ *
+ * Uses `document.execCommand("insertText")` so the mutation participates in
+ * the webview's native undo stack — ⌘Z after our menu's paste/cut should
+ * undo the menu's change, just like a native paste/cut would. The
+ * prototype-setter fallback (synthetic) only runs if execCommand fails,
+ * which on modern WebKit is essentially never for plain inputs.
  */
 function replaceInputRange(
   element: HTMLInputElement | HTMLTextAreaElement,
@@ -189,9 +193,24 @@ function replaceInputRange(
   end: number,
   insert: string,
 ) {
-  const before = element.value.slice(0, start);
-  const after = element.value.slice(end);
-  const next = before + insert + after;
+  element.focus();
+  try {
+    element.setSelectionRange(start, end);
+  } catch {
+    /* some input types (number, color) don't support setSelectionRange */
+  }
+  let nativeOk = false;
+  try {
+    nativeOk = document.execCommand("insertText", false, insert);
+  } catch {
+    nativeOk = false;
+  }
+  if (nativeOk) return;
+
+  // Fallback for environments where execCommand is gone — synthetic value
+  // mutation. This bypasses the undo stack but at least leaves the input
+  // and React state consistent.
+  const next = element.value.slice(0, start) + insert + element.value.slice(end);
   const proto = Object.getPrototypeOf(element);
   const setter = Object.getOwnPropertyDescriptor(proto, "value")?.set;
   if (setter) {
@@ -201,11 +220,10 @@ function replaceInputRange(
   }
   element.dispatchEvent(new Event("input", { bubbles: true }));
   const caret = start + insert.length;
-  element.focus();
   try {
     element.setSelectionRange(caret, caret);
   } catch {
-    /* some input types (number, color) don't support setSelectionRange */
+    /* */
   }
 }
 

--- a/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/text-selection-context-menu.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/lib/cn";
+
+type SelectionMenuState = {
+  x: number;
+  y: number;
+  hasEditableTarget: boolean;
+  hasSelection: boolean;
+};
+
+type Listener = (state: SelectionMenuState) => void;
+let activeListener: Listener | null = null;
+
+/**
+ * Imperative entry point used by `useDisableWebviewContextMenu`. The hook
+ * decides when (input/textarea/contenteditable target, or any element with a
+ * non-empty selection), this component renders the actual menu.
+ */
+export function openTextSelectionMenu(state: SelectionMenuState) {
+  activeListener?.(state);
+}
+
+/**
+ * Tiny self-rendered "Cut / Copy / Paste / Select All" menu. Shown when the
+ * user right-clicks on editable surfaces or text selections — replacing the
+ * webview's native menu after `useDisableWebviewContextMenu` suppresses it.
+ *
+ * Mounted once at app root.
+ */
+export function TextSelectionContextMenu() {
+  const [state, setState] = useState<SelectionMenuState | null>(null);
+
+  useEffect(() => {
+    activeListener = setState;
+    return () => {
+      if (activeListener === setState) activeListener = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!state) return;
+    const close = () => setState(null);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    window.addEventListener("mousedown", close);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("blur", close);
+    window.addEventListener("scroll", close, true);
+    return () => {
+      window.removeEventListener("mousedown", close);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("blur", close);
+      window.removeEventListener("scroll", close, true);
+    };
+  }, [state]);
+
+  if (!state) return null;
+
+  const close = () => setState(null);
+
+  return createPortal(
+    <div
+      role="menu"
+      onMouseDown={(event) => event.stopPropagation()}
+      className="fixed z-[1000] min-w-[180px] overflow-hidden rounded-xl border p-1 outline-none"
+      style={{
+        top: state.y,
+        left: state.x,
+        background: "var(--surface-floating)",
+        borderColor: "var(--surface-floating-border)",
+        backdropFilter: "blur(28px) saturate(150%)",
+        WebkitBackdropFilter: "blur(28px) saturate(150%)",
+        boxShadow: "var(--shadow-floating)",
+      }}
+    >
+      {state.hasEditableTarget ? (
+        <MenuButton
+          label="剪切"
+          shortcut="⌘X"
+          disabled={!state.hasSelection}
+          onSelect={() => {
+            document.execCommand("cut");
+            close();
+          }}
+        />
+      ) : null}
+      <MenuButton
+        label="复制"
+        shortcut="⌘C"
+        disabled={!state.hasSelection}
+        onSelect={() => {
+          document.execCommand("copy");
+          close();
+        }}
+      />
+      {state.hasEditableTarget ? (
+        <MenuButton
+          label="粘贴"
+          shortcut="⌘V"
+          onSelect={async () => {
+            try {
+              const text = await navigator.clipboard.readText();
+              document.execCommand("insertText", false, text);
+            } catch {
+              document.execCommand("paste");
+            }
+            close();
+          }}
+        />
+      ) : null}
+      <div
+        className="my-1 h-px"
+        style={{ background: "var(--border-faint)" }}
+      />
+      <MenuButton
+        label="全选"
+        shortcut="⌘A"
+        onSelect={() => {
+          document.execCommand("selectAll");
+          close();
+        }}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+type MenuButtonProps = {
+  label: string;
+  shortcut?: string;
+  disabled?: boolean;
+  onSelect: () => void;
+};
+
+function MenuButton({ label, shortcut, disabled, onSelect }: MenuButtonProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onSelect}
+      className={cn(
+        "flex w-full items-center justify-between gap-3 rounded-md px-2.5 py-1.5 text-[13px] outline-none",
+        "text-[color:var(--text)]",
+        "hover:bg-[color:var(--bg-hover)]",
+        "disabled:pointer-events-none disabled:opacity-40",
+      )}
+    >
+      <span>{label}</span>
+      {shortcut ? (
+        <span className="text-[11px] tabular-nums text-[color:var(--text-faint)]">
+          {shortcut}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
-import { openTextSelectionMenu } from "@/components/ui/text-selection-context-menu";
+import {
+  openTextSelectionMenu,
+  type SelectionCapture,
+} from "@/components/ui/text-selection-context-menu";
 
 const TRIGGER_OPT_OUT_ATTR = "data-image-action-trigger";
 
@@ -38,14 +41,12 @@ export function useDisableWebviewContextMenu() {
 
       event.preventDefault();
 
-      const editable = isEditableTarget(target);
-      const hasSelection = hasNonEmptySelection();
-      if (editable || hasSelection) {
+      const capture = captureSelection(target);
+      if (capture) {
         openTextSelectionMenu({
           x: event.clientX,
           y: event.clientY,
-          hasEditableTarget: editable,
-          hasSelection,
+          capture,
         });
       }
     };
@@ -77,4 +78,40 @@ export function hasNonEmptySelection(): boolean {
   if (!selection) return false;
   if (selection.isCollapsed) return false;
   return selection.toString().length > 0;
+}
+
+/**
+ * Capture the right snapshot for the text-selection menu so its handlers
+ * don't depend on focus or selection still being live by the time the user
+ * clicks an item. Returns null when the click target has nothing actionable
+ * (no selection AND not an editable surface).
+ */
+function captureSelection(target: HTMLElement): SelectionCapture | null {
+  const inputLike = nearestEditableInput(target);
+  if (inputLike) {
+    const start = inputLike.selectionStart ?? 0;
+    const end = inputLike.selectionEnd ?? 0;
+    return {
+      kind: "input",
+      element: inputLike,
+      selectionStart: start,
+      selectionEnd: end,
+      selectedText: inputLike.value.slice(start, end),
+    };
+  }
+  const text = window.getSelection()?.toString() ?? "";
+  if (text.length > 0) {
+    return { kind: "document", selectedText: text };
+  }
+  return null;
+}
+
+function nearestEditableInput(
+  el: HTMLElement,
+): HTMLInputElement | HTMLTextAreaElement | null {
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA") {
+    return el as HTMLInputElement | HTMLTextAreaElement;
+  }
+  return null;
 }

--- a/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { openTextSelectionMenu } from "@/components/ui/text-selection-context-menu";
+
+const TRIGGER_OPT_OUT_ATTR = "data-image-action-trigger";
+
+/**
+ * Replace the webview's default contextmenu with our app-controlled surfaces.
+ *
+ * - Image triggers (Radix ContextMenu Trigger over an image) handle the event
+ *   themselves; their handler calls preventDefault, so we exit early when the
+ *   bubbled event has `defaultPrevented`. We also honor an explicit opt-out
+ *   marker (`data-image-action-trigger`) for any non-Radix surfaces that want
+ *   to keep their own contextmenu logic.
+ * - Editable inputs / textareas / contenteditable surfaces and any other
+ *   target with a non-collapsed text selection get a small
+ *   "Cut / Copy / Paste / Select All" menu rendered by
+ *   <TextSelectionContextMenu />.
+ * - Everything else simply has the default menu suppressed.
+ *
+ * In dev builds, holding Option (⌥) when right-clicking lets the underlying
+ * webview's native menu show — that's how you reach the devtools "Inspect"
+ * shortcut without unmounting the hook.
+ */
+export function useDisableWebviewContextMenu() {
+  useEffect(() => {
+    const handler = (event: MouseEvent) => {
+      // Dev escape hatch: ⌥ + right-click = native inspect menu.
+      if (import.meta.env.DEV && event.altKey) return;
+
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+
+      // Surfaces that opt out (Radix ContextMenu Trigger over an image,
+      // or anything else marked with `data-image-action-trigger`) handle
+      // the event themselves.
+      if (target.closest(`[${TRIGGER_OPT_OUT_ATTR}]`)) return;
+      if (event.defaultPrevented) return;
+
+      event.preventDefault();
+
+      const editable = isEditableTarget(target);
+      const hasSelection = hasNonEmptySelection();
+      if (editable || hasSelection) {
+        openTextSelectionMenu({
+          x: event.clientX,
+          y: event.clientY,
+          hasEditableTarget: editable,
+          hasSelection,
+        });
+      }
+    };
+
+    // Run on the bubbling phase so Radix-style stopPropagation has a chance
+    // to suppress our handler when an image trigger is hit.
+    window.addEventListener("contextmenu", handler);
+    return () => window.removeEventListener("contextmenu", handler);
+  }, []);
+}
+
+export const IMAGE_ACTION_TRIGGER_ATTR = TRIGGER_OPT_OUT_ATTR;
+
+export function isEditableTarget(el: HTMLElement): boolean {
+  if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") return true;
+  if (el.isContentEditable) return true;
+  // Walk up a few levels in case the click landed on an inline span inside a
+  // contenteditable surface.
+  let parent = el.parentElement;
+  for (let i = 0; i < 4 && parent; i += 1) {
+    if (parent.isContentEditable) return true;
+    parent = parent.parentElement;
+  }
+  return false;
+}
+
+export function hasNonEmptySelection(): boolean {
+  const selection = window.getSelection();
+  if (!selection) return false;
+  if (selection.isCollapsed) return false;
+  return selection.toString().length > 0;
+}

--- a/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-disable-webview-contextmenu.ts
@@ -26,22 +26,57 @@ const TRIGGER_OPT_OUT_ATTR = "data-image-action-trigger";
  */
 export function useDisableWebviewContextMenu() {
   useEffect(() => {
-    const handler = (event: MouseEvent) => {
-      // Dev escape hatch: ⌥ + right-click = native inspect menu.
-      if (import.meta.env.DEV && event.altKey) return;
+    // WebKit will auto-select the word under the cursor when you right-click
+    // an input/textarea. By the time the `contextmenu` event fires, the
+    // input's `selectionStart`/`selectionEnd` already point at that word
+    // — which is wrong for paste (we want to insert at the user-set caret,
+    // not replace a word). Stash the selection on capture-phase mousedown
+    // *before* the user agent gets to mutate it.
+    let stashed: SelectionCapture | null = null;
 
+    const onMouseDownCapture = (event: MouseEvent) => {
+      if (event.button !== 2) {
+        stashed = null;
+        return;
+      }
       const target = event.target as HTMLElement | null;
       if (!target) return;
+      if (target.closest(`[${TRIGGER_OPT_OUT_ATTR}]`)) {
+        stashed = null;
+        return;
+      }
+      stashed = captureSelection(target);
+    };
+
+    const onContextMenu = (event: MouseEvent) => {
+      // Dev escape hatch: ⌥ + right-click = native inspect menu.
+      if (import.meta.env.DEV && event.altKey) {
+        stashed = null;
+        return;
+      }
+
+      const target = event.target as HTMLElement | null;
+      if (!target) {
+        stashed = null;
+        return;
+      }
 
       // Surfaces that opt out (Radix ContextMenu Trigger over an image,
       // or anything else marked with `data-image-action-trigger`) handle
       // the event themselves.
-      if (target.closest(`[${TRIGGER_OPT_OUT_ATTR}]`)) return;
-      if (event.defaultPrevented) return;
+      if (target.closest(`[${TRIGGER_OPT_OUT_ATTR}]`)) {
+        stashed = null;
+        return;
+      }
+      if (event.defaultPrevented) {
+        stashed = null;
+        return;
+      }
 
       event.preventDefault();
 
-      const capture = captureSelection(target);
+      const capture = stashed ?? captureSelection(target);
+      stashed = null;
       if (capture) {
         openTextSelectionMenu({
           x: event.clientX,
@@ -51,10 +86,12 @@ export function useDisableWebviewContextMenu() {
       }
     };
 
-    // Run on the bubbling phase so Radix-style stopPropagation has a chance
-    // to suppress our handler when an image trigger is hit.
-    window.addEventListener("contextmenu", handler);
-    return () => window.removeEventListener("contextmenu", handler);
+    window.addEventListener("mousedown", onMouseDownCapture, true);
+    window.addEventListener("contextmenu", onContextMenu);
+    return () => {
+      window.removeEventListener("mousedown", onMouseDownCapture, true);
+      window.removeEventListener("contextmenu", onContextMenu);
+    };
   }, []);
 }
 

--- a/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useFocusedImage } from "@/lib/image-actions/focused-image";
+import { isEditableTarget } from "./use-disable-webview-contextmenu";
+
+/**
+ * Global keyboard shortcuts for the focused image. Mounted once at app root.
+ *
+ * The handler short-circuits when:
+ *   - the active key event target is editable (input/textarea/contenteditable)
+ *   - there is no focused image asset
+ *
+ * Real key handling lands in successor commits:
+ *   - C2: ⌘⌫ / Delete → soft delete with undo toast
+ *   - C2/C5: ⌘C → copy image
+ *   - C3: Space → open Quick Look
+ *
+ * Reserved here so successor commits register handlers in one obvious place
+ * instead of scattering keydown listeners across components.
+ */
+export function useImageShortcuts() {
+  const focused = useFocusedImage();
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target && isEditableTarget(target)) return;
+      if (!focused) return;
+      // Successor commits attach action-id dispatch here.
+      void event;
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [focused]);
+}

--- a/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { openQuickLook } from "@/components/ui/quick-look";
 import { useFocusedImage } from "@/lib/image-actions/focused-image";
 import { isEditableTarget } from "./use-disable-webview-contextmenu";
 
@@ -7,15 +8,14 @@ import { isEditableTarget } from "./use-disable-webview-contextmenu";
  *
  * The handler short-circuits when:
  *   - the active key event target is editable (input/textarea/contenteditable)
+ *     so a Space inside the prompt textarea inserts a space, not Quick Look
  *   - there is no focused image asset
  *
- * Real key handling lands in successor commits:
- *   - C2: ⌘⌫ / Delete → soft delete with undo toast
- *   - C2/C5: ⌘C → copy image
- *   - C3: Space → open Quick Look
+ * Currently bound:
+ *   - Space → open Quick Look on the focused asset
  *
- * Reserved here so successor commits register handlers in one obvious place
- * instead of scattering keydown listeners across components.
+ * Successor commits add: ⌘⌫ → soft delete with undo (C5), ⌘C → copy image
+ * (C5/C6), j/k → cycle through peer outputs (C6).
  */
 export function useImageShortcuts() {
   const focused = useFocusedImage();
@@ -25,8 +25,10 @@ export function useImageShortcuts() {
       const target = event.target as HTMLElement | null;
       if (target && isEditableTarget(target)) return;
       if (!focused) return;
-      // Successor commits attach action-id dispatch here.
-      void event;
+      if (event.key === " " || event.code === "Space") {
+        event.preventDefault();
+        openQuickLook({ asset: focused });
+      }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);

--- a/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
@@ -1,21 +1,31 @@
 import { useEffect } from "react";
 import { openQuickLook } from "@/components/ui/quick-look";
+import { api } from "@/lib/api";
 import { useFocusedImage } from "@/lib/image-actions/focused-image";
-import { isEditableTarget } from "./use-disable-webview-contextmenu";
+import { findAction } from "@/lib/image-actions/registry";
+import type {
+  ImageActionContext,
+  ImageActionId,
+} from "@/lib/image-actions/types";
+import {
+  hasNonEmptySelection,
+  isEditableTarget,
+} from "./use-disable-webview-contextmenu";
 
 /**
  * Global keyboard shortcuts for the focused image. Mounted once at app root.
  *
+ * Bindings:
+ *   - Space        → open Quick Look on the focused asset
+ *   - ⌘C / Ctrl+C  → copy-image (skipped when text is selected so the
+ *                    native text-copy gesture wins)
+ *   - ⇧⌘C          → copy-image-with-prompt
+ *   - ⌘⌫ / Delete  → soft delete with undo
+ *
  * The handler short-circuits when:
  *   - the active key event target is editable (input/textarea/contenteditable)
- *     so a Space inside the prompt textarea inserts a space, not Quick Look
+ *     so Space inside the prompt textarea inserts a space, not Quick Look
  *   - there is no focused image asset
- *
- * Currently bound:
- *   - Space → open Quick Look on the focused asset
- *
- * Successor commits add: ⌘⌫ → soft delete with undo (C5), ⌘C → copy image
- * (C5/C6), j/k → cycle through peer outputs (C6).
  */
 export function useImageShortcuts() {
   const focused = useFocusedImage();
@@ -25,12 +35,53 @@ export function useImageShortcuts() {
       const target = event.target as HTMLElement | null;
       if (target && isEditableTarget(target)) return;
       if (!focused) return;
+
+      const ctx: ImageActionContext = {
+        asset: focused,
+        runtime: api.kind,
+        // Use the command-palette surface so actions which are gated to
+        // the right-click menu (Copy Path, Edit with Prompt, etc.) still
+        // resolve through `findAction` if a future binding wants them.
+        surface: "command-palette",
+      };
+
       if (event.key === " " || event.code === "Space") {
         event.preventDefault();
         openQuickLook({ asset: focused });
+        return;
+      }
+
+      const meta = event.metaKey || event.ctrlKey;
+      const isC = event.key === "c" || event.key === "C";
+      if (meta && isC) {
+        // Don't fight a real text-selection copy.
+        if (hasNonEmptySelection()) return;
+        event.preventDefault();
+        const id: ImageActionId = event.shiftKey
+          ? "copy-image-with-prompt"
+          : "copy-image";
+        runActionById(id, ctx);
+        return;
+      }
+
+      if (
+        meta &&
+        (event.key === "Backspace" || event.key === "Delete")
+      ) {
+        event.preventDefault();
+        runActionById("delete", ctx);
+        return;
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [focused]);
+}
+
+function runActionById(id: ImageActionId, ctx: ImageActionContext) {
+  const action = findAction(id);
+  if (!action) return;
+  if (!action.isAvailable(ctx)) return;
+  if (action.isEnabled && !action.isEnabled(ctx)) return;
+  void action.execute(ctx);
 }

--- a/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
@@ -19,7 +19,7 @@ import {
  *   - Space        → open Quick Look on the focused asset
  *   - ⌘C / Ctrl+C  → copy-image (skipped when text is selected so the
  *                    native text-copy gesture wins)
- *   - ⇧⌘C          → copy-image-with-prompt
+ *   - ⇧⌘C          → copy-prompt
  *   - ⌘⌫ / Delete  → soft delete with undo
  *
  * The handler short-circuits when:
@@ -58,7 +58,7 @@ export function useImageShortcuts() {
         if (hasNonEmptySelection()) return;
         event.preventDefault();
         const id: ImageActionId = event.shiftKey
-          ? "copy-image-with-prompt"
+          ? "copy-prompt"
           : "copy-image";
         runActionById(id, ctx);
         return;

--- a/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-image-shortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { openQuickLook } from "@/components/ui/quick-look";
 import { api } from "@/lib/api";
 import { useFocusedImage } from "@/lib/image-actions/focused-image";
@@ -32,6 +33,10 @@ export function useImageShortcuts() {
 
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
+      // If a closer-scoped handler already claimed this keypress (e.g.
+      // OutputTile binds Space/Enter to onSelect and calls preventDefault),
+      // don't double-activate from the bubbled event up here.
+      if (event.defaultPrevented) return;
       const target = event.target as HTMLElement | null;
       if (target && isEditableTarget(target)) return;
       if (!focused) return;
@@ -83,5 +88,12 @@ function runActionById(id: ImageActionId, ctx: ImageActionContext) {
   if (!action) return;
   if (!action.isAvailable(ctx)) return;
   if (action.isEnabled && !action.isEnabled(ctx)) return;
-  void action.execute(ctx);
+  // Mirror the error handling in `useImageActions().run` — keyboard-driven
+  // executors otherwise emit unhandled promise rejections (clipboard
+  // permission denied, fetch failures, etc.) and the user gets no feedback
+  // about why nothing happened.
+  void Promise.resolve(action.execute(ctx)).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    toast.error("操作失败", { description: message });
+  });
 }

--- a/apps/gpt-image-2-app/src/index.css
+++ b/apps/gpt-image-2-app/src/index.css
@@ -962,6 +962,11 @@
    tone (default / success / error / info / warning) as a translucent
    glass surface so toasts feel native to the liquid app. */
 [data-sonner-toaster] {
+  /* Stay above drawers and the Quick Look overlay so action feedback
+     (copy success, delete + undo, etc.) isn't hidden behind the surface
+     that triggered the action. */
+  z-index: 9999 !important;
+
   --normal-bg: rgba(14, 14, 20, 0.78);
   --normal-text: var(--text);
   --normal-border: rgba(255, 255, 255, 0.12);

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -1483,6 +1483,20 @@ export const browserApi: ApiClient = {
     eventLog.delete(id);
     nextSeq.delete(id);
   },
+  async softDeleteJob(id: string) {
+    // Browser runtime has no recoverable trash; the executor suppresses the
+    // "undo" toast on non-Tauri runtimes so the UX matches reality.
+    await this.deleteJob(id);
+  },
+  async restoreDeletedJob(_id: string) {
+    throw new Error("浏览器模式不支持恢复，请重新生成。");
+  },
+  async hardDeleteJob(id: string) {
+    await this.deleteJob(id);
+  },
+  async copyImageToClipboard(_path: string, _prompt?: string | null) {
+    throw new Error("浏览器模式请使用 ClipboardItem。");
+  },
   async cancelJob(id: string) {
     await prepareBrowserRuntime();
     const queuedIndex = queue.findIndex((task) => task.job.id === id);

--- a/apps/gpt-image-2-app/src/lib/api/http-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http-transport.ts
@@ -317,6 +317,24 @@ export const httpApi: ApiClient = {
   async deleteJob(id: string) {
     await requestJson(`/jobs/${encodeURIComponent(id)}`, { method: "DELETE" });
   },
+  async softDeleteJob(id: string) {
+    // HTTP backend has no soft-delete endpoint — fall back to hard delete.
+    // The executor that calls this also suppresses the "undo" toast button
+    // when `runtime !== "tauri"` so the UX stays honest.
+    await this.deleteJob(id);
+  },
+  async restoreDeletedJob(_id: string) {
+    throw new Error("HTTP 模式不支持恢复，请重新生成。");
+  },
+  async hardDeleteJob(id: string) {
+    await this.deleteJob(id);
+  },
+  async copyImageToClipboard(_path: string, _prompt?: string | null) {
+    // HTTP runtime has no Rust bridge. The image-actions executor is expected
+    // to use `navigator.clipboard.write` with a `ClipboardItem` instead of
+    // calling this transport method.
+    throw new Error("HTTP 模式请使用浏览器内置剪贴板。");
+  },
   async cancelJob(id: string) {
     const result = await requestJson<TauriJobResponse>(
       `/jobs/${encodeURIComponent(id)}/cancel`,

--- a/apps/gpt-image-2-app/src/lib/api/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/index.ts
@@ -111,6 +111,18 @@ export const api: ApiClient = {
   getJob: (id) => invokeClient("getJob", id) as ReturnType<ApiClient["getJob"]>,
   deleteJob: (id) =>
     invokeClient("deleteJob", id) as ReturnType<ApiClient["deleteJob"]>,
+  softDeleteJob: (id) =>
+    invokeClient("softDeleteJob", id) as ReturnType<ApiClient["softDeleteJob"]>,
+  restoreDeletedJob: (id) =>
+    invokeClient("restoreDeletedJob", id) as ReturnType<
+      ApiClient["restoreDeletedJob"]
+    >,
+  hardDeleteJob: (id) =>
+    invokeClient("hardDeleteJob", id) as ReturnType<ApiClient["hardDeleteJob"]>,
+  copyImageToClipboard: (path, prompt) =>
+    invokeClient("copyImageToClipboard", path, prompt) as ReturnType<
+      ApiClient["copyImageToClipboard"]
+    >,
   cancelJob: (id) =>
     invokeClient("cancelJob", id) as ReturnType<ApiClient["cancelJob"]>,
   queueStatus: () =>

--- a/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
@@ -177,6 +177,18 @@ export const tauriApi: ApiClient = {
   async deleteJob(id: string) {
     await invoke("history_delete", { jobId: id });
   },
+  async softDeleteJob(id: string) {
+    await invoke("soft_delete_job", { jobId: id });
+  },
+  async restoreDeletedJob(id: string) {
+    await invoke("restore_deleted_job", { jobId: id });
+  },
+  async hardDeleteJob(id: string) {
+    await invoke("hard_delete_job", { jobId: id });
+  },
+  async copyImageToClipboard(path: string, prompt?: string | null) {
+    await invoke("copy_image_to_clipboard", { path, prompt: prompt ?? null });
+  },
   async cancelJob(id: string) {
     const result = await invoke<TauriJobResponse>("cancel_job", { jobId: id });
     return normalizeJobResponse(result);

--- a/apps/gpt-image-2-app/src/lib/api/types.ts
+++ b/apps/gpt-image-2-app/src/lib/api/types.ts
@@ -83,6 +83,34 @@ export type ApiClient = RuntimeCapabilities & {
   listActiveJobs(): Promise<Job[]>;
   getJob(id: string): Promise<{ job: Job; events: JobEvent[] }>;
   deleteJob(id: string): Promise<void>;
+  /**
+   * Soft delete: hide a job from listings but keep it recoverable for the
+   * 5-second undo window. On Tauri this moves the job folder into
+   * `jobs_dir/.trash/<id>` and sets the SQLite `deleted_at` timestamp; on
+   * HTTP / Browser runtimes this falls back to a hard delete (no undo).
+   */
+  softDeleteJob(id: string): Promise<void>;
+  /**
+   * Reverse a soft delete. Tauri-only meaningful operation; other runtimes
+   * throw because they have no recoverable trash state.
+   */
+  restoreDeletedJob(id: string): Promise<void>;
+  /**
+   * Permanently delete a job: rm `jobs_dir/<id>` and `jobs_dir/.trash/<id>`,
+   * then DELETE the history row.
+   */
+  hardDeleteJob(id: string): Promise<void>;
+  /**
+   * Tauri-only: read `path` from disk, decode as image, and write to the
+   * system clipboard via `tauri-plugin-clipboard-manager`. Optionally also
+   * writes `prompt` as plain text in the same write so a single Cmd+V on the
+   * far side can yield image + prompt.
+   *
+   * On HTTP / Browser runtimes the executor is expected to use
+   * `navigator.clipboard.write([new ClipboardItem(...)])` directly instead of
+   * calling this method.
+   */
+  copyImageToClipboard(path: string, prompt?: string | null): Promise<void>;
   cancelJob(id: string): Promise<TauriJobResponse>;
   queueStatus(): Promise<QueueStatus>;
   setQueueConcurrency(maxParallel: number): Promise<QueueStatus>;

--- a/apps/gpt-image-2-app/src/lib/image-actions/asset.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/asset.ts
@@ -1,0 +1,49 @@
+import { api } from "@/lib/api";
+import type { Job } from "@/lib/types";
+import type { ImageAsset } from "./types";
+
+export function imageAssetFromJob(
+  job: Job,
+  outputIndex: number = 0,
+): ImageAsset {
+  const url = api.jobOutputUrl(job, outputIndex);
+  const path = api.jobOutputPath(job, outputIndex);
+  return {
+    jobId: job.id,
+    outputIndex,
+    src: url,
+    path: path ?? null,
+    prompt: readPromptFromMetadata(job.metadata),
+    command: job.command,
+    job,
+  };
+}
+
+export function imageAssetFromOutput(args: {
+  jobId: string;
+  outputIndex: number;
+  src: string;
+  path?: string | null;
+  prompt?: string;
+  command?: Job["command"];
+  job?: Job;
+}): ImageAsset {
+  return {
+    jobId: args.jobId,
+    outputIndex: args.outputIndex,
+    src: args.src,
+    path: args.path ?? null,
+    prompt: args.prompt,
+    command: args.command,
+    job: args.job,
+  };
+}
+
+function readPromptFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): string | undefined {
+  if (!metadata) return undefined;
+  const value = metadata["prompt"];
+  if (typeof value === "string" && value.trim().length > 0) return value;
+  return undefined;
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/confirm-action.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/confirm-action.ts
@@ -1,0 +1,26 @@
+import type { ConfirmOptions } from "@/hooks/use-confirm";
+
+/**
+ * Module-level holder so executors (running outside React) can prompt the
+ * user via the project's `<ConfirmProvider>` dialog. App.tsx registers the
+ * provider's confirm fn at boot.
+ */
+let confirmFn: ((opts: ConfirmOptions) => Promise<boolean>) | null = null;
+
+export function setActionsConfirm(
+  fn: ((opts: ConfirmOptions) => Promise<boolean>) | null,
+) {
+  confirmFn = fn;
+}
+
+export async function actionsConfirm(opts: ConfirmOptions): Promise<boolean> {
+  if (!confirmFn) {
+    // Provider not registered — fail closed so destructive flows don't run
+    // silently. Should never happen at runtime since App.tsx wires this up
+    // synchronously after mount.
+    // eslint-disable-next-line no-console
+    console.warn("[image-actions] confirm requested without provider");
+    return false;
+  }
+  return confirmFn(opts);
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import { inferImageMime } from "./mime";
 import type { ImageAsset } from "./types";
 
 /**
@@ -62,48 +63,3 @@ async function fetchAsBlob(src: string, expectedMime: string): Promise<Blob> {
   return new Blob([await raw.arrayBuffer()], { type: expectedMime });
 }
 
-/**
- * Infer the image mime type for an asset. Used by the web path to declare
- * the right ClipboardItem key (which must match the blob's mime, otherwise
- * paste targets receive an unrecognized payload).
- *
- * Order of preference:
- *   1. `metadata.format` from the originating GenerateRequest (most
- *      authoritative — that's what the backend actually rendered as)
- *   2. URL extension (`.jpg`, `.webp`, ...)
- *   3. Default to `image/png`
- */
-function inferImageMime(asset: ImageAsset): string {
-  const meta = asset.job?.metadata as { format?: unknown } | undefined;
-  if (typeof meta?.format === "string") {
-    const fromMeta = formatToMime(meta.format);
-    if (fromMeta) return fromMeta;
-  }
-  const ext = asset.src
-    .toLowerCase()
-    .split("?")[0]
-    .split("#")[0]
-    .split(".")
-    .pop();
-  if (ext) {
-    const fromExt = formatToMime(ext);
-    if (fromExt) return fromExt;
-  }
-  return "image/png";
-}
-
-function formatToMime(value: string): string | null {
-  switch (value.toLowerCase()) {
-    case "png":
-      return "image/png";
-    case "jpg":
-    case "jpeg":
-      return "image/jpeg";
-    case "webp":
-      return "image/webp";
-    case "gif":
-      return "image/gif";
-    default:
-      return null;
-  }
-}

--- a/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
@@ -30,24 +30,80 @@ export async function copyImageToClipboard(
     return;
   }
 
-  // Web path — `ClipboardItem` accepts a Promise<Blob>, which Safari needs in
-  // order to count this as a same-microtask user gesture.
+  // Web path — `ClipboardItem` accepts a Promise<Blob>, which Safari needs
+  // in order to count this as a same-microtask user gesture. The mime is
+  // inferred ahead of time from the asset metadata / URL extension so we
+  // declare the right ClipboardItem key (PNG / JPEG / WEBP / GIF) — a
+  // mismatched declaration silently breaks paste targets on some browsers.
+  if (typeof ClipboardItem === "undefined") {
+    throw new Error("浏览器不支持 ClipboardItem，无法复制图片。");
+  }
+  const mime = inferImageMime(asset);
   const items: Record<string, Blob | Promise<Blob>> = {
-    "image/png": fetchAsBlob(asset.src),
+    [mime]: fetchAsBlob(asset.src, mime),
   };
   if (promptText) {
     items["text/plain"] = new Blob([promptText], { type: "text/plain" });
   }
-  if (typeof ClipboardItem === "undefined") {
-    throw new Error("浏览器不支持 ClipboardItem，无法复制图片。");
-  }
   await navigator.clipboard.write([new ClipboardItem(items)]);
 }
 
-async function fetchAsBlob(src: string): Promise<Blob> {
+async function fetchAsBlob(src: string, expectedMime: string): Promise<Blob> {
   const response = await fetch(src);
   if (!response.ok) {
     throw new Error(`无法读取图片：HTTP ${response.status}`);
   }
-  return response.blob();
+  const raw = await response.blob();
+  // If the server / blob URL returned a mime that doesn't match what the
+  // ClipboardItem key promises (e.g. blob: URLs default to ""), re-wrap so
+  // the Blob.type matches the dictionary key — some browsers reject the
+  // write otherwise.
+  if (raw.type === expectedMime) return raw;
+  return new Blob([await raw.arrayBuffer()], { type: expectedMime });
+}
+
+/**
+ * Infer the image mime type for an asset. Used by the web path to declare
+ * the right ClipboardItem key (which must match the blob's mime, otherwise
+ * paste targets receive an unrecognized payload).
+ *
+ * Order of preference:
+ *   1. `metadata.format` from the originating GenerateRequest (most
+ *      authoritative — that's what the backend actually rendered as)
+ *   2. URL extension (`.jpg`, `.webp`, ...)
+ *   3. Default to `image/png`
+ */
+function inferImageMime(asset: ImageAsset): string {
+  const meta = asset.job?.metadata as { format?: unknown } | undefined;
+  if (typeof meta?.format === "string") {
+    const fromMeta = formatToMime(meta.format);
+    if (fromMeta) return fromMeta;
+  }
+  const ext = asset.src
+    .toLowerCase()
+    .split("?")[0]
+    .split("#")[0]
+    .split(".")
+    .pop();
+  if (ext) {
+    const fromExt = formatToMime(ext);
+    if (fromExt) return fromExt;
+  }
+  return "image/png";
+}
+
+function formatToMime(value: string): string | null {
+  switch (value.toLowerCase()) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    default:
+      return null;
+  }
 }

--- a/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/copy-image.ts
@@ -1,0 +1,53 @@
+import { api } from "@/lib/api";
+import type { ImageAsset } from "./types";
+
+/**
+ * Copy an image to the system clipboard.
+ *
+ * Tauri: `path` is required. We invoke `copy_image_to_clipboard` Rust command,
+ * which reads the file directly from disk and writes a PNG bitmap to the
+ * system clipboard via `tauri-plugin-clipboard-manager`. This bypasses the
+ * WebKit image-cache eviction bug that makes the webview's default Copy Image
+ * unreliable on large or off-screen images.
+ *
+ * Web (HTTP / Browser): we fetch the image URL and write it through the
+ * standard `navigator.clipboard.write` API. Safari requires the blob to be
+ * passed to `ClipboardItem` as a Promise (synchronous gesture preservation),
+ * which is what `fetchAsBlob()` returns below.
+ */
+export async function copyImageToClipboard(
+  asset: ImageAsset,
+  options: { withPrompt?: boolean } = {},
+): Promise<void> {
+  const wantsPrompt = options.withPrompt === true;
+  const promptText = wantsPrompt && asset.prompt ? asset.prompt : null;
+
+  if (api.kind === "tauri") {
+    if (!asset.path) {
+      throw new Error("Tauri 模式需要本地文件路径来复制图片。");
+    }
+    await api.copyImageToClipboard(asset.path, promptText);
+    return;
+  }
+
+  // Web path — `ClipboardItem` accepts a Promise<Blob>, which Safari needs in
+  // order to count this as a same-microtask user gesture.
+  const items: Record<string, Blob | Promise<Blob>> = {
+    "image/png": fetchAsBlob(asset.src),
+  };
+  if (promptText) {
+    items["text/plain"] = new Blob([promptText], { type: "text/plain" });
+  }
+  if (typeof ClipboardItem === "undefined") {
+    throw new Error("浏览器不支持 ClipboardItem，无法复制图片。");
+  }
+  await navigator.clipboard.write([new ClipboardItem(items)]);
+}
+
+async function fetchAsBlob(src: string): Promise<Blob> {
+  const response = await fetch(src);
+  if (!response.ok) {
+    throw new Error(`无法读取图片：HTTP ${response.status}`);
+  }
+  return response.blob();
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/delete-job.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/delete-job.ts
@@ -1,0 +1,83 @@
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import type { RuntimeKind } from "@/lib/api/types";
+import { invalidateJobsQueries } from "./query-client";
+
+const UNDO_WINDOW_MS = 5_000;
+// 500ms grace after toast close so the close animation finishes before the
+// hard delete fires (and the user can't see it flicker back).
+const HARD_DELETE_DELAY_MS = UNDO_WINDOW_MS + 500;
+
+const pendingHardDeletes = new Map<string, number>();
+
+/**
+ * Trigger the soft-delete + 5s undo flow for a job.
+ *
+ * Tauri runtime: moves the job dir into `jobs_dir/.thrash/<id>` and stamps
+ * `deleted_at` in the history DB; if the user clicks "撤回" within 5s the
+ * folder is moved back and the row is unmarked. Otherwise after 5s the row
+ * and folder are permanently removed.
+ *
+ * Non-Tauri runtimes have no recoverable trash — the call falls through to a
+ * hard delete and the toast omits the undo button.
+ */
+export async function softDeleteJobWithUndo(
+  jobId: string,
+  runtime: RuntimeKind,
+): Promise<void> {
+  // If a previous undo timer is still pending for this id, drop it; the new
+  // delete request takes precedence.
+  const existing = pendingHardDeletes.get(jobId);
+  if (existing != null) {
+    window.clearTimeout(existing);
+    pendingHardDeletes.delete(jobId);
+  }
+
+  await api.softDeleteJob(jobId);
+  invalidateJobsQueries();
+
+  if (runtime !== "tauri") {
+    // Backend already hard-deleted (HTTP/Browser fallback). Show a one-shot
+    // success toast without the undo button.
+    toast.success("任务已删除", { duration: 2_500 });
+    return;
+  }
+
+  let cancelled = false;
+  const timeoutId = window.setTimeout(() => {
+    pendingHardDeletes.delete(jobId);
+    if (cancelled) return;
+    void api.hardDeleteJob(jobId).catch((error: unknown) => {
+      // Hard delete failures shouldn't bubble — the job is already hidden
+      // from the UI, and a manual cleanup will catch the leftover on
+      // app restart via cleanup_orphan_trash_on_start.
+      // eslint-disable-next-line no-console
+      console.warn("[image-actions] hard delete failed", error);
+    });
+  }, HARD_DELETE_DELAY_MS);
+  pendingHardDeletes.set(jobId, timeoutId);
+
+  toast("任务已删除", {
+    duration: UNDO_WINDOW_MS,
+    action: {
+      label: "撤回",
+      onClick: () => {
+        cancelled = true;
+        const id = pendingHardDeletes.get(jobId);
+        if (id != null) window.clearTimeout(id);
+        pendingHardDeletes.delete(jobId);
+        api
+          .restoreDeletedJob(jobId)
+          .then(() => {
+            invalidateJobsQueries();
+            toast.success("已恢复", { duration: 1_500 });
+          })
+          .catch((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            toast.error("恢复失败", { description: message });
+          });
+      },
+    },
+  });
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/drag-out.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/drag-out.ts
@@ -1,0 +1,36 @@
+import type { DragEvent } from "react";
+import { startDrag } from "@crabnebula/tauri-plugin-drag";
+import { api } from "@/lib/api";
+import type { ImageAsset } from "./types";
+
+/**
+ * Native drag-out support backed by `@crabnebula/tauri-plugin-drag`. The
+ * plugin replaces the webview's default drag payload with a platform-native
+ * file drag that drops into Finder, iMessage, Photoshop, etc. as a real PNG.
+ *
+ * Tauri only — there's no Web equivalent that can pass binary file data,
+ * since browsers won't elevate a `text/uri-list` to a real file. The helper
+ * hook returns no-op props on non-Tauri runtimes.
+ */
+export function imageDragProps(
+  asset: ImageAsset,
+): {
+  draggable: boolean;
+  onDragStart?: (event: DragEvent<HTMLElement>) => void;
+} {
+  if (api.kind !== "tauri" || !asset.path) {
+    return { draggable: false };
+  }
+  const path = asset.path;
+  return {
+    draggable: true,
+    onDragStart: (event) => {
+      // Cancel the webview's own drag (which would carry just an asset:// URL)
+      // so the platform's native drag service starts clean. The plugin then
+      // injects file-flavored pasteboard items.
+      event.preventDefault();
+      event.stopPropagation();
+      void startDrag({ item: [path], icon: path });
+    },
+  };
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { api } from "@/lib/api";
+import { openQuickLook } from "@/components/ui/quick-look";
 import { copyImageToClipboard } from "./copy-image";
 import { softDeleteJobWithUndo } from "./delete-job";
 import { invalidateJobsQueries } from "./query-client";
@@ -15,6 +16,22 @@ import type { ImageAction } from "./types";
  * Space + the action). Variations and Upscale stay out of scope until the
  * backend supports them.
  */
+
+const quickLook: ImageAction = {
+  id: "quick-look",
+  // Quick Look isn't shown inside the right-click menu — Space is a much
+  // stickier mental model for it, and the action would just bloat the menu.
+  // Hover toolbar (first slot) and command palette still see it.
+  label: () => "快速查看",
+  icon: "eye",
+  shortcut: "Space",
+  group: "transfer",
+  isAvailable: ({ surface, asset }) =>
+    surface !== "context-menu" && Boolean(asset.src),
+  execute: ({ asset }) => {
+    openQuickLook({ asset });
+  },
+};
 
 const copyImage: ImageAction = {
   id: "copy-image",
@@ -137,6 +154,8 @@ export const C2_TRANSFER_EXPORT_MANAGE_ACTIONS: ImageAction[] = [
   openWithDefault,
   deleteAction,
 ];
+
+export const C3_PREVIEW_ACTIONS: ImageAction[] = [quickLook];
 
 function inferDownloadName(
   src: string,

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -52,6 +52,23 @@ const copyImage: ImageAction = {
   },
 };
 
+const copyImageWithPrompt: ImageAction = {
+  id: "copy-image-with-prompt",
+  label: () => "复制图片+提示词",
+  icon: "copy",
+  shortcut: "⇧⌘C",
+  group: "transfer",
+  isAvailable: ({ asset }) => Boolean(asset.src),
+  // Older jobs without a stored prompt grey-out instead of hide so the menu
+  // shape stays stable.
+  isEnabled: ({ asset }) => Boolean(asset.prompt?.trim()),
+  disabledReason: () => "这个任务没有保存提示词",
+  execute: async ({ asset }) => {
+    await copyImageToClipboard(asset, { withPrompt: true });
+    toast.success("已复制图片和提示词", { duration: 1_500 });
+  },
+};
+
 const copyPathOrLink: ImageAction = {
   id: "copy-path-or-link",
   label: ({ runtime }) => (runtime === "tauri" ? "复制文件路径" : "复制链接"),
@@ -186,6 +203,43 @@ const revealJobInHistory: ImageAction = {
   },
 };
 
+const shareAction: ImageAction = {
+  id: "share",
+  label: () => "分享…",
+  icon: "external",
+  group: "transfer",
+  isAvailable: ({ runtime, asset }) => {
+    if (runtime === "tauri") return false;
+    if (typeof navigator === "undefined") return false;
+    if (typeof navigator.share !== "function") return false;
+    return Boolean(asset.src);
+  },
+  execute: async ({ asset }) => {
+    const response = await fetch(asset.src);
+    if (!response.ok) {
+      throw new Error(`无法读取图片：HTTP ${response.status}`);
+    }
+    const blob = await response.blob();
+    const filename = `${asset.jobId}-${asset.outputIndex}.png`;
+    const file = new File([blob], filename, { type: "image/png" });
+    const shareData: ShareData = { files: [file] };
+    if (asset.prompt) shareData.text = asset.prompt;
+    // Some platforms (older Safari) don't support file shares — fall back
+    // to URL-only when feature detection fails.
+    if (
+      typeof navigator.canShare === "function" &&
+      !navigator.canShare({ files: [file] })
+    ) {
+      await navigator.share({
+        url: asset.src,
+        text: asset.prompt,
+      });
+      return;
+    }
+    await navigator.share(shareData);
+  },
+};
+
 const deleteAction: ImageAction = {
   id: "delete",
   label: () => "删除",
@@ -202,10 +256,12 @@ const deleteAction: ImageAction = {
 
 export const C2_TRANSFER_EXPORT_MANAGE_ACTIONS: ImageAction[] = [
   copyImage,
+  copyImageWithPrompt,
   copyPathOrLink,
   saveAs,
   revealInFinder,
   openWithDefault,
+  shareAction,
   deleteAction,
 ];
 

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -2,6 +2,7 @@ import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { openQuickLook } from "@/components/ui/quick-look";
 import { openJobInHistory, sendImageToEdit } from "@/lib/job-navigation";
+import { actionsConfirm } from "./confirm-action";
 import { copyImageToClipboard } from "./copy-image";
 import { softDeleteJobWithUndo } from "./delete-job";
 import { navigateToScreen } from "./navigation";
@@ -52,20 +53,19 @@ const copyImage: ImageAction = {
   },
 };
 
-const copyImageWithPrompt: ImageAction = {
-  id: "copy-image-with-prompt",
-  label: () => "复制图片+提示词",
+const copyPrompt: ImageAction = {
+  id: "copy-prompt",
+  label: () => "复制提示词",
   icon: "copy",
   shortcut: "⇧⌘C",
   group: "transfer",
-  isAvailable: ({ asset }) => Boolean(asset.src),
-  // Older jobs without a stored prompt grey-out instead of hide so the menu
-  // shape stays stable.
-  isEnabled: ({ asset }) => Boolean(asset.prompt?.trim()),
-  disabledReason: () => "这个任务没有保存提示词",
+  // Hide on older jobs without a saved prompt — there's no graceful "fall
+  // back to image" here because the user explicitly asked for the prompt.
+  isAvailable: ({ asset }) => Boolean(asset.prompt?.trim()),
   execute: async ({ asset }) => {
-    await copyImageToClipboard(asset, { withPrompt: true });
-    toast.success("已复制图片和提示词", { duration: 1_500 });
+    if (!asset.prompt) throw new Error("没有提示词。");
+    await navigator.clipboard.writeText(asset.prompt);
+    toast.success("已复制提示词", { duration: 1_500 });
   },
 };
 
@@ -242,13 +242,30 @@ const shareAction: ImageAction = {
 
 const deleteAction: ImageAction = {
   id: "delete",
-  label: () => "删除",
+  label: () => "删除任务",
   icon: "trash",
   shortcut: "⌘⌫",
   group: "destructive",
   destructive: true,
   isAvailable: () => true,
   execute: async ({ asset, runtime }) => {
+    // Important: a Job is the unit of deletion — a multi-output job has
+    // all of its outputs grouped under one DB row + one folder. Right-
+    // clicking a single output and choosing Delete WILL remove the entire
+    // job, so the confirm copy makes that explicit when there's more than
+    // one output.
+    const outputCount = asset.job?.outputs?.length ?? 1;
+    const description =
+      outputCount > 1
+        ? `这是包含 ${outputCount} 张图的任务，删除会移除整个任务记录和全部 ${outputCount} 张图，无法分别删除单张。`
+        : "这会删除这张图和它的任务记录。";
+    const ok = await actionsConfirm({
+      title: "删除任务？",
+      description,
+      confirmText: "删除任务",
+      variant: "danger",
+    });
+    if (!ok) return;
     await softDeleteJobWithUndo(asset.jobId, runtime);
     invalidateJobsQueries();
   },
@@ -256,7 +273,7 @@ const deleteAction: ImageAction = {
 
 export const C2_TRANSFER_EXPORT_MANAGE_ACTIONS: ImageAction[] = [
   copyImage,
-  copyImageWithPrompt,
+  copyPrompt,
   copyPathOrLink,
   saveAs,
   revealInFinder,

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -5,6 +5,7 @@ import { openJobInHistory, sendImageToEdit } from "@/lib/job-navigation";
 import { actionsConfirm } from "./confirm-action";
 import { copyImageToClipboard } from "./copy-image";
 import { softDeleteJobWithUndo } from "./delete-job";
+import { inferImageExtension, inferImageMime } from "./mime";
 import { navigateToScreen } from "./navigation";
 import { invalidateJobsQueries } from "./query-client";
 import type { ImageAction } from "./types";
@@ -219,9 +220,15 @@ const shareAction: ImageAction = {
     if (!response.ok) {
       throw new Error(`无法读取图片：HTTP ${response.status}`);
     }
-    const blob = await response.blob();
-    const filename = `${asset.jobId}-${asset.outputIndex}.png`;
-    const file = new File([blob], filename, { type: "image/png" });
+    // Match the share payload's mime + filename extension to the actual
+    // image format so JPEG/WEBP/GIF jobs don't get sent to native share
+    // sheets advertised as PNG (some targets reject the mismatch outright).
+    const mime = inferImageMime(asset);
+    const ext = inferImageExtension(asset);
+    const raw = await response.blob();
+    const blob = raw.type === mime ? raw : new Blob([await raw.arrayBuffer()], { type: mime });
+    const filename = `${asset.jobId}-${asset.outputIndex}.${ext}`;
+    const file = new File([blob], filename, { type: mime });
     const shareData: ShareData = { files: [file] };
     if (asset.prompt) shareData.text = asset.prompt;
     // Some platforms (older Safari) don't support file shares — fall back

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -1,8 +1,10 @@
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { openQuickLook } from "@/components/ui/quick-look";
+import { openJobInHistory, sendImageToEdit } from "@/lib/job-navigation";
 import { copyImageToClipboard } from "./copy-image";
 import { softDeleteJobWithUndo } from "./delete-job";
+import { navigateToScreen } from "./navigation";
 import { invalidateJobsQueries } from "./query-client";
 import type { ImageAction } from "./types";
 
@@ -132,6 +134,58 @@ const openWithDefault: ImageAction = {
   },
 };
 
+const useAsReference: ImageAction = {
+  id: "use-as-reference",
+  label: () => "用作参考图",
+  icon: "arrowin",
+  group: "generate",
+  isAvailable: ({ asset }) => Boolean(asset.path || asset.src),
+  execute: ({ asset }) => {
+    sendImageToEdit({
+      jobId: asset.jobId,
+      outputIndex: asset.outputIndex,
+      path: asset.path ?? null,
+      url: asset.src,
+    });
+    navigateToScreen("edit");
+  },
+};
+
+const editWithPrompt: ImageAction = {
+  id: "edit-with-prompt",
+  label: () => "用提示词编辑",
+  icon: "edit",
+  group: "generate",
+  isAvailable: ({ asset }) => Boolean(asset.path || asset.src),
+  isEnabled: ({ asset }) => Boolean(asset.prompt?.trim()),
+  disabledReason: () => "这个任务没有保存提示词",
+  execute: ({ asset }) => {
+    sendImageToEdit({
+      jobId: asset.jobId,
+      outputIndex: asset.outputIndex,
+      path: asset.path ?? null,
+      url: asset.src,
+      prompt: asset.prompt,
+    });
+    navigateToScreen("edit");
+  },
+};
+
+const revealJobInHistory: ImageAction = {
+  id: "reveal-job-in-history",
+  label: () => "在历史中查看任务",
+  icon: "history",
+  group: "manage",
+  isAvailable: ({ asset }) => Boolean(asset.jobId),
+  execute: ({ asset }) => {
+    navigateToScreen("history");
+    // openJobInHistory's listener is mounted on the History screen which
+    // is always rendered (just hidden). The event is delivered immediately;
+    // the history drawer opens once navigation lands.
+    openJobInHistory(asset.jobId);
+  },
+};
+
 const deleteAction: ImageAction = {
   id: "delete",
   label: () => "删除",
@@ -156,6 +210,12 @@ export const C2_TRANSFER_EXPORT_MANAGE_ACTIONS: ImageAction[] = [
 ];
 
 export const C3_PREVIEW_ACTIONS: ImageAction[] = [quickLook];
+
+export const C4_GENERATE_ACTIONS: ImageAction[] = [
+  useAsReference,
+  editWithPrompt,
+  revealJobInHistory,
+];
 
 function inferDownloadName(
   src: string,

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -8,7 +8,7 @@ import { softDeleteJobWithUndo } from "./delete-job";
 import { inferImageExtension, inferImageMime } from "./mime";
 import { navigateToScreen } from "./navigation";
 import { invalidateJobsQueries } from "./query-client";
-import type { ImageAction } from "./types";
+import type { ImageAction, ImageAsset } from "./types";
 
 /**
  * Concrete `ImageAction` definitions registered in `registry.ts`. Each entry
@@ -116,7 +116,7 @@ const saveAs: ImageAction = {
     // honor the `download` attribute even cross-origin if CORS allows it.
     const a = document.createElement("a");
     a.href = asset.src;
-    a.download = inferDownloadName(asset.src, asset.jobId, asset.outputIndex);
+    a.download = inferDownloadName(asset);
     a.rel = "noopener";
     document.body.appendChild(a);
     a.click();
@@ -297,17 +297,18 @@ export const C4_GENERATE_ACTIONS: ImageAction[] = [
   revealJobInHistory,
 ];
 
-function inferDownloadName(
-  src: string,
-  jobId: string,
-  index: number,
-): string {
+function inferDownloadName(asset: ImageAsset): string {
+  // Prefer a real basename from the URL when present.
   try {
-    const url = new URL(src, window.location.href);
+    const url = new URL(asset.src, window.location.href);
     const last = url.pathname.split("/").filter(Boolean).pop();
     if (last && last.includes(".")) return last;
   } catch {
     /* fall through to the fabricated name */
   }
-  return `${jobId}-${index}.png`;
+  // Fabricated fallback — must match the asset's true format so OS / app
+  // associations don't mis-handle a JPEG/WEBP saved with a `.png`
+  // extension. `inferImageExtension` consults metadata.format first, then
+  // URL/path extension, before defaulting to png.
+  return `${asset.jobId}-${asset.outputIndex}.${inferImageExtension(asset)}`;
 }

--- a/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/executors.ts
@@ -1,0 +1,154 @@
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { copyImageToClipboard } from "./copy-image";
+import { softDeleteJobWithUndo } from "./delete-job";
+import { invalidateJobsQueries } from "./query-client";
+import type { ImageAction } from "./types";
+
+/**
+ * Concrete `ImageAction` definitions registered in `registry.ts`. Each entry
+ * combines its UI metadata (label / icon / shortcut hint / group) with a
+ * runtime-aware `isAvailable` predicate and the actual `execute` function.
+ *
+ * Successor commits add: Use as Reference / Edit with Prompt / Reveal Job
+ * (C4), Copy with Prompt / Drag-out / Share (C5), Quick Look (C3 wires up
+ * Space + the action). Variations and Upscale stay out of scope until the
+ * backend supports them.
+ */
+
+const copyImage: ImageAction = {
+  id: "copy-image",
+  label: () => "复制图片",
+  icon: "copy",
+  shortcut: "⌘C",
+  group: "transfer",
+  isAvailable: () => true,
+  isEnabled: ({ asset, runtime }) => {
+    if (runtime === "tauri") return Boolean(asset.path);
+    return Boolean(asset.src);
+  },
+  execute: async ({ asset }) => {
+    await copyImageToClipboard(asset);
+    toast.success("已复制图片", { duration: 1_500 });
+  },
+};
+
+const copyPathOrLink: ImageAction = {
+  id: "copy-path-or-link",
+  label: ({ runtime }) => (runtime === "tauri" ? "复制文件路径" : "复制链接"),
+  icon: "external",
+  shortcut: "⌥⌘C",
+  group: "transfer",
+  isAvailable: ({ runtime, asset }) => {
+    // Browser runtime serves images as ephemeral blob: URLs that are useless
+    // outside the current tab; only show the action when there's a stable
+    // string to paste somewhere meaningful.
+    if (runtime === "browser") return false;
+    if (runtime === "tauri") return Boolean(asset.path);
+    return Boolean(asset.src);
+  },
+  execute: async ({ asset, runtime }) => {
+    const value = runtime === "tauri" ? asset.path ?? "" : asset.src;
+    if (!value) throw new Error("没有可复制的路径或链接。");
+    await navigator.clipboard.writeText(value);
+    toast.success(runtime === "tauri" ? "已复制路径" : "已复制链接", {
+      duration: 1_500,
+    });
+  },
+};
+
+const saveAs: ImageAction = {
+  id: "save-as",
+  label: () => "保存到下载文件夹",
+  icon: "download",
+  shortcut: "⌘S",
+  group: "export",
+  isAvailable: () => true,
+  execute: async ({ asset, runtime }) => {
+    if (runtime === "tauri") {
+      if (asset.path) {
+        const saved = await api.exportFilesToDownloads([asset.path]);
+        toast.success(`已保存 ${saved.length} 张图片`, { duration: 2_000 });
+      } else {
+        const saved = await api.exportJobToDownloads(asset.jobId);
+        toast.success(`已保存 ${saved.length} 张图片`, { duration: 2_000 });
+      }
+      return;
+    }
+    // Web fallback — trigger an anchor download. Modern Chromium / Safari
+    // honor the `download` attribute even cross-origin if CORS allows it.
+    const a = document.createElement("a");
+    a.href = asset.src;
+    a.download = inferDownloadName(asset.src, asset.jobId, asset.outputIndex);
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    toast.success("已开始下载", { duration: 1_500 });
+  },
+};
+
+const revealInFinder: ImageAction = {
+  id: "reveal-in-finder",
+  label: () => "在 Finder 中显示",
+  icon: "folder",
+  shortcut: "⌥⌘R",
+  group: "export",
+  isAvailable: ({ runtime, asset }) =>
+    runtime === "tauri" && Boolean(asset.path),
+  execute: async ({ asset }) => {
+    if (!asset.path) throw new Error("无可定位的路径。");
+    await api.revealPath(asset.path);
+  },
+};
+
+const openWithDefault: ImageAction = {
+  id: "open-with-default",
+  label: () => "用默认应用打开",
+  icon: "external",
+  group: "export",
+  isAvailable: ({ runtime, asset }) =>
+    runtime === "tauri" && Boolean(asset.path),
+  execute: async ({ asset }) => {
+    if (!asset.path) throw new Error("无可打开的路径。");
+    await api.openPath(asset.path);
+  },
+};
+
+const deleteAction: ImageAction = {
+  id: "delete",
+  label: () => "删除",
+  icon: "trash",
+  shortcut: "⌘⌫",
+  group: "destructive",
+  destructive: true,
+  isAvailable: () => true,
+  execute: async ({ asset, runtime }) => {
+    await softDeleteJobWithUndo(asset.jobId, runtime);
+    invalidateJobsQueries();
+  },
+};
+
+export const C2_TRANSFER_EXPORT_MANAGE_ACTIONS: ImageAction[] = [
+  copyImage,
+  copyPathOrLink,
+  saveAs,
+  revealInFinder,
+  openWithDefault,
+  deleteAction,
+];
+
+function inferDownloadName(
+  src: string,
+  jobId: string,
+  index: number,
+): string {
+  try {
+    const url = new URL(src, window.location.href);
+    const last = url.pathname.split("/").filter(Boolean).pop();
+    if (last && last.includes(".")) return last;
+  } catch {
+    /* fall through to the fabricated name */
+  }
+  return `${jobId}-${index}.png`;
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/focused-image.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/focused-image.ts
@@ -1,0 +1,55 @@
+import { useSyncExternalStore } from "react";
+import type { ImageAsset } from "./types";
+
+let focused: ImageAsset | null = null;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function sameIdentity(a: ImageAsset | null, b: ImageAsset | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.jobId === b.jobId && a.outputIndex === b.outputIndex;
+}
+
+/**
+ * Set the currently-focused image asset. Used by hover/focus handlers on
+ * thumbnails and main preview tiles. Pass `null` on blur.
+ *
+ * Identity-stable updates (same jobId + outputIndex) refresh the stored
+ * reference without notifying subscribers — this avoids re-render churn
+ * when a parent component recreates the asset object on every render.
+ */
+export function setFocusedImage(next: ImageAsset | null) {
+  if (sameIdentity(focused, next)) {
+    focused = next;
+    return;
+  }
+  focused = next;
+  emit();
+}
+
+export function clearFocusedImageIfMatches(jobId: string, outputIndex?: number) {
+  if (!focused) return;
+  if (focused.jobId !== jobId) return;
+  if (outputIndex != null && focused.outputIndex !== outputIndex) return;
+  focused = null;
+  emit();
+}
+
+export function getFocusedImage(): ImageAsset | null {
+  return focused;
+}
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function useFocusedImage(): ImageAsset | null {
+  return useSyncExternalStore(subscribe, getFocusedImage, () => null);
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/mime.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/mime.ts
@@ -1,0 +1,67 @@
+import type { ImageAsset } from "./types";
+
+/**
+ * Infer the image mime type for an asset. Used by every web-side path that
+ * needs to declare a content type to a Web API (ClipboardItem key, File
+ * constructor, navigator.share files) — declaring the wrong mime silently
+ * breaks paste targets / share targets on some browsers.
+ *
+ * Order of preference:
+ *   1. `metadata.format` from the originating GenerateRequest (most
+ *      authoritative — that's what the backend actually rendered as)
+ *   2. URL / path extension (`.jpg`, `.webp`, ...)
+ *   3. Default to `image/png`
+ */
+export function inferImageMime(asset: ImageAsset): string {
+  const meta = asset.job?.metadata as { format?: unknown } | undefined;
+  if (typeof meta?.format === "string") {
+    const fromMeta = formatToMime(meta.format);
+    if (fromMeta) return fromMeta;
+  }
+  const ext = extensionFromUrl(asset.path ?? asset.src);
+  if (ext) {
+    const fromExt = formatToMime(ext);
+    if (fromExt) return fromExt;
+  }
+  return "image/png";
+}
+
+/** File extension to put on a download / share filename. */
+export function inferImageExtension(asset: ImageAsset): string {
+  const mime = inferImageMime(asset);
+  return mimeToExtension(mime);
+}
+
+function extensionFromUrl(url: string): string | null {
+  const tail = url.toLowerCase().split("?")[0]?.split("#")[0]?.split(".").pop();
+  return tail && tail !== url.toLowerCase() ? tail : null;
+}
+
+function formatToMime(value: string): string | null {
+  switch (value.toLowerCase()) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "webp":
+      return "image/webp";
+    case "gif":
+      return "image/gif";
+    default:
+      return null;
+  }
+}
+
+function mimeToExtension(mime: string): string {
+  switch (mime) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/webp":
+      return "webp";
+    case "image/gif":
+      return "gif";
+    default:
+      return "png";
+  }
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/navigation.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/navigation.ts
@@ -1,0 +1,16 @@
+import type { ScreenId } from "@/components/shell/screens";
+
+/**
+ * Module-level holder so executors (running outside React) can switch the
+ * top-level screen without threading `setScreen` through every call site.
+ * `App.tsx` registers the setter at boot.
+ */
+let setScreenFn: ((screen: ScreenId) => void) | null = null;
+
+export function setActionsNavigator(setScreen: (screen: ScreenId) => void) {
+  setScreenFn = setScreen;
+}
+
+export function navigateToScreen(screen: ScreenId) {
+  setScreenFn?.(screen);
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/query-client.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/query-client.ts
@@ -1,0 +1,19 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Module-level holder so executors (which run outside React) can invalidate
+ * job-related queries without dragging a `useQueryClient()` argument through
+ * every call site. Set once at app boot from `main.tsx`.
+ */
+let stored: QueryClient | null = null;
+
+export function setActionsQueryClient(qc: QueryClient) {
+  stored = qc;
+}
+
+export function invalidateJobsQueries() {
+  if (!stored) return;
+  void stored.invalidateQueries({ queryKey: ["jobs"] });
+  void stored.invalidateQueries({ queryKey: ["jobs", "active"] });
+  void stored.invalidateQueries({ queryKey: ["jobs", "pages"] });
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
@@ -1,4 +1,7 @@
-import { C2_TRANSFER_EXPORT_MANAGE_ACTIONS } from "./executors";
+import {
+  C2_TRANSFER_EXPORT_MANAGE_ACTIONS,
+  C3_PREVIEW_ACTIONS,
+} from "./executors";
 import type {
   ImageAction,
   ImageActionContext,
@@ -18,6 +21,7 @@ import type {
  * `actionsFor(ctx)` and never define their own action shapes.
  */
 export const IMAGE_ACTIONS: ImageAction[] = [
+  ...C3_PREVIEW_ACTIONS,
   ...C2_TRANSFER_EXPORT_MANAGE_ACTIONS,
 ];
 

--- a/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
@@ -1,3 +1,4 @@
+import { C2_TRANSFER_EXPORT_MANAGE_ACTIONS } from "./executors";
 import type {
   ImageAction,
   ImageActionContext,
@@ -16,7 +17,9 @@ import type {
  * The ContextMenu, HoverToolbar, and CommandPalette all read this list via
  * `actionsFor(ctx)` and never define their own action shapes.
  */
-export const IMAGE_ACTIONS: ImageAction[] = [];
+export const IMAGE_ACTIONS: ImageAction[] = [
+  ...C2_TRANSFER_EXPORT_MANAGE_ACTIONS,
+];
 
 const GROUP_ORDER: ImageActionGroup[] = [
   "transfer",

--- a/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
@@ -1,0 +1,55 @@
+import type {
+  ImageAction,
+  ImageActionContext,
+  ImageActionGroup,
+  ImageActionId,
+} from "./types";
+
+/**
+ * Single source of truth for every image action surfaced in the app.
+ *
+ * Populated incrementally:
+ *   - C2 adds transfer/export/manage actions (Copy / Save / Reveal / Delete).
+ *   - C4 adds generate actions (Use as Reference / Edit with Prompt / Reveal Job).
+ *   - C5 adds Drag-out / Copy with Prompt / Share.
+ *
+ * The ContextMenu, HoverToolbar, and CommandPalette all read this list via
+ * `actionsFor(ctx)` and never define their own action shapes.
+ */
+export const IMAGE_ACTIONS: ImageAction[] = [];
+
+const GROUP_ORDER: ImageActionGroup[] = [
+  "transfer",
+  "export",
+  "generate",
+  "manage",
+  "destructive",
+];
+
+export function actionsFor(ctx: ImageActionContext): ImageAction[] {
+  return IMAGE_ACTIONS.filter((action) => action.isAvailable(ctx));
+}
+
+export type GroupedActions = Array<{
+  group: ImageActionGroup;
+  actions: ImageAction[];
+}>;
+
+export function groupedActions(ctx: ImageActionContext): GroupedActions {
+  const buckets = new Map<ImageActionGroup, ImageAction[]>();
+  for (const action of actionsFor(ctx)) {
+    const list = buckets.get(action.group) ?? [];
+    list.push(action);
+    buckets.set(action.group, list);
+  }
+  const out: GroupedActions = [];
+  for (const group of GROUP_ORDER) {
+    const actions = buckets.get(group);
+    if (actions && actions.length > 0) out.push({ group, actions });
+  }
+  return out;
+}
+
+export function findAction(id: ImageActionId): ImageAction | undefined {
+  return IMAGE_ACTIONS.find((action) => action.id === id);
+}

--- a/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/registry.ts
@@ -1,6 +1,7 @@
 import {
   C2_TRANSFER_EXPORT_MANAGE_ACTIONS,
   C3_PREVIEW_ACTIONS,
+  C4_GENERATE_ACTIONS,
 } from "./executors";
 import type {
   ImageAction,
@@ -23,6 +24,7 @@ import type {
 export const IMAGE_ACTIONS: ImageAction[] = [
   ...C3_PREVIEW_ACTIONS,
   ...C2_TRANSFER_EXPORT_MANAGE_ACTIONS,
+  ...C4_GENERATE_ACTIONS,
 ];
 
 const GROUP_ORDER: ImageActionGroup[] = [

--- a/apps/gpt-image-2-app/src/lib/image-actions/types.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/types.ts
@@ -1,0 +1,60 @@
+import type { IconName } from "@/components/icon";
+import type { Job } from "@/lib/types";
+import type { RuntimeKind } from "@/lib/api/types";
+
+export type ImageActionId =
+  | "copy-image"
+  | "copy-image-with-prompt"
+  | "copy-path-or-link"
+  | "save-as"
+  | "reveal-in-finder"
+  | "open-with-default"
+  | "use-as-reference"
+  | "edit-with-prompt"
+  | "reveal-job-in-history"
+  | "quick-look"
+  | "drag-out"
+  | "share"
+  | "delete";
+
+export type ImageActionGroup =
+  | "transfer"
+  | "export"
+  | "generate"
+  | "manage"
+  | "destructive";
+
+export type ImageActionSurface =
+  | "context-menu"
+  | "hover-toolbar"
+  | "command-palette";
+
+export type ImageAsset = {
+  jobId: string;
+  outputIndex: number;
+  src: string;
+  path?: string | null;
+  prompt?: string;
+  command?: Job["command"];
+  job?: Job;
+};
+
+export type ImageActionContext = {
+  asset: ImageAsset;
+  runtime: RuntimeKind;
+  surface: ImageActionSurface;
+};
+
+export type ImageAction = {
+  id: ImageActionId;
+  label: (ctx: ImageActionContext) => string;
+  shortLabel?: (ctx: ImageActionContext) => string;
+  icon: IconName;
+  shortcut?: string;
+  group: ImageActionGroup;
+  destructive?: boolean;
+  isAvailable: (ctx: ImageActionContext) => boolean;
+  isEnabled?: (ctx: ImageActionContext) => boolean;
+  disabledReason?: (ctx: ImageActionContext) => string | undefined;
+  execute: (ctx: ImageActionContext) => Promise<void> | void;
+};

--- a/apps/gpt-image-2-app/src/lib/image-actions/types.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/types.ts
@@ -4,7 +4,7 @@ import type { RuntimeKind } from "@/lib/api/types";
 
 export type ImageActionId =
   | "copy-image"
-  | "copy-image-with-prompt"
+  | "copy-prompt"
   | "copy-path-or-link"
   | "save-as"
   | "reveal-in-finder"

--- a/apps/gpt-image-2-app/src/lib/image-actions/use-image-actions.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/use-image-actions.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { actionsFor, findAction, groupedActions } from "./registry";
+import type {
+  ImageAction,
+  ImageActionContext,
+  ImageActionId,
+  ImageActionSurface,
+  ImageAsset,
+} from "./types";
+
+export type UseImageActionsOptions = {
+  asset: ImageAsset;
+  surface: ImageActionSurface;
+};
+
+/**
+ * Shared hook consumed by ContextMenu, HoverToolbar, and CommandPalette.
+ *
+ * Returns the available + grouped action lists for the given asset/surface
+ * combo, plus a `run(id)` callback that resolves availability + enabled
+ * state, executes the action, and surfaces failures via a sonner toast.
+ */
+export function useImageActions({ asset, surface }: UseImageActionsOptions) {
+  const ctx: ImageActionContext = useMemo(
+    () => ({ asset, runtime: api.kind, surface }),
+    [asset, surface],
+  );
+
+  const available = useMemo(() => actionsFor(ctx), [ctx]);
+  const groups = useMemo(() => groupedActions(ctx), [ctx]);
+
+  const run = useCallback(
+    async (id: ImageActionId) => {
+      const action = findAction(id);
+      if (!action) {
+        // eslint-disable-next-line no-console
+        console.warn(`[image-actions] unknown action id: ${id}`);
+        return;
+      }
+      if (!action.isAvailable(ctx)) return;
+      if (action.isEnabled && !action.isEnabled(ctx)) return;
+      try {
+        await action.execute(ctx);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        toast.error("操作失败", { description: message });
+      }
+    },
+    [ctx],
+  );
+
+  return { ctx, available, groups, run };
+}
+
+export type UseImageActions = ReturnType<typeof useImageActions>;
+
+export type { ImageAction, ImageActionContext, ImageActionId };

--- a/apps/gpt-image-2-app/src/lib/image-actions/use-image-actions.ts
+++ b/apps/gpt-image-2-app/src/lib/image-actions/use-image-actions.ts
@@ -20,7 +20,8 @@ export type UseImageActionsOptions = {
  *
  * Returns the available + grouped action lists for the given asset/surface
  * combo, plus a `run(id)` callback that resolves availability + enabled
- * state, executes the action, and surfaces failures via a sonner toast.
+ * state, executes the action, surfaces failures via a sonner toast, and
+ * reports whether the executor completed successfully.
  */
 export function useImageActions({ asset, surface }: UseImageActionsOptions) {
   const ctx: ImageActionContext = useMemo(
@@ -37,15 +38,17 @@ export function useImageActions({ asset, surface }: UseImageActionsOptions) {
       if (!action) {
         // eslint-disable-next-line no-console
         console.warn(`[image-actions] unknown action id: ${id}`);
-        return;
+        return false;
       }
-      if (!action.isAvailable(ctx)) return;
-      if (action.isEnabled && !action.isEnabled(ctx)) return;
+      if (!action.isAvailable(ctx)) return false;
+      if (action.isEnabled && !action.isEnabled(ctx)) return false;
       try {
         await action.execute(ctx);
+        return true;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         toast.error("操作失败", { description: message });
+        return false;
       }
     },
     [ctx],

--- a/apps/gpt-image-2-app/src/lib/job-navigation.ts
+++ b/apps/gpt-image-2-app/src/lib/job-navigation.ts
@@ -7,6 +7,11 @@ export type SendToEditPayload = {
   path?: string | null;
   url?: string | null;
   name?: string;
+  /**
+   * Optional prompt to prefill in the edit screen's textarea after the image
+   * is added as a reference. Used by the "Edit with Prompt" image action.
+   */
+  prompt?: string;
 };
 
 export function openJobInHistory(jobId: string) {

--- a/apps/gpt-image-2-app/src/main.tsx
+++ b/apps/gpt-image-2-app/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import { TweaksProvider } from "@/hooks/use-tweaks";
 import { ConfirmProvider } from "@/hooks/use-confirm";
+import { setActionsQueryClient } from "@/lib/image-actions/query-client";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -15,6 +16,12 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// Image-action executors run outside React (e.g. inside contextmenu callbacks
+// or sonner toast actions) and need a way to invalidate job queries after a
+// soft delete or undo. Hand them the singleton at app boot so they don't
+// have to thread `useQueryClient()` through every call site.
+setActionsQueryClient(queryClient);
 
 // In dev mode, expose the QueryClient on window so we can inspect & mock data
 // from the browser console / preview eval. No-op in production builds.

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -4541,6 +4541,32 @@ fn open_history_db() -> Result<Connection, AppError> {
         )
         .with_detail(json!({"error": error.to_string()}))
     })?;
+    // Soft-delete migration: add `deleted_at TEXT` column. SQLite returns
+    // "duplicate column name" if the column already exists — swallow only
+    // that case so the migration is idempotent.
+    match conn.execute("ALTER TABLE jobs ADD COLUMN deleted_at TEXT", []) {
+        Ok(_) => {}
+        Err(rusqlite::Error::SqliteFailure(_, Some(msg)))
+            if msg.contains("duplicate column name") => {}
+        Err(error) => {
+            return Err(AppError::new(
+                "history_migration_failed",
+                "Unable to add deleted_at column.",
+            )
+            .with_detail(json!({"error": error.to_string()})));
+        }
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_jobs_deleted_at_created_at ON jobs (deleted_at, created_at DESC, id DESC)",
+        [],
+    )
+    .map_err(|error| {
+        AppError::new(
+            "history_migration_failed",
+            "Unable to initialize history indexes.",
+        )
+        .with_detail(json!({"error": error.to_string()}))
+    })?;
     Ok(conn)
 }
 
@@ -4611,12 +4637,54 @@ pub fn delete_history_job(job_id: &str) -> Result<usize, AppError> {
         })
 }
 
+/// Mark a history row as soft-deleted by stamping `deleted_at` with the
+/// current epoch seconds. Already-deleted rows are not re-stamped, keeping
+/// the original deletion time intact for trash retention windows.
+pub fn soft_delete_history_job(job_id: &str) -> Result<usize, AppError> {
+    let conn = open_history_db()?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    conn.execute(
+        "UPDATE jobs SET deleted_at = ?1 WHERE id = ?2 AND deleted_at IS NULL",
+        params![now, job_id],
+    )
+    .map_err(|error| {
+        AppError::new(
+            "history_soft_delete_failed",
+            "Unable to soft-delete history job.",
+        )
+        .with_detail(json!({"error": error.to_string()}))
+    })
+}
+
+/// Clear `deleted_at` so the row reappears in the default listing. Idempotent.
+pub fn restore_deleted_history_job(job_id: &str) -> Result<usize, AppError> {
+    let conn = open_history_db()?;
+    conn.execute(
+        "UPDATE jobs SET deleted_at = NULL WHERE id = ?1",
+        params![job_id],
+    )
+    .map_err(|error| {
+        AppError::new(
+            "history_restore_failed",
+            "Unable to restore history job.",
+        )
+        .with_detail(json!({"error": error.to_string()}))
+    })
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct HistoryListOptions {
     pub limit: Option<usize>,
     pub cursor: Option<String>,
     pub status: Option<String>,
     pub query: Option<String>,
+    /// When false (default), soft-deleted rows (deleted_at IS NOT NULL) are
+    /// excluded. Trash views set this to true to surface them.
+    pub include_deleted: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -4769,6 +4837,9 @@ pub fn list_history_jobs_page(options: HistoryListOptions) -> Result<HistoryList
     let mut count_clauses = Vec::new();
     let mut count_params = Vec::new();
     append_status_filter(&mut count_clauses, &mut count_params, &statuses);
+    if !options.include_deleted {
+        count_clauses.push("deleted_at IS NULL".to_string());
+    }
     append_search_filter(
         &mut count_clauses,
         &mut count_params,
@@ -4790,6 +4861,9 @@ pub fn list_history_jobs_page(options: HistoryListOptions) -> Result<HistoryList
     let mut clauses = Vec::new();
     let mut query_params = Vec::new();
     append_status_filter(&mut clauses, &mut query_params, &statuses);
+    if !options.include_deleted {
+        clauses.push("deleted_at IS NULL".to_string());
+    }
     append_search_filter(&mut clauses, &mut query_params, options.query.as_deref());
     if let Some((created_at, id)) = cursor {
         clauses.push("(created_at < ? OR (created_at = ? AND id < ?))".to_string());
@@ -4841,7 +4915,7 @@ pub fn list_history_jobs() -> Result<Vec<Value>, AppError> {
 pub fn list_active_history_jobs() -> Result<Vec<Value>, AppError> {
     let conn = open_history_db()?;
     let mut stmt = conn
-        .prepare("SELECT id, command, provider, status, output_path, created_at, metadata FROM jobs WHERE status IN ('queued', 'running') ORDER BY created_at DESC, id DESC")
+        .prepare("SELECT id, command, provider, status, output_path, created_at, metadata FROM jobs WHERE status IN ('queued', 'running') AND deleted_at IS NULL ORDER BY created_at DESC, id DESC")
         .map_err(|error| AppError::new("history_query_failed", "Unable to query active history.").with_detail(json!({"error": error.to_string()})))?;
     stmt.query_map([], history_row_to_value)
         .map_err(|error| {

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -4673,6 +4673,46 @@ pub fn restore_deleted_history_job(job_id: &str) -> Result<usize, AppError> {
     })
 }
 
+/// Return the IDs of soft-deleted history jobs whose `deleted_at` epoch
+/// timestamp is at or before `threshold_epoch_secs` (i.e. their undo window
+/// has elapsed). Used by the trash GC worker so the cutoff is anchored to
+/// when the row was soft-deleted, not to the trash directory's filesystem
+/// mtime (which `fs::rename` doesn't update).
+pub fn list_expired_deleted_history_jobs(
+    threshold_epoch_secs: u64,
+) -> Result<Vec<String>, AppError> {
+    let conn = open_history_db()?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id FROM jobs WHERE deleted_at IS NOT NULL AND CAST(deleted_at AS INTEGER) <= ?1",
+        )
+        .map_err(|error| {
+            AppError::new(
+                "history_expired_query_failed",
+                "Unable to query expired trash entries.",
+            )
+            .with_detail(json!({"error": error.to_string()}))
+        })?;
+    let rows = stmt
+        .query_map(params![threshold_epoch_secs as i64], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|error| {
+            AppError::new(
+                "history_expired_query_failed",
+                "Unable to query expired trash entries.",
+            )
+            .with_detail(json!({"error": error.to_string()}))
+        })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(|error| {
+        AppError::new(
+            "history_expired_query_failed",
+            "Unable to read expired trash rows.",
+        )
+        .with_detail(json!({"error": error.to_string()}))
+    })
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct HistoryListOptions {
     pub limit: Option<usize>,

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -4668,11 +4668,8 @@ pub fn restore_deleted_history_job(job_id: &str) -> Result<usize, AppError> {
         params![job_id],
     )
     .map_err(|error| {
-        AppError::new(
-            "history_restore_failed",
-            "Unable to restore history job.",
-        )
-        .with_detail(json!({"error": error.to_string()}))
+        AppError::new("history_restore_failed", "Unable to restore history job.")
+            .with_detail(json!({"error": error.to_string()}))
     })
 }
 

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -1680,6 +1680,7 @@ async fn history_list(Query(query): Query<HistoryListQuery>) -> ApiResult {
         cursor: query.cursor,
         status: query.status,
         query: query.q,
+        include_deleted: false,
     })
     .map_err(app_error)
     .map_err(ApiError::internal)?;


### PR DESCRIPTION
## 背景

Tauri macOS 上,WebKit 的 image cache eviction 让默认右键 *Copy Image* 在 4K 大图 / 历史图 / 切屏后变图常常失败,粘出来的是 \`asset://localhost/...\` URL 字符串而不是 PNG bitmap。除此之外 webview 默认菜单(Open Image in New Window / Look Up / Reload …)也不符合桌面创作工具语境,业务相关动作(Use as Reference / Reveal Job)更是完全缺席。

本 PR 完全接管图片右键 surface,做成一套 **runtime-aware 的图片操作系统**:Tauri 和 Web(HTTP-backed)共享同一个 actions registry,通过 capability matrix 优雅降级。

## 架构

\`\`\`
              IMAGE_ACTIONS registry  ← single source of truth
                       │
       ┌───────────────┼────────────────┐
       │               │                │
  ContextMenu      HoverToolbar     QuickLook
   (Radix CM)     (5 fixed slots)   (Space + click)
\`\`\`

- 所有 actions 集中在 \`apps/gpt-image-2-app/src/lib/image-actions/registry.ts\`,每条带 \`isAvailable(ctx)\` 决定哪些 runtime 可用
- 三个消费层都通过 \`useImageActions\` hook 拿到同一份 actions,无重复定义
- Executors 在 React 之外运行,通过 module-level singleton 接 \`QueryClient\` / \`setScreen\` / \`useConfirm\`(\`query-client.ts\` / \`navigation.ts\` / \`confirm-action.ts\`)

## Capability Matrix

| Action | tauri | http | browser |
|---|---|---|---|
| copy-image | ✓ Rust+clipboard plugin | ✓ ClipboardItem | ✓ ClipboardItem |
| copy-prompt | ✓ | ✓ | ✓ |
| copy-path-or-link | ✓ "Copy File Path" | ✓ "Copy Link" | ✗ |
| save-as | ✓ export-to-Downloads | ✓ blob save | ✓ |
| reveal-in-finder | ✓ | ✗ | ✗ |
| open-with-default | ✓ | ✗ | ✗ |
| drag-out | ✓ tauri-plugin-drag | ✗ | ✗ |
| share | ✗ | ✓ Web Share API | ✓ |
| use-as-reference / edit-with-prompt | ✓ | ✓ | ✓ |
| reveal-job-in-history | ✓ | ✓ | ✓ |
| quick-look | ✓ | ✓ | ✓ |
| delete (soft + 5s undo) | ✓ | ✓ (hard) | ✓ (hard) |

## 主要改动

**Rust**
- \`gpt-image-2-core\`: \`history.sqlite\` 加 \`deleted_at\` 列(idempotent ALTER),\`list_history_jobs_page\` 默认过滤;新增 \`soft_delete_history_job\` / \`restore_deleted_history_job\`
- \`gpt-image-2-app/src-tauri\`: 5 个新 commands(\`read_image_bytes\`、\`copy_image_to_clipboard\`、\`soft_delete_job\`、\`restore_deleted_job\`、\`hard_delete_job\`)+ \`cleanup_orphan_trash_on_start\` 启动清理
- 装 \`tauri-plugin-clipboard-manager\`(写 PNG bitmap 绕开 webview cache 问题)+ \`tauri-plugin-drag\`(原生 drag-out)
- \`gpt-image-2-web\` 同步 \`HistoryListOptions\` 新字段

**Frontend**
- 新增 \`lib/image-actions/\`:types / asset / registry / executors / use-image-actions / focused-image / copy-image / delete-job / drag-out / navigation / query-client / confirm-action
- \`ApiClient\` 加 4 方法(\`softDeleteJob\` / \`restoreDeletedJob\` / \`hardDeleteJob\` / \`copyImageToClipboard\`),三个 transport 都实现
- 新组件:\`ImageContextMenu\`(Radix wrapper)、\`ImageHoverToolbar\`(5 slot + ceremony flash)、\`QuickLookHost\`(全局 imperative API)、\`TextSelectionContextMenu\`(自绘 viewport-clamped)
- \`useDisableWebviewContextMenu\` 全局拦截(dev mode ⌥+右键透传 devtools);\`useImageShortcuts\` 接 Space / ⌘C / ⇧⌘C / ⌘⌫
- \`OutputTile\` / \`job-image-detail-drawer\` / history list 三个 surface 接入,drawer footer 改为 icon-only + Tooltip
- \`SendToEditPayload\` 加 \`prompt?\` 字段,Edit 屏 \`handleSendToEdit\` 同时填 prompt
- Drawer 大图点击 + Space 都走 \`openQuickLook\`,旧的 inline zoom dialog 删除

## 实施分 6 阶段(commit 顺序)

1. **C1** scaffold registry + intercept webview contextmenu
2. **C2** transfer/export/manage actions + Rust commands + soft delete schema
3. **C3** hover toolbar + global Quick Look overlay
4. **C4** generate-stage actions + history surfaces
5. **C5** copy-with-prompt / drag-out / share
6. **C6** copy/save ceremony + complete keyboard set

加 3 个 fix commit(round 1 / round 2 / round 3 review fixes):

- 右键菜单点击后菜单不消失(\`onSelect preventDefault\` 误用)→ 修
- toast 被 drawer / Quick Look 挡 → 改 \`createPortal\` 到 body,加 \`z-index: 9999 !important\` CSS
- 文本选区菜单 cut/copy/paste 不工作 + 视口边缘被裁 → mousedown capture phase 提前抓 selection、execCommand 进 undo 栈、useLayoutEffect clamp 位置
- ⌘Z 不能撤销 paste/cut → \`replaceInputRange\` 改用 \`document.execCommand("insertText")\`
- 删除单图却整个 job 被删 → 加二次确认 + 多图任务文案明确说"包含 N 张图,无法分别删除"
- 复制图片+提示词 → 改为只复制提示词
- Drawer 大图点击不弹 Quick Look(Radix asChild merge 吃了 click)→ 用 \`display:contents\` div 包

## 已知推迟项(下个 PR)

- \`⌘K\` Command Palette
- 2-up Compare 视图
- Hover toolbar inline metadata caret(seed/size/quality)
- Variations / Upscale(后端未实现)
- Star / Tag(决定不做)

## Test plan

跑过:
- [x] \`npm run typecheck\`(apps/gpt-image-2-app)
- [x] \`npm run test:browser\`(12/12 vitest)
- [x] \`cargo check --workspace\`

需要手动验证(Tauri):
- [x] 主预览 / 历史详情 / 历史列表三处右键菜单弹出 + 全功能
- [x] Copy Image 在 4K 图 / 切 tab 后图上仍 100% 拿到 PNG bitmap(原 bug)
- [x] 主预览拖到 Finder / iMessage / Photoshop 落成 PNG 文件
- [x] Space 任意 hover 图开 Quick Look,Esc 关
- [x] ⌘⌫ 删除 → 5s undo toast 内点 → 任务复活;不点 → \`~/.codex/.../jobs/<id>/\` 真删
- [x] 复制成功 toolbar icon ✓ + 蓝色 ring
- [x] 多图任务右键单图 → confirm 文案"包含 N 张图,无法分别删除单张"
- [x] 输入框右键 → 自定义 Cut/Copy/Paste/Select All;Cut/Copy 静默成功;Paste 在末尾不吞字;⌘Z 能撤销 paste/cut

需要手动验证(Web,\`just dev-http-backend\` + \`just dev-http-frontend\`):
- [x] Copy Image 用 ClipboardItem 路径,Safari/Chrome/Firefox 各一遍
- [x] Drag-out 不出现在菜单(\`isAvailable=false\`)
- [x] Share 在 Safari 可见,Chrome desktop 不可见