### PR TITLE
[codex] Add task recovery protocol v1

### DIFF
--- a/apps/gpt-image-2-app/src-tauri/Cargo.toml
+++ b/apps/gpt-image-2-app/src-tauri/Cargo.toml
@@ -38,3 +38,6 @@ tauri-plugin-updater = "2.10.1"
 # behind a Tauri command, so the existing Tauri runtime gating already
 # scopes its availability.
 rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
+
+[features]
+recovery-fault-injection = ["gpt-image-2-core/recovery-fault-injection"]

--- a/apps/gpt-image-2-app/src-tauri/src/job_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_commands.rs
@@ -53,7 +53,10 @@ pub(crate) fn enqueue_generate_image(
     requested_n(request.n)?;
     let (id, dir) = unique_job_dir()?;
     let provider = selected_provider_name(request.provider.as_deref());
-    let metadata = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
+    let metadata = annotate_recovery_job_dir(
+        serde_json::to_value(&request).unwrap_or_else(|_| json!({})),
+        &dir,
+    );
     enqueue_job(
         app,
         state.inner().clone(),
@@ -84,7 +87,7 @@ pub(crate) fn enqueue_edit_image(
     requested_n(request.n)?;
     let (id, dir) = unique_job_dir()?;
     let provider = selected_provider_name(request.provider.as_deref());
-    let metadata = edit_request_metadata(&request);
+    let metadata = annotate_recovery_job_dir(edit_request_metadata(&request), &dir);
     enqueue_job(
         app,
         state.inner().clone(),

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
@@ -95,7 +95,7 @@ pub(crate) fn run_edit_request(
             "out.{}",
             output_extension(request.format.as_deref())
         ));
-        cli_json_result(&edit_args(
+        cli_json_result(&edit_args_with_recovery(
             &request,
             &ref_paths,
             if edit_region_mode == "native-mask" {
@@ -105,6 +105,7 @@ pub(crate) fn run_edit_request(
             },
             &out,
             provider_supports_n,
+            Some((&fallback_id, &dir)),
         ))?
     } else {
         let arg_sets = (0..output_count)

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
@@ -108,9 +108,19 @@ pub(crate) fn run_edit_request(
             Some((&fallback_id, &dir)),
         ))?
     } else {
-        let arg_sets = (0..output_count)
+        let recovery_targets = (0..output_count)
             .map(|index| {
-                edit_args(
+                (
+                    batch_recovery_job_id(&fallback_id, index),
+                    batch_recovery_job_dir(&dir, index),
+                )
+            })
+            .collect::<Vec<_>>();
+        let arg_sets = recovery_targets
+            .iter()
+            .enumerate()
+            .map(|(index, (recovery_job_id, recovery_job_dir))| {
+                edit_args_with_recovery(
                     &request,
                     &ref_paths,
                     if edit_region_mode == "native-mask" {
@@ -118,8 +128,9 @@ pub(crate) fn run_edit_request(
                     } else {
                         None
                     },
-                    &batch_output_path(&dir, request.format.as_deref(), index),
+                    &batch_output_path(&dir, request.format.as_deref(), index as u8),
                     false,
+                    Some((recovery_job_id.as_str(), recovery_job_dir.as_path())),
                 )
             })
             .collect::<Vec<_>>();
@@ -134,12 +145,35 @@ pub(crate) fn run_edit_request(
                 apply_partial_output(ctx, &mut list, index, payload);
             }
         });
-        merge_batch_payloads(
+        let merged = merge_batch_payloads(
             "images edit",
             output_count.into(),
             batch.payloads,
             batch.errors,
+        );
+        let outputs_present = merged
+            .get("output")
+            .and_then(|output| output.get("files"))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0);
+        let failures = merged
+            .get("batch")
+            .and_then(|batch| batch.get("failure_count"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        write_batch_recovery_summary(
+            &fallback_id,
+            &dir,
+            &recovery_targets
+                .iter()
+                .map(|(_, recovery_dir)| recovery_dir.clone())
+                .collect::<Vec<_>>(),
+            outputs_present,
+            failures,
         )
+        .map_err(app_error)?;
+        merged
     };
     let request_meta = edit_request_metadata(&request);
     let job = job_from_payload(&payload, &fallback_id, "images edit", request_meta);

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
@@ -28,12 +28,23 @@ pub(crate) fn run_generate_request(
             Some((&fallback_id, &dir)),
         ))?
     } else {
-        let arg_sets = (0..output_count)
+        let recovery_targets = (0..output_count)
             .map(|index| {
-                generate_args(
+                (
+                    batch_recovery_job_id(&fallback_id, index),
+                    batch_recovery_job_dir(&dir, index),
+                )
+            })
+            .collect::<Vec<_>>();
+        let arg_sets = recovery_targets
+            .iter()
+            .enumerate()
+            .map(|(index, (recovery_job_id, recovery_job_dir))| {
+                generate_args_with_recovery(
                     &request,
-                    &batch_output_path(&dir, request.format.as_deref(), index),
+                    &batch_output_path(&dir, request.format.as_deref(), index as u8),
                     false,
+                    Some((recovery_job_id.as_str(), recovery_job_dir.as_path())),
                 )
             })
             .collect::<Vec<_>>();
@@ -48,12 +59,35 @@ pub(crate) fn run_generate_request(
                 apply_partial_output(ctx, &mut list, index, payload);
             }
         });
-        merge_batch_payloads(
+        let merged = merge_batch_payloads(
             "images generate",
             output_count.into(),
             batch.payloads,
             batch.errors,
+        );
+        let outputs_present = merged
+            .get("output")
+            .and_then(|output| output.get("files"))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0);
+        let failures = merged
+            .get("batch")
+            .and_then(|batch| batch.get("failure_count"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        write_batch_recovery_summary(
+            &fallback_id,
+            &dir,
+            &recovery_targets
+                .iter()
+                .map(|(_, recovery_dir)| recovery_dir.clone())
+                .collect::<Vec<_>>(),
+            outputs_present,
+            failures,
         )
+        .map_err(app_error)?;
+        merged
     };
     let request_meta = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
     let job = job_from_payload(&payload, &fallback_id, "images generate", request_meta);

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
@@ -21,7 +21,12 @@ pub(crate) fn run_generate_request(
             "out.{}",
             output_extension(request.format.as_deref())
         ));
-        cli_json_result(&generate_args(&request, &out, provider_supports_n))?
+        cli_json_result(&generate_args_with_recovery(
+            &request,
+            &out,
+            provider_supports_n,
+            Some((&fallback_id, &dir)),
+        ))?
     } else {
         let arg_sets = (0..output_count)
             .map(|index| {

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -12,10 +12,10 @@ use gpt_image_2_core::{
     AppConfig, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions, KEYCHAIN_SERVICE,
     NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, StorageConfig, StorageReadback,
     StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    annotate_recovery_job_dir, batch_output_path, build_recovery_descriptor, default_config_path,
-    default_keychain_account, delete_history_job, dispatch_task_notifications, edit_args,
-    edit_args_with_recovery, generate_args, generate_args_with_recovery, history_db_path,
-    initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
+    annotate_recovery_job_dir, batch_output_path, batch_recovery_job_dir, batch_recovery_job_id,
+    build_recovery_descriptor, default_config_path, default_keychain_account, delete_history_job,
+    dispatch_task_notifications, edit_args_with_recovery, generate_args_with_recovery,
+    history_db_path, initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
     list_active_history_jobs, list_expired_deleted_history_jobs, list_history_jobs_page,
     load_app_config, mark_interrupted_jobs_on_startup, materialize_openai_raw_response,
     merge_recovery_metadata, notification_status_allowed, output_extension,
@@ -24,7 +24,8 @@ use gpt_image_2_core::{
     product_storage_fallback_dir, read_job_output_from_storage_with_options, read_keychain_secret,
     recovery_job_dir, redact_app_config, requested_n, restore_deleted_history_job, run_json,
     save_app_config, shared_config_dir, show_history_job, soft_delete_history_job, test_fault,
-    upload_job_outputs_to_storage, upsert_history_job, write_keychain_secret,
+    upload_job_outputs_to_storage, upsert_history_job, write_batch_recovery_summary,
+    write_keychain_secret,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -12,17 +12,19 @@ use gpt_image_2_core::{
     AppConfig, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions, KEYCHAIN_SERVICE,
     NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, StorageConfig, StorageReadback,
     StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    batch_output_path, default_config_path, default_keychain_account, delete_history_job,
-    dispatch_task_notifications, edit_args, generate_args, history_db_path,
+    annotate_recovery_job_dir, batch_output_path, build_recovery_descriptor, default_config_path,
+    default_keychain_account, delete_history_job, dispatch_task_notifications, edit_args,
+    edit_args_with_recovery, generate_args, generate_args_with_recovery, history_db_path,
     initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
     list_active_history_jobs, list_expired_deleted_history_jobs, list_history_jobs_page,
-    load_app_config, notification_status_allowed, output_extension, preserve_notification_secrets,
-    preserve_storage_secrets, product_app_data_dir, product_default_export_dir,
-    product_default_export_dirs, product_result_library_dir, product_storage_fallback_dir,
-    read_job_output_from_storage_with_options, read_keychain_secret, redact_app_config,
-    requested_n, restore_deleted_history_job, run_json, save_app_config, shared_config_dir,
-    show_history_job, soft_delete_history_job, upload_job_outputs_to_storage, upsert_history_job,
-    write_keychain_secret,
+    load_app_config, mark_interrupted_jobs_on_startup, materialize_openai_raw_response,
+    merge_recovery_metadata, notification_status_allowed, output_extension,
+    preserve_notification_secrets, preserve_storage_secrets, product_app_data_dir,
+    product_default_export_dir, product_default_export_dirs, product_result_library_dir,
+    product_storage_fallback_dir, read_job_output_from_storage_with_options, read_keychain_secret,
+    recovery_job_dir, redact_app_config, requested_n, restore_deleted_history_job, run_json,
+    save_app_config, shared_config_dir, show_history_job, soft_delete_history_job, test_fault,
+    upload_job_outputs_to_storage, upsert_history_job, write_keychain_secret,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -41,6 +43,7 @@ mod job_execution;
 mod provider_config;
 mod queue_commands;
 mod queue_workers;
+mod recovery_commands;
 mod retry_commands;
 mod settings_commands;
 mod support;
@@ -58,6 +61,7 @@ pub(crate) use job_execution::*;
 pub(crate) use provider_config::*;
 pub(crate) use queue_commands::*;
 pub(crate) use queue_workers::*;
+pub(crate) use recovery_commands::*;
 pub(crate) use retry_commands::*;
 pub(crate) use settings_commands::*;
 pub(crate) use support::*;
@@ -86,6 +90,7 @@ pub fn run() {
         }))
         .setup(|app| {
             allow_result_library_asset_scope(app.handle());
+            let _ = mark_interrupted_jobs_on_startup();
             // Off-thread so a slow filesystem walk can't delay startup, and
             // periodic so undo windows that elapse mid-session still get
             // finalized without waiting for the next app launch.
@@ -117,6 +122,9 @@ pub fn run() {
             set_queue_concurrency,
             cancel_job,
             retry_job,
+            job_recovery,
+            interrupted_jobs,
+            resume_job,
             read_dropped_image_files,
             enqueue_generate_image,
             enqueue_edit_image,
@@ -136,6 +144,14 @@ pub fn run() {
             restore_deleted_job,
             hard_delete_job,
             pick_folder,
+            #[cfg(feature = "recovery-fault-injection")]
+            set_test_faults,
+            #[cfg(feature = "recovery-fault-injection")]
+            test_provider_http_attempts,
+            #[cfg(feature = "recovery-fault-injection")]
+            test_job_attempts,
+            #[cfg(feature = "recovery-fault-injection")]
+            test_raw_response_hash,
         ])
         .run(tauri::generate_context!())
         .expect("error while running gpt-image-2-app");

--- a/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> Value {
+    let metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     let payload = response.get("payload").unwrap_or(response);
     let provider = payload
         .get("provider")
@@ -35,7 +36,7 @@ pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> V
             .and_then(Value::as_str)
             .unwrap_or("completed"),
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path,
         outputs,
         error: payload.get("error").cloned().unwrap_or(Value::Null),
@@ -43,6 +44,7 @@ pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> V
 }
 
 pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> Value {
+    let metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     let payload = response.get("payload").unwrap_or(response);
     let provider = payload
         .get("provider")
@@ -72,7 +74,7 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
         provider,
         status: "uploading",
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path,
         outputs,
         error: Value::Null,
@@ -80,13 +82,17 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
 }
 
 pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value {
+    let mut metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
+    if let Value::Object(map) = &mut metadata {
+        map.insert("error".to_string(), json!({"message": message.clone()}));
+    }
     job_snapshot(JobSnapshotInput {
         id: &queued.id,
         command: &queued.command,
         provider: &queued.provider,
         status: "failed",
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path: None,
         outputs: json!([]),
         error: json!({"message": message}),

--- a/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
@@ -1,0 +1,180 @@
+#![allow(unused_imports)]
+
+use super::*;
+
+#[tauri::command]
+pub(crate) fn job_recovery(job_id: String) -> Result<Value, String> {
+    let job = show_history_job(&job_id).map_err(app_error)?;
+    Ok(build_recovery_descriptor(&job))
+}
+
+#[tauri::command]
+pub(crate) fn interrupted_jobs() -> Result<Value, String> {
+    let page = list_history_jobs_page(HistoryListOptions {
+        status: Some("failed".to_string()),
+        ..HistoryListOptions::default()
+    })
+    .map_err(app_error)?;
+    let jobs = page
+        .jobs
+        .into_iter()
+        .filter(|job| {
+            job.get("metadata")
+                .and_then(|metadata| metadata.get("interrupted_reason"))
+                .and_then(Value::as_str)
+                .is_some()
+        })
+        .map(|job| build_recovery_descriptor(&job))
+        .collect::<Vec<_>>();
+    Ok(json!({ "jobs": jobs }))
+}
+
+#[tauri::command]
+pub(crate) fn resume_job(
+    job_id: String,
+    action: String,
+    app: tauri::AppHandle,
+    state: tauri::State<'_, JobQueueState>,
+) -> Result<Value, String> {
+    match action.as_str() {
+        "continue_save" => continue_save_job(&job_id),
+        "resubmit" => retry_job(job_id, app, state),
+        "discard" => discard_job(&job_id),
+        _ => Err("Unsupported recovery action.".to_string()),
+    }
+}
+
+pub(crate) fn continue_save_job(job_id: &str) -> Result<Value, String> {
+    let job = show_history_job(job_id).map_err(app_error)?;
+    let metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    let job_dir =
+        recovery_job_dir(&metadata).ok_or_else(|| "Recovery job dir is missing.".to_string())?;
+    let format = metadata.get("format").and_then(Value::as_str);
+    let output_path = job_dir.join(format!("out.{}", output_extension(format)));
+    let before_attempts = test_fault::provider_http_attempts(job_id);
+    let saved_files = materialize_openai_raw_response(&job_dir, &output_path).map_err(app_error)?;
+    let after_attempts = test_fault::provider_http_attempts(job_id);
+    if after_attempts != before_attempts {
+        return Err("continue_save attempted a provider HTTP request.".to_string());
+    }
+    let mut recovery_ctx =
+        gpt_image_2_core::RecoveryContext::new(job_id.to_string(), job_dir.clone())
+            .map_err(app_error)?;
+    let _ = recovery_ctx.mark_stage(gpt_image_2_core::RecoveryStage::Materialized);
+    let _ = recovery_ctx.mark_stage(gpt_image_2_core::RecoveryStage::Completed);
+    let output_path = saved_files
+        .first()
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let mut merged_metadata = merge_recovery_metadata(metadata, &job_dir);
+    if let Value::Object(map) = &mut merged_metadata {
+        map.remove("error");
+        map.insert("stage".to_string(), json!("completed"));
+        map.insert(
+            "recoverability".to_string(),
+            json!("recoverable.local_response_cached"),
+        );
+    }
+    let completed = job_snapshot(JobSnapshotInput {
+        id: job_id,
+        command: job
+            .get("command")
+            .and_then(Value::as_str)
+            .unwrap_or("images generate"),
+        provider: job
+            .get("provider")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        status: "completed",
+        created_at: job
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        metadata: merged_metadata,
+        output_path,
+        outputs: json!(saved_files),
+        error: Value::Null,
+    });
+    let notify_job = upload_completed_job_outputs(&completed)?;
+    Ok(json!({
+        "job_id": job_id,
+        "job": notify_job,
+        "events": [{
+            "seq": 1,
+            "kind": "local",
+            "type": "job.completed",
+            "data": completed_event_data(&notify_job),
+        }],
+        "recovered": true,
+    }))
+}
+
+pub(crate) fn discard_job(job_id: &str) -> Result<Value, String> {
+    let mut job = show_history_job(job_id).map_err(app_error)?;
+    let mut metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    if let Value::Object(map) = &mut metadata {
+        map.insert("discarded_at".to_string(), json!(chrono_like_now()));
+    }
+    let output_path = job
+        .get("output_path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    upsert_history_job(
+        job_id,
+        job.get("command")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        job.get("provider")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        "failed",
+        output_path.as_deref(),
+        Some(
+            job.get("created_at")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+        metadata.clone(),
+    )
+    .map_err(app_error)?;
+    job["metadata"] = metadata;
+    Ok(json!({ "job_id": job_id, "job": job, "discarded": true }))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+#[tauri::command]
+pub(crate) fn set_test_faults(fail_at: Option<String>, kill_at: Option<String>) -> Value {
+    test_fault::set_faults(fail_at, kill_at);
+    test_fault::faults_json()
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+#[tauri::command]
+pub(crate) fn test_provider_http_attempts(job_id: String) -> Value {
+    json!({ "total": test_fault::provider_http_attempts(&job_id) })
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+#[tauri::command]
+pub(crate) fn test_job_attempts(job_id: String) -> Result<Value, String> {
+    let job = show_history_job(&job_id).map_err(app_error)?;
+    let (attempts, attempts_truncated_count) = gpt_image_2_core::recovery_attempts_from_metadata(
+        job.get("metadata").unwrap_or(&Value::Null),
+    );
+    Ok(json!({
+        "attempts": attempts,
+        "attempts_truncated_count": attempts_truncated_count,
+    }))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+#[tauri::command]
+pub(crate) fn test_raw_response_hash(job_id: String) -> Result<Value, String> {
+    let job = show_history_job(&job_id).map_err(app_error)?;
+    let metadata = job.get("metadata").cloned().unwrap_or(Value::Null);
+    let job_dir =
+        recovery_job_dir(&metadata).ok_or_else(|| "Recovery job dir is missing.".to_string())?;
+    let sha256 = gpt_image_2_core::raw_response_sha256(&job_dir).map_err(app_error)?;
+    Ok(json!({ "sha256": sha256 }))
+}

--- a/apps/gpt-image-2-app/src-tauri/src/retry_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/retry_commands.rs
@@ -159,7 +159,10 @@ pub(crate) fn retry_job(
             requested_n(request.n)?;
             let (id, dir) = unique_job_dir()?;
             let provider = selected_provider_name(request.provider.as_deref());
-            let metadata = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
+            let metadata = annotate_recovery_job_dir(
+                serde_json::to_value(&request).unwrap_or_else(|_| json!({})),
+                &dir,
+            );
             enqueue_job(
                 app,
                 state.inner().clone(),
@@ -182,7 +185,7 @@ pub(crate) fn retry_job(
             requested_n(request.n)?;
             let (id, dir) = unique_job_dir()?;
             let provider = selected_provider_name(request.provider.as_deref());
-            let metadata = edit_request_metadata(&request);
+            let metadata = annotate_recovery_job_dir(edit_request_metadata(&request), &dir);
             enqueue_job(
                 app,
                 state.inner().clone(),

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -8,7 +8,7 @@ import {
   useDeleteJob,
   useJob,
   useJobPages,
-  useRetryJob,
+  useResumeJob,
 } from "@/hooks/use-jobs";
 import { OPEN_JOB_EVENT, sendImageToEdit } from "@/lib/job-navigation";
 import { jobOutputPath, jobOutputUrl } from "@/lib/job-outputs";
@@ -37,7 +37,7 @@ export function HistoryScreen({
 } = {}) {
   const deleteJob = useDeleteJob();
   const cancelJob = useCancelJob();
-  const retryJob = useRetryJob();
+  const resumeJob = useResumeJob();
   const confirm = useConfirm();
   const reducedMotion = useReducedMotion();
   const [filter, setFilter] = useState<FilterValue>("all");
@@ -136,21 +136,31 @@ export function HistoryScreen({
     finished.forEach((j) => deleteJob.mutate(j.id));
   };
 
-  const handleRetry = async (jobId: string) => {
-    const toastId = toast.loading("正在重试任务");
+  const handleRecover = async (job: Job) => {
+    const recoverability = String(job.metadata?.recoverability ?? "");
+    const action =
+      recoverability === "recoverable.local_response_cached"
+        ? "continue_save"
+        : "resubmit";
+    const toastId = toast.loading(
+      action === "continue_save" ? "正在继续完成任务" : "正在重新生成任务",
+    );
     try {
-      const result = await retryJob.mutateAsync(jobId);
-      toast.success("已重新提交", {
+      const result = await resumeJob.mutateAsync({ id: job.id, action });
+      toast.success(action === "continue_save" ? "已继续完成" : "已重新生成", {
         id: toastId,
-        description: `新任务 ${result.job_id} 已进入队列。`,
+        description:
+          action === "continue_save"
+            ? "已使用本地缓存响应完成保存，未再次调用 API。"
+            : `新任务 ${result.job_id} 已进入队列，将再次调用 API。`,
       });
       setExpandedIds((prev) => {
         const next = new Set(prev);
-        next.add(result.job_id);
+        next.add(result.job_id ?? job.id);
         return next;
       });
     } catch (error) {
-      toast.error("重试失败", {
+      toast.error(action === "continue_save" ? "继续完成失败" : "重新生成失败", {
         id: toastId,
         description: error instanceof Error ? error.message : String(error),
       });
@@ -340,7 +350,7 @@ export function HistoryScreen({
                         setDetailJobId(j.id);
                         setDetailIndex(outputIndex);
                       }}
-                      onRetry={() => void handleRetry(j.id)}
+                      onRetry={() => void handleRecover(j)}
                     />
                   </motion.div>
                 ))}
@@ -385,7 +395,10 @@ export function HistoryScreen({
           });
         }}
         onRerun={onSwitchToGenerate}
-        onRetry={(jobId) => void handleRetry(jobId)}
+        onRetry={(jobId) => {
+          const job = jobs.find((item) => item.id === jobId) ?? detailJob;
+          if (job) void handleRecover(job);
+        }}
         onSendToEdit={(job, outputIndex) => {
           sendImageToEdit({
             jobId: job.id,

--- a/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
@@ -90,6 +90,15 @@ export function JobImageDetailDrawer({
   );
   const copy = runtimeCopy();
   const canShowFileLocation = isDesktopRuntime();
+  const recoverability = String(job?.metadata?.recoverability ?? "");
+  const recoveryLabel =
+    recoverability === "recoverable.local_response_cached"
+      ? "继续完成"
+      : "重新生成";
+  const recoveryTip =
+    recoverability === "recoverable.local_response_cached"
+      ? "继续完成（不再次调用 API）"
+      : "重新生成（将再次调用 API）";
 
   const handleRerun = () => {
     if (!job) return;
@@ -297,12 +306,12 @@ export function JobImageDetailDrawer({
             {onRetry &&
               job &&
               (job.status === "failed" || job.status === "cancelled") && (
-                <Tooltip text="重试（原样重新提交）">
+                <Tooltip text={recoveryTip}>
                   <Button
                     variant="secondary"
                     size="iconSm"
                     icon="reload"
-                    aria-label="重试"
+                    aria-label={recoveryLabel}
                     onClick={() => onRetry(job.id)}
                   />
                 </Tooltip>

--- a/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
@@ -73,6 +73,15 @@ export function JobRowExpandable({
     status === "failed" ||
     status === "partial_failed" ||
     status === "cancelled";
+  const recoverability = String(job.metadata?.recoverability ?? "");
+  const recoveryLabel =
+    recoverability === "recoverable.local_response_cached"
+      ? "继续完成"
+      : "重新生成";
+  const recoveryTitle =
+    recoverability === "recoverable.local_response_cached"
+      ? "使用已收到的响应继续完成，不再次调用 API"
+      : "重新生成 · 将再次调用 API";
   const isQueueing = status === "queued";
   const isRunning = status === "running" || status === "uploading";
   const outputIndexes = jobOutputIndexes(job);
@@ -258,11 +267,11 @@ export function JobRowExpandable({
                 onRetry();
               }}
               className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11.5px] font-semibold text-foreground transition-colors hover:bg-[color:var(--accent-12)]"
-              aria-label="重试任务"
-              title="原样重试"
+              aria-label={recoveryLabel}
+              title={recoveryTitle}
             >
               <Loader2 size={12} className="hidden" />
-              重试
+              {recoveryLabel}
             </button>
           )}
           <ChevronDown
@@ -491,12 +500,13 @@ export function JobRowExpandable({
                       variant="secondary"
                       size="sm"
                       icon="reload"
+                      title={recoveryTitle}
                       onClick={(e) => {
                         e.stopPropagation();
                         onRetry();
                       }}
                     >
-                      重试
+                      {recoveryLabel}
                     </Button>
                   )}
                   <div className="flex-1" />

--- a/apps/gpt-image-2-app/src/hooks/use-jobs.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-jobs.ts
@@ -97,6 +97,20 @@ export function useRetryJob() {
   });
 }
 
+export function useResumeJob() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      action,
+    }: {
+      id: string;
+      action: "continue_save" | "resubmit" | "discard";
+    }) => api.resumeJob(id, action),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["jobs"] }),
+  });
+}
+
 export function useQueueStatus() {
   return useQuery<QueueStatus>({
     queryKey: ["queue-status"],

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -423,6 +423,11 @@ export const browserApi: ApiClient = {
     }
     throw new Error("这个任务类型暂不支持重试。");
   },
+  async resumeJob(jobId: string, action: "continue_save" | "resubmit" | "discard") {
+    if (action === "resubmit") return browserApi.retryJob(jobId);
+    if (action === "discard") throw new Error("浏览器模式暂不支持丢弃恢复任务。");
+    throw new Error("浏览器模式不支持继续完成，请改用 Docker/App。");
+  },
   outputUrl(jobId: string, index = 0) {
     const path = outputPath(jobId, index);
     return path ? browserApi.fileUrl(path) : "";

--- a/apps/gpt-image-2-app/src/lib/api/http-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http-transport.ts
@@ -294,6 +294,13 @@ export const httpApi: ApiClient = {
     );
     return normalizeJobResponse(result);
   },
+  async resumeJob(jobId: string, action: "continue_save" | "resubmit" | "discard") {
+    const result = await requestJson<TauriJobResponse>(
+      `/jobs/${encodeURIComponent(jobId)}/resume`,
+      { method: "POST", body: jsonBody({ action }) },
+    );
+    return normalizeJobResponse(result);
+  },
   outputUrl(jobId: string, index = 0) {
     const path = outputPath(jobId, index);
     return path ? httpApi.fileUrl(path) : "";

--- a/apps/gpt-image-2-app/src/lib/api/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/index.ts
@@ -209,6 +209,8 @@ export const api: ApiClient = {
     invokeClient("createEdit", form) as ReturnType<ApiClient["createEdit"]>,
   retryJob: (jobId) =>
     invokeClient("retryJob", jobId) as ReturnType<ApiClient["retryJob"]>,
+  resumeJob: (jobId, action) =>
+    invokeClient("resumeJob", jobId, action) as ReturnType<ApiClient["resumeJob"]>,
   outputUrl(jobId, index) {
     return activeClient.outputUrl(jobId, index);
   },

--- a/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
@@ -298,6 +298,13 @@ export const tauriApi: ApiClient = {
     const result = await invoke<TauriJobResponse>("retry_job", { jobId });
     return normalizeJobResponse(result);
   },
+  async resumeJob(jobId: string, action: "continue_save" | "resubmit" | "discard") {
+    const result = await invoke<TauriJobResponse>("resume_job", {
+      jobId,
+      action,
+    });
+    return normalizeJobResponse(result);
+  },
   outputUrl(jobId: string, index = 0) {
     const path = outputPath(jobId, index);
     return path ? convertFileSrc(path) : "";

--- a/apps/gpt-image-2-app/src/lib/api/types.ts
+++ b/apps/gpt-image-2-app/src/lib/api/types.ts
@@ -170,6 +170,10 @@ export type ApiClient = RuntimeCapabilities & {
   createGenerate(body: GenerateRequest): Promise<TauriJobResponse>;
   createEdit(form: FormData): Promise<TauriJobResponse>;
   retryJob(jobId: string): Promise<TauriJobResponse>;
+  resumeJob(
+    jobId: string,
+    action: "continue_save" | "resubmit" | "discard",
+  ): Promise<TauriJobResponse>;
   outputUrl(jobId: string, index?: number): string;
   outputPath(jobId: string, index?: number): string | undefined;
   fileUrl(path?: string | null): string;

--- a/crates/gpt-image-2-core/Cargo.toml
+++ b/crates/gpt-image-2-core/Cargo.toml
@@ -29,5 +29,8 @@ sha2 = "0.10.9"
 ssh2 = "0.9.5"
 url = "2.5.7"
 
+[features]
+recovery-fault-injection = []
+
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/crates/gpt-image-2-core/src/cli_types.rs
+++ b/crates/gpt-image-2-core/src/cli_types.rs
@@ -308,6 +308,10 @@ pub struct SharedImageArgs {
     pub n: Option<u8>,
     #[arg(long, value_enum)]
     pub moderation: Option<Moderation>,
+    #[arg(long, hide = true)]
+    pub recovery_job_id: Option<String>,
+    #[arg(long, hide = true)]
+    pub recovery_job_dir: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/gpt-image-2-core/src/history_list.rs
+++ b/crates/gpt-image-2-core/src/history_list.rs
@@ -41,7 +41,9 @@ pub(crate) fn history_row_to_value_with_uploads(
     let id = row.get::<_, String>(0)?;
     let output_path = row.get::<_, Option<String>>(4)?;
     let created_at = row.get::<_, String>(5)?;
-    let metadata = serde_json::from_str::<Value>(&row.get::<_, String>(6)?).unwrap_or(Value::Null);
+    let mut metadata =
+        serde_json::from_str::<Value>(&row.get::<_, String>(6)?).unwrap_or(Value::Null);
+    redact_recovery_attempts(&mut metadata);
     let output = metadata.get("output").cloned().unwrap_or_else(|| json!({}));
     let outputs = output
         .get("files")
@@ -72,6 +74,13 @@ pub(crate) fn history_row_to_value_with_uploads(
         "storage_status": storage_status_for_uploads(uploads),
         "error": error,
     }))
+}
+
+fn redact_recovery_attempts(metadata: &mut Value) {
+    if let Value::Object(map) = metadata {
+        map.remove("attempts");
+        map.remove("attempts_truncated_count");
+    }
 }
 
 pub(crate) fn normalize_history_limit(limit: Option<usize>) -> usize {

--- a/crates/gpt-image-2-core/src/image_commands.rs
+++ b/crates/gpt-image-2-core/src/image_commands.rs
@@ -37,24 +37,73 @@ pub(crate) fn run_openai_image_command(
         shared.n,
         shared.moderation,
     );
+    let mut recovery = match (&shared.recovery_job_id, &shared.recovery_job_dir) {
+        (Some(job_id), Some(job_dir)) => {
+            let ctx = RecoveryContext::new(job_id.clone(), PathBuf::from(job_dir))?;
+            ctx.write_request_meta(&json!({
+                "operation": operation,
+                "provider": selection.resolved,
+                "request": summarize_image_request_options("openai", operation, &resolved_model, shared, resolved_ref_images.len(), resolved_mask.is_some(), input_fidelity),
+            }))?;
+            Some(ctx)
+        }
+        _ => None,
+    };
     let endpoint = build_openai_operation_endpoint(&selection.api_base, operation)?;
     let mut logger = JsonEventLogger::new(cli.json_events);
-    let (payload, retry_count) =
-        execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
-            if operation == "edit" {
-                request_openai_edit_once(&endpoint, &auth_state, &body, logger)
-            } else {
-                request_openai_images_once(&endpoint, &auth_state, &body, logger)
+    let request_result = execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
+        if operation == "edit" {
+            request_openai_edit_once(&endpoint, &auth_state, &body, logger, recovery.as_mut())
+        } else {
+            request_openai_images_once(&endpoint, &auth_state, &body, logger, recovery.as_mut())
+        }
+    });
+    let (payload, retry_count) = match request_result {
+        Ok(value) => value,
+        Err(error) => {
+            if let Some(ctx) = recovery.as_mut() {
+                let _ = ctx.finish_error(RecoveryStage::Submitted, &error);
             }
-        })?;
-    let (image_bytes_list, revised_prompts) = decode_openai_images(&payload)?;
+            return Err(error);
+        }
+    };
+    if let Some(ctx) = recovery.as_mut()
+        && let Err(error) = ctx.maybe_fail_materialize_start()
+    {
+        let _ = ctx.finish_error(RecoveryStage::ResponseReceived, &error);
+        return Err(error);
+    }
+    let (image_bytes_list, revised_prompts) = match decode_openai_images(&payload) {
+        Ok(value) => value,
+        Err(error) => {
+            if let Some(ctx) = recovery.as_mut() {
+                let _ = ctx.finish_error(RecoveryStage::ResponseReceived, &error);
+            }
+            return Err(error);
+        }
+    };
     if image_bytes_list.is_empty() {
-        return Err(AppError::new(
+        let error = AppError::new(
             "missing_image_result",
             "The response did not include a generated image.",
-        ));
+        );
+        if let Some(ctx) = recovery.as_mut() {
+            let _ = ctx.finish_error(RecoveryStage::ResponseReceived, &error);
+        }
+        return Err(error);
     }
-    let saved_files = save_images(&output_path, &image_bytes_list)?;
+    let saved_files = match save_images(&output_path, &image_bytes_list) {
+        Ok(value) => value,
+        Err(error) => {
+            if let Some(ctx) = recovery.as_mut() {
+                let _ = ctx.finish_error(RecoveryStage::ResponseReceived, &error);
+            }
+            return Err(error);
+        }
+    };
+    if let Some(ctx) = recovery.as_mut() {
+        let _ = ctx.mark_stage(RecoveryStage::Materialized);
+    }
     let primary_output_path = primary_saved_output_path(&output_path, &saved_files);
     let history_job_id = record_history_job(
         &format!("images {operation}"),

--- a/crates/gpt-image-2-core/src/image_requests/openai.rs
+++ b/crates/gpt-image-2-core/src/image_requests/openai.rs
@@ -7,6 +7,7 @@ pub(crate) fn request_openai_images_once(
     auth_state: &OpenAiAuthState,
     body: &Value,
     logger: &mut JsonEventLogger,
+    mut recovery: Option<&mut RecoveryContext>,
 ) -> Result<Value, AppError> {
     logger.emit(
         "local",
@@ -22,19 +23,28 @@ pub(crate) fn request_openai_images_once(
         Some(0),
         json!({ "endpoint": endpoint }),
     );
+    let client_request_id = if let Some(ctx) = recovery.as_deref_mut() {
+        let client_request_id = ctx.begin_attempt()?;
+        test_fault::record_provider_http_attempt(&ctx.job_id);
+        Some(client_request_id)
+    } else {
+        None
+    };
     let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
-    let response = client
+    let mut request = client
         .post(endpoint)
         .header(AUTHORIZATION, format!("Bearer {}", auth_state.api_key))
         .header(CONTENT_TYPE, "application/json")
         .header(ACCEPT, "application/json")
-        .body(body.to_string())
-        .send()
-        .map_err(|error| {
-            AppError::new("network_error", "OpenAI request failed.")
-                .with_detail(json!({ "error": error.to_string() }))
-        })?;
-    parse_openai_json_response(response, logger)
+        .body(body.to_string());
+    if let Some(client_request_id) = &client_request_id {
+        request = request.header("X-Client-Request-Id", client_request_id);
+    }
+    let response = request.send().map_err(|error| {
+        AppError::new("network_error", "OpenAI request failed.")
+            .with_detail(json!({ "error": error.to_string() }))
+    })?;
+    parse_openai_json_response(response, logger, recovery.as_deref_mut())
 }
 
 pub(crate) fn request_openai_edit_once(
@@ -42,6 +52,7 @@ pub(crate) fn request_openai_edit_once(
     auth_state: &OpenAiAuthState,
     body: &Value,
     logger: &mut JsonEventLogger,
+    mut recovery: Option<&mut RecoveryContext>,
 ) -> Result<Value, AppError> {
     logger.emit(
         "local",
@@ -67,29 +78,53 @@ pub(crate) fn request_openai_edit_once(
         Some(10),
         json!({ "transport": "multipart" }),
     );
+    let client_request_id = if let Some(ctx) = recovery.as_deref_mut() {
+        let client_request_id = ctx.begin_attempt()?;
+        test_fault::record_provider_http_attempt(&ctx.job_id);
+        Some(client_request_id)
+    } else {
+        None
+    };
     let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
-    let response = client
+    let mut request = client
         .post(endpoint)
         .header(AUTHORIZATION, format!("Bearer {}", auth_state.api_key))
-        .multipart(form)
-        .send()
-        .map_err(|error| {
-            AppError::new("network_error", "OpenAI multipart request failed.")
-                .with_detail(json!({ "error": error.to_string() }))
-        })?;
-    parse_openai_json_response(response, logger)
+        .multipart(form);
+    if let Some(client_request_id) = &client_request_id {
+        request = request.header("X-Client-Request-Id", client_request_id);
+    }
+    let response = request.send().map_err(|error| {
+        AppError::new("network_error", "OpenAI multipart request failed.")
+            .with_detail(json!({ "error": error.to_string() }))
+    })?;
+    parse_openai_json_response(response, logger, recovery.as_deref_mut())
 }
 
 pub(crate) fn parse_openai_json_response(
     response: Response,
     logger: &mut JsonEventLogger,
+    mut recovery: Option<&mut RecoveryContext>,
 ) -> Result<Value, AppError> {
+    if let Some(ctx) = recovery.as_deref_mut() {
+        ctx.mark_response_headers(response.headers())?;
+    }
     if !response.status().is_success() {
         let status = response.status();
         let detail = response.text().unwrap_or_else(|_| String::new());
         return Err(http_status_error(status, detail));
     }
-    let payload: Value = response.json().map_err(|error| {
+    let raw = response.text().map_err(|error| {
+        AppError::new(
+            "invalid_json_response",
+            "OpenAI Images API response body could not be read.",
+        )
+        .with_detail(json!({ "error": error.to_string() }))
+    })?;
+    if let Some(ctx) = recovery.as_deref_mut() {
+        ctx.mark_response_body_completed()?;
+        ctx.spool_raw_response(&raw)?;
+    }
+    let payload: Value = serde_json::from_str(&raw).map_err(|error| {
         AppError::new(
             "invalid_json_response",
             "OpenAI Images API returned invalid JSON.",

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -127,9 +127,10 @@ pub use provider_types::ProviderConfig;
 pub(crate) use provider_types::*;
 pub use recovery::{
     Recoverability, RecoveryAttempt, RecoveryContext, RecoveryStage, RecoveryState,
-    annotate_recovery_job_dir, build_recovery_descriptor, mark_interrupted_jobs_on_startup,
-    materialize_openai_raw_response, merge_recovery_metadata, raw_response_sha256,
-    recovery_attempts_from_metadata, recovery_job_dir, test_fault,
+    annotate_recovery_job_dir, batch_recovery_job_dir, batch_recovery_job_id,
+    build_recovery_descriptor, mark_interrupted_jobs_on_startup, materialize_openai_raw_response,
+    merge_recovery_metadata, raw_response_sha256, recovery_attempts_from_metadata,
+    recovery_job_dir, test_fault, write_batch_recovery_summary,
 };
 pub(crate) use request_commands::*;
 pub use request_commands::{run, run_json};

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -45,6 +45,7 @@ mod notifications;
 mod paths;
 mod provider_selection;
 mod provider_types;
+mod recovery;
 mod request_commands;
 mod request_payloads;
 mod runtime_image_args;
@@ -124,13 +125,19 @@ pub(crate) use paths::{
 pub(crate) use provider_selection::*;
 pub use provider_types::ProviderConfig;
 pub(crate) use provider_types::*;
+pub use recovery::{
+    Recoverability, RecoveryAttempt, RecoveryContext, RecoveryStage, RecoveryState,
+    annotate_recovery_job_dir, build_recovery_descriptor, mark_interrupted_jobs_on_startup,
+    materialize_openai_raw_response, merge_recovery_metadata, raw_response_sha256,
+    recovery_attempts_from_metadata, recovery_job_dir, test_fault,
+};
 pub(crate) use request_commands::*;
 pub use request_commands::{run, run_json};
 pub use request_payloads::build_openai_image_body;
 pub(crate) use request_payloads::*;
 pub use runtime_image_args::{
-    batch_output_path, edit_args, generate_args, output_extension, push_optional,
-    push_provider_arg, requested_n,
+    batch_output_path, edit_args, edit_args_with_recovery, generate_args,
+    generate_args_with_recovery, output_extension, push_optional, push_provider_arg, requested_n,
 };
 pub use runtime_request_types::{EditRequest, GenerateRequest, UploadFile};
 #[cfg(test)]

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -1,0 +1,937 @@
+#![allow(unused_imports)]
+
+use super::*;
+use sha2::Digest;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(all(feature = "recovery-fault-injection", not(any(test, debug_assertions))))]
+compile_error!("recovery-fault-injection must not be enabled in release builds");
+
+pub const RECOVERY_ATTEMPTS_LIMIT: usize = 5;
+pub const RECOVERY_STATE_FILE: &str = "recovery_state.json";
+pub const REQUEST_META_FILE: &str = "request_meta.json";
+pub const RAW_RESPONSE_FILE: &str = "raw_response.json";
+pub const ERROR_FILE: &str = "error.json";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryStage {
+    Staged,
+    Submitted,
+    ResponseReceived,
+    Materialized,
+    Uploaded,
+    Completed,
+}
+
+impl RecoveryStage {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Staged => "staged",
+            Self::Submitted => "submitted",
+            Self::ResponseReceived => "response_received",
+            Self::Materialized => "materialized",
+            Self::Uploaded => "uploaded",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Recoverability {
+    #[serde(rename = "recoverable.never_dispatched")]
+    NeverDispatched,
+    #[serde(rename = "recoverable.local_response_cached")]
+    LocalResponseCached,
+    #[serde(rename = "recoverable.partial_outputs")]
+    PartialOutputs,
+    #[serde(rename = "recoverable.upload_failed")]
+    UploadFailed,
+    #[serde(rename = "recoverable.remote_in_progress")]
+    RemoteInProgress,
+    #[serde(rename = "ambiguous.remote_maybe_accepted")]
+    RemoteMaybeAccepted,
+    #[serde(rename = "terminal.local_recovery_unavailable")]
+    LocalRecoveryUnavailable,
+    #[serde(rename = "terminal.provider_rejected")]
+    ProviderRejected,
+    #[serde(rename = "terminal.user_cancelled")]
+    UserCancelled,
+}
+
+impl Recoverability {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NeverDispatched => "recoverable.never_dispatched",
+            Self::LocalResponseCached => "recoverable.local_response_cached",
+            Self::PartialOutputs => "recoverable.partial_outputs",
+            Self::UploadFailed => "recoverable.upload_failed",
+            Self::RemoteInProgress => "recoverable.remote_in_progress",
+            Self::RemoteMaybeAccepted => "ambiguous.remote_maybe_accepted",
+            Self::LocalRecoveryUnavailable => "terminal.local_recovery_unavailable",
+            Self::ProviderRejected => "terminal.provider_rejected",
+            Self::UserCancelled => "terminal.user_cancelled",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "recoverable.never_dispatched" => Some(Self::NeverDispatched),
+            "recoverable.local_response_cached" => Some(Self::LocalResponseCached),
+            "recoverable.partial_outputs" => Some(Self::PartialOutputs),
+            "recoverable.upload_failed" => Some(Self::UploadFailed),
+            "recoverable.remote_in_progress" => Some(Self::RemoteInProgress),
+            "ambiguous.remote_maybe_accepted" => Some(Self::RemoteMaybeAccepted),
+            "terminal.local_recovery_unavailable" => Some(Self::LocalRecoveryUnavailable),
+            "terminal.provider_rejected" => Some(Self::ProviderRejected),
+            "terminal.user_cancelled" => Some(Self::UserCancelled),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RecoveryAttempt {
+    pub attempt_id: String,
+    pub client_request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_headers_received_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_body_completed_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_response_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage_at_failure: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RecoveryState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recoverability: Option<String>,
+    #[serde(default)]
+    pub attempts: Vec<RecoveryAttempt>,
+    #[serde(default)]
+    pub attempts_truncated_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interrupted_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecoveryContext {
+    pub job_id: String,
+    pub job_dir: PathBuf,
+    state: RecoveryState,
+}
+
+static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn token(prefix: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{nanos:x}-{:x}-{:x}", std::process::id(), seq)
+}
+
+pub fn recovery_state_path(job_dir: &Path) -> PathBuf {
+    job_dir.join(RECOVERY_STATE_FILE)
+}
+
+pub fn request_meta_path(job_dir: &Path) -> PathBuf {
+    job_dir.join(REQUEST_META_FILE)
+}
+
+pub fn raw_response_path(job_dir: &Path) -> PathBuf {
+    job_dir.join(RAW_RESPONSE_FILE)
+}
+
+pub fn error_json_path(job_dir: &Path) -> PathBuf {
+    job_dir.join(ERROR_FILE)
+}
+
+pub fn atomic_write_json(path: &Path, value: &Value) -> Result<(), AppError> {
+    let bytes = serde_json::to_vec_pretty(value).map_err(|error| {
+        AppError::new(
+            "recovery_json_encode_failed",
+            "Unable to encode recovery JSON.",
+        )
+        .with_detail(json!({"error": error.to_string()}))
+    })?;
+    atomic_write_bytes(path, &bytes)
+}
+
+pub fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AppError::new(
+                "recovery_write_failed",
+                "Unable to create recovery directory.",
+            )
+            .with_detail(json!({"path": parent.display().to_string(), "error": error.to_string()}))
+        })?;
+    }
+    let part = path.with_extension(format!(
+        "{}part",
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("{ext}."))
+            .unwrap_or_default()
+    ));
+    {
+        let mut file = fs::File::create(&part).map_err(|error| {
+            AppError::new("recovery_write_failed", "Unable to create recovery file.").with_detail(
+                json!({"path": part.display().to_string(), "error": error.to_string()}),
+            )
+        })?;
+        file.write_all(bytes).map_err(|error| {
+            AppError::new("recovery_write_failed", "Unable to write recovery file.").with_detail(
+                json!({"path": part.display().to_string(), "error": error.to_string()}),
+            )
+        })?;
+        file.sync_all().map_err(|error| {
+            AppError::new("recovery_write_failed", "Unable to flush recovery file.").with_detail(
+                json!({"path": part.display().to_string(), "error": error.to_string()}),
+            )
+        })?;
+    }
+    fs::rename(&part, path).map_err(|error| {
+        AppError::new("recovery_write_failed", "Unable to finalize recovery file.").with_detail(
+            json!({
+                "from": part.display().to_string(),
+                "to": path.display().to_string(),
+                "error": error.to_string()
+            }),
+        )
+    })?;
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
+    Ok(())
+}
+
+pub fn load_recovery_state(job_dir: &Path) -> Option<RecoveryState> {
+    fs::read_to_string(recovery_state_path(job_dir))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<RecoveryState>(&raw).ok())
+}
+
+pub fn recovery_job_dir(metadata: &Value) -> Option<PathBuf> {
+    metadata
+        .get("recovery")
+        .and_then(|value| value.get("job_dir"))
+        .and_then(Value::as_str)
+        .or_else(|| metadata.get("job_dir").and_then(Value::as_str))
+        .map(PathBuf::from)
+}
+
+pub fn annotate_recovery_job_dir(mut metadata: Value, job_dir: &Path) -> Value {
+    if !metadata.is_object() {
+        metadata = json!({});
+    }
+    if let Value::Object(map) = &mut metadata {
+        let mut recovery = map.get("recovery").cloned().unwrap_or_else(|| json!({}));
+        if let Value::Object(recovery_map) = &mut recovery {
+            recovery_map.insert("job_dir".to_string(), json!(job_dir.display().to_string()));
+        }
+        map.insert("recovery".to_string(), recovery);
+    }
+    metadata
+}
+
+pub fn merge_recovery_metadata(mut metadata: Value, job_dir: &Path) -> Value {
+    metadata = annotate_recovery_job_dir(metadata, job_dir);
+    let Some(mut state) = load_recovery_state(job_dir) else {
+        let recoverability =
+            classify_from_evidence(None, raw_response_path(job_dir).is_file(), None);
+        if let Value::Object(map) = &mut metadata {
+            map.insert("recoverability".to_string(), json!(recoverability.as_str()));
+        }
+        return metadata;
+    };
+    if state.recoverability.is_none() {
+        state.recoverability = Some(
+            classify_from_state_and_evidence(&state, raw_response_path(job_dir).is_file())
+                .as_str()
+                .to_string(),
+        );
+    }
+    if let Value::Object(map) = &mut metadata {
+        map.remove("attempts");
+        map.remove("attempts_truncated_count");
+        if let Some(stage) = state.stage {
+            map.insert("stage".to_string(), json!(stage));
+        }
+        if let Some(recoverability) = state.recoverability {
+            map.insert("recoverability".to_string(), json!(recoverability));
+        }
+        if let Some(reason) = state.interrupted_reason {
+            map.insert("interrupted_reason".to_string(), json!(reason));
+        }
+    }
+    metadata
+}
+
+pub fn classify_from_state_and_evidence(
+    state: &RecoveryState,
+    raw_response_present: bool,
+) -> Recoverability {
+    classify_from_evidence(state.attempts.last(), raw_response_present, None)
+}
+
+pub fn classify_from_evidence(
+    attempt: Option<&RecoveryAttempt>,
+    raw_response_present: bool,
+    fallback_error_code: Option<&str>,
+) -> Recoverability {
+    let Some(attempt) = attempt else {
+        return if raw_response_present {
+            Recoverability::LocalResponseCached
+        } else {
+            Recoverability::NeverDispatched
+        };
+    };
+    if attempt.request_started_at.is_none() {
+        return Recoverability::NeverDispatched;
+    }
+    if attempt.response_body_completed_at.is_some() {
+        if attempt.raw_response_path.is_some() || raw_response_present {
+            return Recoverability::LocalResponseCached;
+        }
+        return Recoverability::LocalRecoveryUnavailable;
+    }
+    if matches!(
+        fallback_error_code.or(attempt.error_code.as_deref()),
+        Some("provider_rejected")
+    ) {
+        return Recoverability::ProviderRejected;
+    }
+    Recoverability::RemoteMaybeAccepted
+}
+
+impl RecoveryContext {
+    pub fn new(job_id: impl Into<String>, job_dir: impl Into<PathBuf>) -> Result<Self, AppError> {
+        let job_id = job_id.into();
+        let job_dir = job_dir.into();
+        fs::create_dir_all(&job_dir).map_err(|error| {
+            AppError::new("recovery_write_failed", "Unable to create job directory.").with_detail(
+                json!({"path": job_dir.display().to_string(), "error": error.to_string()}),
+            )
+        })?;
+        let state = load_recovery_state(&job_dir).unwrap_or_else(|| RecoveryState {
+            job_id: Some(job_id.clone()),
+            job_dir: Some(job_dir.display().to_string()),
+            stage: Some(RecoveryStage::Staged.as_str().to_string()),
+            ..RecoveryState::default()
+        });
+        let ctx = Self {
+            job_id,
+            job_dir,
+            state,
+        };
+        ctx.persist_state()?;
+        Ok(ctx)
+    }
+
+    pub fn write_request_meta(&self, request_meta: &Value) -> Result<(), AppError> {
+        atomic_write_json(&request_meta_path(&self.job_dir), request_meta)
+    }
+
+    fn persist_state(&self) -> Result<(), AppError> {
+        let value = serde_json::to_value(&self.state).map_err(|error| {
+            AppError::new(
+                "recovery_json_encode_failed",
+                "Unable to encode recovery state.",
+            )
+            .with_detail(json!({"error": error.to_string()}))
+        })?;
+        atomic_write_json(&recovery_state_path(&self.job_dir), &value)
+    }
+
+    fn current_attempt_mut(&mut self) -> Option<&mut RecoveryAttempt> {
+        self.state.attempts.last_mut()
+    }
+
+    pub fn begin_attempt(&mut self) -> Result<String, AppError> {
+        let attempt = RecoveryAttempt {
+            attempt_id: token("attempt"),
+            client_request_id: token("client"),
+            ..RecoveryAttempt::default()
+        };
+        if self.state.attempts.len() >= RECOVERY_ATTEMPTS_LIMIT {
+            self.state.attempts.remove(0);
+            self.state.attempts_truncated_count += 1;
+        }
+        let client_request_id = attempt.client_request_id.clone();
+        self.state.attempts.push(attempt);
+        self.state.stage = Some(RecoveryStage::Submitted.as_str().to_string());
+        self.state.recoverability = Some(Recoverability::RemoteMaybeAccepted.as_str().to_string());
+        self.mark_request_started()?;
+        Ok(client_request_id)
+    }
+
+    pub fn mark_request_started(&mut self) -> Result<(), AppError> {
+        if let Some(attempt) = self.current_attempt_mut() {
+            attempt.request_started_at = Some(now_iso());
+        }
+        self.persist_state()?;
+        test_fault::maybe_abort("request_started");
+        Ok(())
+    }
+
+    pub fn mark_response_headers(&mut self, headers: &HeaderMap) -> Result<(), AppError> {
+        if let Some(attempt) = self.current_attempt_mut() {
+            attempt.response_headers_received_at = Some(now_iso());
+            attempt.provider_request_id = normalize_provider_request_id(headers);
+        }
+        self.persist_state()
+    }
+
+    pub fn mark_response_body_completed(&mut self) -> Result<(), AppError> {
+        if let Some(attempt) = self.current_attempt_mut() {
+            attempt.response_body_completed_at = Some(now_iso());
+        }
+        self.persist_state()
+    }
+
+    pub fn spool_raw_response(&mut self, raw: &str) -> Result<(), AppError> {
+        let path = raw_response_path(&self.job_dir);
+        let part = path.with_extension("json.part");
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                AppError::new(
+                    "recovery_write_failed",
+                    "Unable to create recovery directory.",
+                )
+                .with_detail(
+                    json!({"path": parent.display().to_string(), "error": error.to_string()}),
+                )
+            })?;
+        }
+        {
+            let mut file = fs::File::create(&part).map_err(|error| {
+                AppError::new(
+                    "recovery_write_failed",
+                    "Unable to create raw response part.",
+                )
+                .with_detail(
+                    json!({"path": part.display().to_string(), "error": error.to_string()}),
+                )
+            })?;
+            file.write_all(raw.as_bytes()).map_err(|error| {
+                AppError::new(
+                    "recovery_write_failed",
+                    "Unable to write raw response part.",
+                )
+                .with_detail(
+                    json!({"path": part.display().to_string(), "error": error.to_string()}),
+                )
+            })?;
+            file.sync_all().map_err(|error| {
+                AppError::new(
+                    "recovery_write_failed",
+                    "Unable to flush raw response part.",
+                )
+                .with_detail(
+                    json!({"path": part.display().to_string(), "error": error.to_string()}),
+                )
+            })?;
+        }
+        test_fault::maybe_fail("raw_spool_rename")?;
+        fs::rename(&part, &path).map_err(|error| {
+            AppError::new("recovery_write_failed", "Unable to finalize raw response.")
+                .with_detail(json!({"from": part.display().to_string(), "to": path.display().to_string(), "error": error.to_string()}))
+        })?;
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+        test_fault::maybe_abort("raw_spool_renamed");
+        test_fault::maybe_fail("metadata_after_spool")?;
+        if let Some(attempt) = self.current_attempt_mut() {
+            attempt.raw_response_path = Some(path.display().to_string());
+        }
+        self.state.stage = Some(RecoveryStage::ResponseReceived.as_str().to_string());
+        self.state.recoverability = Some(Recoverability::LocalResponseCached.as_str().to_string());
+        self.persist_state()?;
+        test_fault::maybe_abort("response_received");
+        Ok(())
+    }
+
+    pub fn maybe_fail_materialize_start(&self) -> Result<(), AppError> {
+        test_fault::maybe_fail("materialize_start")
+    }
+
+    pub fn mark_stage(&mut self, stage: RecoveryStage) -> Result<(), AppError> {
+        self.state.stage = Some(stage.as_str().to_string());
+        if stage == RecoveryStage::Completed {
+            self.state.recoverability =
+                Some(Recoverability::LocalResponseCached.as_str().to_string());
+        }
+        self.persist_state()
+    }
+
+    pub fn finish_error(&mut self, stage: RecoveryStage, error: &AppError) -> Result<(), AppError> {
+        if let Some(attempt) = self.current_attempt_mut() {
+            attempt.stage_at_failure = Some(stage.as_str().to_string());
+            attempt.error_code = Some(error.code.clone());
+        }
+        if error
+            .status_code
+            .map(|status| (400..500).contains(&status))
+            .unwrap_or(false)
+        {
+            self.state.recoverability = Some(Recoverability::ProviderRejected.as_str().to_string());
+        } else {
+            self.state.recoverability = Some(
+                classify_from_state_and_evidence(
+                    &self.state,
+                    raw_response_path(&self.job_dir).is_file(),
+                )
+                .as_str()
+                .to_string(),
+            );
+        }
+        let error_value = json!({
+            "failed_at_stage": stage.as_str(),
+            "error_code": error.code,
+            "message": error.message,
+            "detail": error.detail,
+        });
+        let _ = atomic_write_json(&error_json_path(&self.job_dir), &error_value);
+        self.persist_state()
+    }
+}
+
+pub fn normalize_provider_request_id(headers: &HeaderMap) -> Option<String> {
+    for name in ["x-request-id", "request-id", "openai-request-id"] {
+        if let Some(value) = headers.get(name)
+            && let Ok(text) = value.to_str()
+            && !text.trim().is_empty()
+        {
+            return Some(text.trim().to_string());
+        }
+    }
+    None
+}
+
+pub fn materialize_openai_raw_response(
+    job_dir: &Path,
+    output_path: &Path,
+) -> Result<Vec<Value>, AppError> {
+    let raw_path = raw_response_path(job_dir);
+    let raw = fs::read_to_string(&raw_path).map_err(|error| {
+        AppError::new(
+            "raw_response_missing",
+            "Unable to read cached raw response for recovery.",
+        )
+        .with_detail(json!({"path": raw_path.display().to_string(), "error": error.to_string()}))
+    })?;
+    let payload: Value = serde_json::from_str(&raw).map_err(|error| {
+        AppError::new(
+            "invalid_json_response",
+            "Cached raw response is not valid JSON.",
+        )
+        .with_detail(json!({"path": raw_path.display().to_string(), "error": error.to_string()}))
+    })?;
+    let (image_bytes_list, _) = decode_openai_images(&payload)?;
+    save_images(output_path, &image_bytes_list)
+}
+
+pub fn raw_response_sha256(job_dir: &Path) -> Result<String, AppError> {
+    let path = raw_response_path(job_dir);
+    let bytes = fs::read(&path).map_err(|error| {
+        AppError::new(
+            "raw_response_missing",
+            "Unable to read cached raw response.",
+        )
+        .with_detail(json!({"path": path.display().to_string(), "error": error.to_string()}))
+    })?;
+    let digest = sha2::Sha256::digest(&bytes);
+    Ok(format!("{digest:x}"))
+}
+
+pub fn recovery_attempts_from_metadata(metadata: &Value) -> (Vec<Value>, usize) {
+    if let Some(job_dir) = recovery_job_dir(metadata)
+        && let Some(state) = load_recovery_state(&job_dir)
+    {
+        return (
+            state
+                .attempts
+                .into_iter()
+                .filter_map(|attempt| serde_json::to_value(attempt).ok())
+                .collect(),
+            state.attempts_truncated_count,
+        );
+    }
+    let attempts = metadata
+        .get("attempts")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let truncated = metadata
+        .get("attempts_truncated_count")
+        .and_then(Value::as_u64)
+        .unwrap_or(0) as usize;
+    (attempts, truncated)
+}
+
+pub fn build_recovery_descriptor(job: &Value) -> Value {
+    let metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    let job_dir = recovery_job_dir(&metadata);
+    let raw_present = job_dir
+        .as_deref()
+        .map(raw_response_path)
+        .map(|path| path.is_file())
+        .unwrap_or(false);
+    let raw_bytes = job_dir
+        .as_deref()
+        .map(raw_response_path)
+        .and_then(|path| fs::metadata(path).ok())
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    let recoverability = metadata
+        .get("recoverability")
+        .and_then(Value::as_str)
+        .and_then(Recoverability::from_str)
+        .unwrap_or_else(|| {
+            let state = job_dir.as_deref().and_then(load_recovery_state);
+            if let Some(state) = state {
+                classify_from_state_and_evidence(&state, raw_present)
+            } else {
+                classify_from_evidence(None, raw_present, None)
+            }
+        });
+    let job_id = job.get("id").and_then(Value::as_str).unwrap_or("");
+    let outputs_present = job
+        .get("outputs")
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let outputs_expected = metadata.get("n").and_then(Value::as_u64).unwrap_or(1);
+    let is_completed = job
+        .get("status")
+        .and_then(Value::as_str)
+        .map(|status| status == "completed")
+        .unwrap_or(false)
+        || metadata
+            .get("stage")
+            .and_then(Value::as_str)
+            .map(|stage| stage == RecoveryStage::Completed.as_str())
+            .unwrap_or(false);
+    let (primary_action, secondary_actions) = if is_completed {
+        (Value::Null, Vec::new())
+    } else {
+        recovery_actions(job_id, &recoverability)
+    };
+    json!({
+        "job_id": job_id,
+        "recoverability": recoverability.as_str(),
+        "primary_action": primary_action,
+        "secondary_actions": secondary_actions,
+        "evidence": {
+            "raw_response_present": raw_present,
+            "raw_response_bytes": raw_bytes,
+            "outputs_present": outputs_present,
+            "outputs_expected": outputs_expected
+        }
+    })
+}
+
+fn recovery_actions(job_id: &str, recoverability: &Recoverability) -> (Value, Vec<Value>) {
+    let endpoint = format!("/jobs/{job_id}/resume");
+    let continue_save = json!({
+        "id": "continue_save",
+        "label": "继续完成",
+        "endpoint": endpoint,
+        "billable": false,
+        "explanation": "已收到模型响应，可在不重新生成的前提下完成本地保存。"
+    });
+    let resubmit = json!({
+        "id": "resubmit",
+        "label": "重新生成",
+        "endpoint": endpoint,
+        "billable": true,
+        "estimated_cost_label": Value::Null,
+        "warning": "将再次调用 API"
+    });
+    match recoverability {
+        Recoverability::LocalResponseCached => (continue_save, vec![resubmit]),
+        Recoverability::NeverDispatched => (resubmit, Vec::new()),
+        Recoverability::RemoteMaybeAccepted => (
+            json!({
+                "id": "resubmit",
+                "label": "重新生成",
+                "endpoint": endpoint,
+                "billable": true,
+                "estimated_cost_label": Value::Null,
+                "warning": "上次请求可能已经被服务端接收；重新生成将再次调用 API"
+            }),
+            Vec::new(),
+        ),
+        Recoverability::LocalRecoveryUnavailable => (
+            Value::Null,
+            vec![json!({
+                "id": "resubmit",
+                "label": "重新生成",
+                "endpoint": endpoint,
+                "billable": true,
+                "warning": "完整响应曾到达，但恢复源未保存成功；重新生成会再次调用 API"
+            })],
+        ),
+        Recoverability::UserCancelled => (Value::Null, vec![resubmit]),
+        _ => (Value::Null, Vec::new()),
+    }
+}
+
+pub fn mark_interrupted_jobs_on_startup() -> Result<Vec<Value>, AppError> {
+    let jobs = list_active_history_jobs()?;
+    let mut interrupted = Vec::new();
+    for mut job in jobs {
+        let metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+        let Some(job_dir) = recovery_job_dir(&metadata) else {
+            continue;
+        };
+        let mut merged = merge_recovery_metadata(metadata, &job_dir);
+        if let Value::Object(map) = &mut merged {
+            map.insert("interrupted_reason".to_string(), json!("process_killed"));
+            if !map.contains_key("recoverability") {
+                let state = load_recovery_state(&job_dir);
+                let recoverability = state
+                    .as_ref()
+                    .map(|state| {
+                        classify_from_state_and_evidence(
+                            state,
+                            raw_response_path(&job_dir).is_file(),
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        classify_from_evidence(None, raw_response_path(&job_dir).is_file(), None)
+                    });
+                map.insert("recoverability".to_string(), json!(recoverability.as_str()));
+            }
+        }
+        let id = job
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let command = job
+            .get("command")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let provider = job
+            .get("provider")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let created_at = job
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let output_path = job
+            .get("output_path")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+        upsert_history_job(
+            &id,
+            &command,
+            &provider,
+            "failed",
+            output_path.as_deref().map(Path::new),
+            Some(&created_at),
+            merged.clone(),
+        )?;
+        job["status"] = json!("failed");
+        job["metadata"] = merged;
+        interrupted.push(build_recovery_descriptor(&job));
+    }
+    Ok(interrupted)
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub mod test_fault {
+    use super::*;
+
+    #[derive(Default)]
+    struct FaultState {
+        fail_at: Option<String>,
+        kill_at: Option<String>,
+        provider_attempts: BTreeMap<String, u64>,
+    }
+
+    static STATE: OnceLock<Mutex<FaultState>> = OnceLock::new();
+
+    fn state() -> &'static Mutex<FaultState> {
+        STATE.get_or_init(|| Mutex::new(FaultState::default()))
+    }
+
+    pub fn set_faults(fail_at: Option<String>, kill_at: Option<String>) {
+        if let Ok(mut state) = state().lock() {
+            state.fail_at = fail_at;
+            state.kill_at = kill_at;
+        }
+    }
+
+    pub fn faults_json() -> Value {
+        if let Ok(state) = state().lock() {
+            return json!({
+                "fail_at": state.fail_at,
+                "kill_at": state.kill_at,
+            });
+        }
+        json!({})
+    }
+
+    pub fn maybe_fail(point: &str) -> Result<(), AppError> {
+        let matched = state()
+            .lock()
+            .ok()
+            .and_then(|state| state.fail_at.clone())
+            .as_deref()
+            == Some(point);
+        if matched {
+            return Err(AppError::new(
+                "recovery_fault_injected",
+                format!("Injected recovery failure at {point}."),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn maybe_abort(point: &str) {
+        let matched = state()
+            .lock()
+            .ok()
+            .and_then(|state| state.kill_at.clone())
+            .as_deref()
+            == Some(point);
+        if matched {
+            std::process::abort();
+        }
+    }
+
+    pub fn record_provider_http_attempt(job_id: &str) {
+        if let Ok(mut state) = state().lock() {
+            *state
+                .provider_attempts
+                .entry(job_id.to_string())
+                .or_insert(0) += 1;
+        }
+    }
+
+    pub fn provider_http_attempts(job_id: &str) -> u64 {
+        state()
+            .lock()
+            .ok()
+            .and_then(|state| state.provider_attempts.get(job_id).copied())
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(not(feature = "recovery-fault-injection"))]
+pub mod test_fault {
+    use super::*;
+
+    pub fn set_faults(_fail_at: Option<String>, _kill_at: Option<String>) {}
+    pub fn faults_json() -> Value {
+        json!({})
+    }
+    pub fn maybe_fail(_point: &str) -> Result<(), AppError> {
+        Ok(())
+    }
+    pub fn maybe_abort(_point: &str) {}
+    pub fn record_provider_http_attempt(_job_id: &str) {}
+    pub fn provider_http_attempts(_job_id: &str) -> u64 {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_omits_attempt_details_and_actions_for_completed_jobs() {
+        let job = json!({
+            "id": "job-1",
+            "status": "completed",
+            "outputs": [{"path": "/tmp/out.png"}],
+            "metadata": {
+                "stage": "completed",
+                "recoverability": "recoverable.local_response_cached",
+                "n": 1,
+                "attempts": [{
+                    "client_request_id": "client-secret",
+                    "provider_request_id": "provider-secret",
+                    "raw_response_path": "/tmp/raw_response.json"
+                }],
+                "attempts_truncated_count": 0
+            }
+        });
+
+        let descriptor = build_recovery_descriptor(&job);
+
+        assert!(descriptor.get("primary_action").is_some_and(Value::is_null));
+        assert_eq!(
+            descriptor
+                .get("secondary_actions")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(0)
+        );
+        let evidence = descriptor
+            .get("evidence")
+            .and_then(Value::as_object)
+            .unwrap();
+        assert!(evidence.contains_key("raw_response_present"));
+        assert!(evidence.contains_key("raw_response_bytes"));
+        assert!(evidence.contains_key("outputs_present"));
+        assert!(evidence.contains_key("outputs_expected"));
+        assert!(!evidence.contains_key("last_attempt"));
+        assert!(!evidence.contains_key("stage_reached"));
+    }
+
+    #[test]
+    fn remote_maybe_accepted_resubmit_warns_about_possible_server_acceptance() {
+        let job = json!({
+            "id": "job-2",
+            "status": "failed",
+            "outputs": [],
+            "metadata": {
+                "recoverability": "ambiguous.remote_maybe_accepted",
+                "n": 1
+            }
+        });
+
+        let descriptor = build_recovery_descriptor(&job);
+        let primary = descriptor.get("primary_action").unwrap();
+
+        assert_eq!(primary.get("id").and_then(Value::as_str), Some("resubmit"));
+        assert_eq!(primary.get("billable").and_then(Value::as_bool), Some(true));
+        assert!(
+            primary
+                .get("warning")
+                .and_then(Value::as_str)
+                .is_some_and(|warning| warning.contains("上次请求可能已经被服务端接收"))
+        );
+    }
+}

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -567,6 +567,116 @@ pub fn raw_response_sha256(job_dir: &Path) -> Result<String, AppError> {
     Ok(format!("{digest:x}"))
 }
 
+pub fn batch_recovery_job_id(parent_job_id: &str, index: u8) -> String {
+    format!("{parent_job_id}-part-{}", index + 1)
+}
+
+pub fn batch_recovery_job_dir(parent_dir: &Path, index: u8) -> PathBuf {
+    parent_dir.join(format!("recovery-part-{}", index + 1))
+}
+
+pub fn write_batch_recovery_summary(
+    parent_job_id: &str,
+    parent_dir: &Path,
+    child_dirs: &[PathBuf],
+    outputs_present: usize,
+    failures: usize,
+) -> Result<(), AppError> {
+    let mut attempts = Vec::new();
+    let mut attempts_truncated_count = 0usize;
+    let mut child_recoverabilities = Vec::new();
+    let mut any_body_completed = false;
+
+    for child_dir in child_dirs {
+        let Some(state) = load_recovery_state(child_dir) else {
+            continue;
+        };
+        any_body_completed |= state
+            .attempts
+            .iter()
+            .any(|attempt| attempt.response_body_completed_at.is_some());
+        let recoverability = state
+            .recoverability
+            .as_deref()
+            .and_then(Recoverability::from_str)
+            .unwrap_or_else(|| {
+                classify_from_state_and_evidence(&state, raw_response_path(child_dir).is_file())
+            });
+        child_recoverabilities.push(recoverability);
+        attempts_truncated_count += state.attempts_truncated_count;
+        for attempt in state.attempts {
+            if attempts.len() >= RECOVERY_ATTEMPTS_LIMIT {
+                attempts.remove(0);
+                attempts_truncated_count += 1;
+            }
+            attempts.push(attempt);
+        }
+    }
+
+    if attempts.is_empty() && child_recoverabilities.is_empty() {
+        return Ok(());
+    }
+
+    let recoverability = batch_recoverability(&child_recoverabilities, outputs_present, failures);
+    let stage = if failures == 0 {
+        RecoveryStage::Completed
+    } else if outputs_present > 0 {
+        RecoveryStage::Materialized
+    } else if any_body_completed {
+        RecoveryStage::ResponseReceived
+    } else {
+        RecoveryStage::Submitted
+    };
+    let state = RecoveryState {
+        job_id: Some(parent_job_id.to_string()),
+        job_dir: Some(parent_dir.display().to_string()),
+        stage: Some(stage.as_str().to_string()),
+        recoverability: Some(recoverability.as_str().to_string()),
+        attempts,
+        attempts_truncated_count,
+        interrupted_reason: None,
+    };
+    atomic_write_json(
+        &recovery_state_path(parent_dir),
+        &serde_json::to_value(state).unwrap_or_else(|_| json!({})),
+    )
+}
+
+fn batch_recoverability(
+    child_recoverabilities: &[Recoverability],
+    outputs_present: usize,
+    failures: usize,
+) -> Recoverability {
+    if failures > 0 && outputs_present > 0 {
+        return Recoverability::PartialOutputs;
+    }
+    if failures == 0 {
+        return child_recoverabilities
+            .iter()
+            .find(|recoverability| matches!(recoverability, Recoverability::LocalResponseCached))
+            .cloned()
+            .unwrap_or(Recoverability::NeverDispatched);
+    }
+    if child_recoverabilities.iter().any(|recoverability| {
+        matches!(
+            recoverability,
+            Recoverability::LocalResponseCached
+                | Recoverability::RemoteMaybeAccepted
+                | Recoverability::LocalRecoveryUnavailable
+                | Recoverability::RemoteInProgress
+        )
+    }) {
+        return Recoverability::RemoteMaybeAccepted;
+    }
+    if child_recoverabilities
+        .iter()
+        .any(|recoverability| matches!(recoverability, Recoverability::ProviderRejected))
+    {
+        return Recoverability::ProviderRejected;
+    }
+    Recoverability::NeverDispatched
+}
+
 pub fn recovery_attempts_from_metadata(metadata: &Value) -> (Vec<Value>, usize) {
     if let Some(job_dir) = recovery_job_dir(metadata)
         && let Some(state) = load_recovery_state(&job_dir)

--- a/crates/gpt-image-2-core/src/request_commands.rs
+++ b/crates/gpt-image-2-core/src/request_commands.rs
@@ -144,9 +144,9 @@ pub(crate) fn run_request_create_openai(
     let (payload, retry_count) =
         execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
             if args.request_operation == RequestOperation::Edit {
-                request_openai_edit_once(&endpoint, &auth_state, &body, logger)
+                request_openai_edit_once(&endpoint, &auth_state, &body, logger, None)
             } else {
-                request_openai_images_once(&endpoint, &auth_state, &body, logger)
+                request_openai_images_once(&endpoint, &auth_state, &body, logger, None)
             }
         })?;
     let (image_bytes_list, revised_prompts) = decode_openai_images(&payload)?;

--- a/crates/gpt-image-2-core/src/runtime_image_args.rs
+++ b/crates/gpt-image-2-core/src/runtime_image_args.rs
@@ -38,6 +38,15 @@ pub fn push_provider_arg(args: &mut Vec<String>, provider: Option<&str>) {
 }
 
 pub fn generate_args(request: &GenerateRequest, out: &Path, include_n: bool) -> Vec<String> {
+    generate_args_with_recovery(request, out, include_n, None)
+}
+
+pub fn generate_args_with_recovery(
+    request: &GenerateRequest,
+    out: &Path,
+    include_n: bool,
+    recovery: Option<(&str, &Path)>,
+) -> Vec<String> {
     let mut args = Vec::new();
     push_provider_arg(&mut args, request.provider.as_deref());
     args.extend([
@@ -61,6 +70,12 @@ pub fn generate_args(request: &GenerateRequest, out: &Path, include_n: bool) -> 
         args.push("--compression".to_string());
         args.push(compression.to_string());
     }
+    if let Some((job_id, job_dir)) = recovery {
+        args.push("--recovery-job-id".to_string());
+        args.push(job_id.to_string());
+        args.push("--recovery-job-dir".to_string());
+        args.push(job_dir.display().to_string());
+    }
     args
 }
 
@@ -70,6 +85,17 @@ pub fn edit_args(
     mask_path: Option<&Path>,
     out: &Path,
     include_n: bool,
+) -> Vec<String> {
+    edit_args_with_recovery(request, ref_paths, mask_path, out, include_n, None)
+}
+
+pub fn edit_args_with_recovery(
+    request: &EditRequest,
+    ref_paths: &[PathBuf],
+    mask_path: Option<&Path>,
+    out: &Path,
+    include_n: bool,
+    recovery: Option<(&str, &Path)>,
 ) -> Vec<String> {
     let mut args = Vec::new();
     push_provider_arg(&mut args, request.provider.as_deref());
@@ -106,6 +132,12 @@ pub fn edit_args(
     if let Some(compression) = request.compression {
         args.push("--compression".to_string());
         args.push(compression.to_string());
+    }
+    if let Some((job_id, job_dir)) = recovery {
+        args.push("--recovery-job-id".to_string());
+        args.push(job_id.to_string());
+        args.push("--recovery-job-dir".to_string());
+        args.push(job_dir.display().to_string());
     }
     args
 }

--- a/crates/gpt-image-2-core/src/transparent/commands/command_handlers.rs
+++ b/crates/gpt-image-2-core/src/transparent/commands/command_handlers.rs
@@ -52,6 +52,8 @@ pub(crate) fn run_transparent_generate(
         output_compression: args.output_compression,
         n: None,
         moderation: args.moderation,
+        recovery_job_id: None,
+        recovery_job_dir: None,
     };
     validate_provider_specific_image_args(&selection, &shared, None, None)?;
     let source_generation = generate_source_image(cli, &selection, &shared)?;

--- a/crates/gpt-image-2-core/src/transparent/commands/source_generation.rs
+++ b/crates/gpt-image-2-core/src/transparent/commands/source_generation.rs
@@ -43,7 +43,7 @@ pub(crate) fn generate_openai_source_image(
     let mut logger = JsonEventLogger::new(cli.json_events);
     let (payload, retry_count) =
         execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
-            request_openai_images_once(&endpoint, &auth_state, &body, logger)
+            request_openai_images_once(&endpoint, &auth_state, &body, logger, None)
         })?;
     let (image_bytes_list, revised_prompts) = decode_openai_images(&payload)?;
     if image_bytes_list.is_empty() {

--- a/crates/gpt-image-2-web/Cargo.toml
+++ b/crates/gpt-image-2-web/Cargo.toml
@@ -20,3 +20,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["fs", "macros", "net", "rt-multi-thread"] }
 tower-http = { version = "0.6.7", features = ["fs"] }
+
+[features]
+recovery-fault-injection = ["gpt-image-2-core/recovery-fault-injection"]

--- a/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
@@ -95,7 +95,7 @@ pub(crate) fn run_edit_request(
             "out.{}",
             output_extension(request.format.as_deref())
         ));
-        cli_json_result(&edit_args(
+        cli_json_result(&edit_args_with_recovery(
             &request,
             &ref_paths,
             if edit_region_mode == "native-mask" {
@@ -105,6 +105,7 @@ pub(crate) fn run_edit_request(
             },
             &out,
             provider_supports_n,
+            Some((&fallback_id, &dir)),
         ))?
     } else {
         let arg_sets = (0..output_count)

--- a/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
@@ -108,9 +108,19 @@ pub(crate) fn run_edit_request(
             Some((&fallback_id, &dir)),
         ))?
     } else {
-        let arg_sets = (0..output_count)
+        let recovery_targets = (0..output_count)
             .map(|index| {
-                edit_args(
+                (
+                    batch_recovery_job_id(&fallback_id, index),
+                    batch_recovery_job_dir(&dir, index),
+                )
+            })
+            .collect::<Vec<_>>();
+        let arg_sets = recovery_targets
+            .iter()
+            .enumerate()
+            .map(|(index, (recovery_job_id, recovery_job_dir))| {
+                edit_args_with_recovery(
                     &request,
                     &ref_paths,
                     if edit_region_mode == "native-mask" {
@@ -118,8 +128,9 @@ pub(crate) fn run_edit_request(
                     } else {
                         None
                     },
-                    &batch_output_path(&dir, request.format.as_deref(), index),
+                    &batch_output_path(&dir, request.format.as_deref(), index as u8),
                     false,
+                    Some((recovery_job_id.as_str(), recovery_job_dir.as_path())),
                 )
             })
             .collect::<Vec<_>>();
@@ -134,12 +145,35 @@ pub(crate) fn run_edit_request(
                 apply_partial_output(ctx, &mut list, index, payload);
             }
         });
-        merge_batch_payloads(
+        let merged = merge_batch_payloads(
             "images edit",
             output_count.into(),
             batch.payloads,
             batch.errors,
+        );
+        let outputs_present = merged
+            .get("output")
+            .and_then(|output| output.get("files"))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0);
+        let failures = merged
+            .get("batch")
+            .and_then(|batch| batch.get("failure_count"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        write_batch_recovery_summary(
+            &fallback_id,
+            &dir,
+            &recovery_targets
+                .iter()
+                .map(|(_, recovery_dir)| recovery_dir.clone())
+                .collect::<Vec<_>>(),
+            outputs_present,
+            failures,
         )
+        .map_err(app_error)?;
+        merged
     };
     let request_meta = edit_request_metadata(&request);
     let job = job_from_payload(&payload, &fallback_id, "images edit", request_meta);

--- a/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
@@ -28,12 +28,23 @@ pub(crate) fn run_generate_request(
             Some((&fallback_id, &dir)),
         ))?
     } else {
-        let arg_sets = (0..output_count)
+        let recovery_targets = (0..output_count)
             .map(|index| {
-                generate_args(
+                (
+                    batch_recovery_job_id(&fallback_id, index),
+                    batch_recovery_job_dir(&dir, index),
+                )
+            })
+            .collect::<Vec<_>>();
+        let arg_sets = recovery_targets
+            .iter()
+            .enumerate()
+            .map(|(index, (recovery_job_id, recovery_job_dir))| {
+                generate_args_with_recovery(
                     &request,
-                    &batch_output_path(&dir, request.format.as_deref(), index),
+                    &batch_output_path(&dir, request.format.as_deref(), index as u8),
                     false,
+                    Some((recovery_job_id.as_str(), recovery_job_dir.as_path())),
                 )
             })
             .collect::<Vec<_>>();
@@ -48,12 +59,35 @@ pub(crate) fn run_generate_request(
                 apply_partial_output(ctx, &mut list, index, payload);
             }
         });
-        merge_batch_payloads(
+        let merged = merge_batch_payloads(
             "images generate",
             output_count.into(),
             batch.payloads,
             batch.errors,
+        );
+        let outputs_present = merged
+            .get("output")
+            .and_then(|output| output.get("files"))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or(0);
+        let failures = merged
+            .get("batch")
+            .and_then(|batch| batch.get("failure_count"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0) as usize;
+        write_batch_recovery_summary(
+            &fallback_id,
+            &dir,
+            &recovery_targets
+                .iter()
+                .map(|(_, recovery_dir)| recovery_dir.clone())
+                .collect::<Vec<_>>(),
+            outputs_present,
+            failures,
         )
+        .map_err(app_error)?;
+        merged
     };
     let request_meta = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
     let job = job_from_payload(&payload, &fallback_id, "images generate", request_meta);

--- a/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
@@ -21,7 +21,12 @@ pub(crate) fn run_generate_request(
             "out.{}",
             output_extension(request.format.as_deref())
         ));
-        cli_json_result(&generate_args(&request, &out, provider_supports_n))?
+        cli_json_result(&generate_args_with_recovery(
+            &request,
+            &out,
+            provider_supports_n,
+            Some((&fallback_id, &dir)),
+        ))?
     } else {
         let arg_sets = (0..output_count)
             .map(|index| {

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -19,10 +19,10 @@ use gpt_image_2_core::{
     AppConfig, CONFIG_DIR_NAME, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions,
     KEYCHAIN_SERVICE, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig,
     StorageConfig, StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    annotate_recovery_job_dir, batch_output_path, build_recovery_descriptor, default_config_path,
-    default_keychain_account, delete_history_job, dispatch_task_notifications, edit_args,
-    edit_args_with_recovery, generate_args, generate_args_with_recovery, history_db_path,
-    initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
+    annotate_recovery_job_dir, batch_output_path, batch_recovery_job_dir, batch_recovery_job_id,
+    build_recovery_descriptor, default_config_path, default_keychain_account, delete_history_job,
+    dispatch_task_notifications, edit_args_with_recovery, generate_args_with_recovery,
+    history_db_path, initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
     list_active_history_jobs, list_history_jobs_page, load_app_config,
     mark_interrupted_jobs_on_startup, materialize_openai_raw_response, merge_recovery_metadata,
     notification_status_allowed, output_extension, preserve_notification_secrets,
@@ -31,7 +31,7 @@ use gpt_image_2_core::{
     read_job_output_from_storage_with_options, read_keychain_secret, recovery_job_dir,
     redact_app_config, requested_n, run_json, save_app_config, shared_config_dir, show_history_job,
     test_fault, test_storage_target, upload_job_outputs_to_storage, upsert_history_job,
-    write_keychain_secret,
+    write_batch_recovery_summary, write_keychain_secret,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -19,16 +19,19 @@ use gpt_image_2_core::{
     AppConfig, CONFIG_DIR_NAME, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions,
     KEYCHAIN_SERVICE, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig,
     StorageConfig, StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    batch_output_path, default_config_path, default_keychain_account, delete_history_job,
-    dispatch_task_notifications, edit_args, generate_args, history_db_path,
+    annotate_recovery_job_dir, batch_output_path, build_recovery_descriptor, default_config_path,
+    default_keychain_account, delete_history_job, dispatch_task_notifications, edit_args,
+    edit_args_with_recovery, generate_args, generate_args_with_recovery, history_db_path,
     initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
-    list_active_history_jobs, list_history_jobs_page, load_app_config, notification_status_allowed,
-    output_extension, preserve_notification_secrets, preserve_storage_secrets,
-    product_app_data_dir, product_default_export_dir, product_default_export_dirs,
-    product_result_library_dir, product_storage_fallback_dir,
-    read_job_output_from_storage_with_options, read_keychain_secret, redact_app_config,
-    requested_n, run_json, save_app_config, shared_config_dir, show_history_job,
-    test_storage_target, upload_job_outputs_to_storage, upsert_history_job, write_keychain_secret,
+    list_active_history_jobs, list_history_jobs_page, load_app_config,
+    mark_interrupted_jobs_on_startup, materialize_openai_raw_response, merge_recovery_metadata,
+    notification_status_allowed, output_extension, preserve_notification_secrets,
+    preserve_storage_secrets, product_app_data_dir, product_default_export_dir,
+    product_default_export_dirs, product_result_library_dir, product_storage_fallback_dir,
+    read_job_output_from_storage_with_options, read_keychain_secret, recovery_job_dir,
+    redact_app_config, requested_n, run_json, save_app_config, shared_config_dir, show_history_job,
+    test_fault, test_storage_target, upload_job_outputs_to_storage, upsert_history_job,
+    write_keychain_secret,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -42,6 +45,7 @@ mod job_execution;
 mod provider_config;
 mod queue_api;
 mod queue_workers;
+mod recovery_api;
 mod retry_api;
 mod server;
 mod support;
@@ -55,6 +59,7 @@ pub(crate) use job_execution::*;
 pub(crate) use provider_config::*;
 pub(crate) use queue_api::*;
 pub(crate) use queue_workers::*;
+pub(crate) use recovery_api::*;
 pub(crate) use retry_api::*;
 pub(crate) use server::*;
 pub(crate) use support::*;
@@ -71,6 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .into());
     }
+    let _ = mark_interrupted_jobs_on_startup();
     let static_files = ServeDir::new(&settings.static_dir)
         .not_found_service(ServeFile::new(settings.static_dir.join("index.html")));
     let app = Router::new()

--- a/crates/gpt-image-2-web/src/queue_api.rs
+++ b/crates/gpt-image-2-web/src/queue_api.rs
@@ -93,7 +93,10 @@ pub(crate) async fn enqueue_generate_image(
     requested_n(request.n).map_err(ApiError::bad_request)?;
     let (id, dir) = unique_job_dir().map_err(ApiError::internal)?;
     let provider = selected_provider_name(request.provider.as_deref());
-    let metadata = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
+    let metadata = annotate_recovery_job_dir(
+        serde_json::to_value(&request).unwrap_or_else(|_| json!({})),
+        &dir,
+    );
     enqueue_job(
         state,
         QueuedJob {
@@ -125,7 +128,7 @@ pub(crate) async fn enqueue_edit_image(
     requested_n(request.n).map_err(ApiError::bad_request)?;
     let (id, dir) = unique_job_dir().map_err(ApiError::internal)?;
     let provider = selected_provider_name(request.provider.as_deref());
-    let metadata = edit_request_metadata(&request);
+    let metadata = annotate_recovery_job_dir(edit_request_metadata(&request), &dir);
     enqueue_job(
         state,
         QueuedJob {

--- a/crates/gpt-image-2-web/src/queue_workers.rs
+++ b/crates/gpt-image-2-web/src/queue_workers.rs
@@ -3,6 +3,7 @@
 use super::*;
 
 pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> Value {
+    let metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     let payload = response.get("payload").unwrap_or(response);
     let provider = payload
         .get("provider")
@@ -35,7 +36,7 @@ pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> V
             .and_then(Value::as_str)
             .unwrap_or("completed"),
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path,
         outputs,
         error: payload.get("error").cloned().unwrap_or(Value::Null),
@@ -43,6 +44,7 @@ pub(crate) fn completed_job_for_queue(queued: &QueuedJob, response: &Value) -> V
 }
 
 pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> Value {
+    let metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     let payload = response.get("payload").unwrap_or(response);
     let provider = payload
         .get("provider")
@@ -72,7 +74,7 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
         provider,
         status: "uploading",
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path,
         outputs,
         error: Value::Null,
@@ -80,13 +82,17 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
 }
 
 pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value {
+    let mut metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
+    if let Value::Object(map) = &mut metadata {
+        map.insert("error".to_string(), json!({"message": message.clone()}));
+    }
     job_snapshot(JobSnapshotInput {
         id: &queued.id,
         command: &queued.command,
         provider: &queued.provider,
         status: "failed",
         created_at: &queued.created_at,
-        metadata: queued.metadata.clone(),
+        metadata,
         output_path: None,
         outputs: json!([]),
         error: json!({"message": message}),

--- a/crates/gpt-image-2-web/src/recovery_api.rs
+++ b/crates/gpt-image-2-web/src/recovery_api.rs
@@ -1,0 +1,198 @@
+#![allow(unused_imports)]
+
+use super::*;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ResumeRequest {
+    pub(crate) action: String,
+}
+
+pub(crate) async fn job_recovery(Path(job_id): Path<String>) -> ApiResult {
+    let job = show_history_job(&job_id)
+        .map_err(app_error)
+        .map_err(ApiError::not_found)?;
+    Ok(Json(build_recovery_descriptor(&job)))
+}
+
+pub(crate) async fn interrupted_jobs() -> ApiResult {
+    let jobs = list_history_jobs_page(HistoryListOptions {
+        status: Some("failed".to_string()),
+        ..HistoryListOptions::default()
+    })
+    .map_err(app_error)
+    .map_err(ApiError::internal)?
+    .jobs
+    .into_iter()
+    .filter(|job| {
+        job.get("metadata")
+            .and_then(|metadata| metadata.get("interrupted_reason"))
+            .and_then(Value::as_str)
+            .is_some()
+    })
+    .map(|job| build_recovery_descriptor(&job))
+    .collect::<Vec<_>>();
+    Ok(Json(json!({ "jobs": jobs })))
+}
+
+pub(crate) async fn resume_job(
+    Path(job_id): Path<String>,
+    State(state): State<JobQueueState>,
+    Json(body): Json<ResumeRequest>,
+) -> ApiResult {
+    match body.action.as_str() {
+        "continue_save" => continue_save_job(&job_id)
+            .map(Json)
+            .map_err(ApiError::internal),
+        "resubmit" => retry_job(Path(job_id), State(state)).await,
+        "discard" => discard_job(&job_id).map(Json).map_err(ApiError::internal),
+        _ => Err(ApiError::bad_request("Unsupported recovery action.")),
+    }
+}
+
+pub(crate) fn continue_save_job(job_id: &str) -> Result<Value, String> {
+    let job = show_history_job(job_id).map_err(app_error)?;
+    let metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    let job_dir =
+        recovery_job_dir(&metadata).ok_or_else(|| "Recovery job dir is missing.".to_string())?;
+    let format = metadata.get("format").and_then(Value::as_str);
+    let output_path = job_dir.join(format!("out.{}", output_extension(format)));
+    let before_attempts = test_fault::provider_http_attempts(job_id);
+    let saved_files = materialize_openai_raw_response(&job_dir, &output_path).map_err(app_error)?;
+    let after_attempts = test_fault::provider_http_attempts(job_id);
+    if after_attempts != before_attempts {
+        return Err("continue_save attempted a provider HTTP request.".to_string());
+    }
+    let mut recovery_ctx =
+        gpt_image_2_core::RecoveryContext::new(job_id.to_string(), job_dir.clone())
+            .map_err(app_error)?;
+    let _ = recovery_ctx.mark_stage(gpt_image_2_core::RecoveryStage::Materialized);
+    let _ = recovery_ctx.mark_stage(gpt_image_2_core::RecoveryStage::Completed);
+    let output_path = saved_files
+        .first()
+        .and_then(|file| file.get("path"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let mut merged_metadata = merge_recovery_metadata(metadata, &job_dir);
+    if let Value::Object(map) = &mut merged_metadata {
+        map.remove("error");
+        map.insert("stage".to_string(), json!("completed"));
+        map.insert(
+            "recoverability".to_string(),
+            json!("recoverable.local_response_cached"),
+        );
+    }
+    let completed = job_snapshot(JobSnapshotInput {
+        id: job_id,
+        command: job
+            .get("command")
+            .and_then(Value::as_str)
+            .unwrap_or("images generate"),
+        provider: job
+            .get("provider")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown"),
+        status: "completed",
+        created_at: job
+            .get("created_at")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        metadata: merged_metadata,
+        output_path,
+        outputs: json!(saved_files),
+        error: Value::Null,
+    });
+    let notify_job = upload_completed_job_outputs(&completed)?;
+    Ok(json!({
+        "job_id": job_id,
+        "job": notify_job,
+        "events": [{
+            "seq": 1,
+            "kind": "local",
+            "type": "job.completed",
+            "data": completed_event_data(&notify_job),
+        }],
+        "recovered": true,
+    }))
+}
+
+pub(crate) fn discard_job(job_id: &str) -> Result<Value, String> {
+    let mut job = show_history_job(job_id).map_err(app_error)?;
+    let mut metadata = job.get("metadata").cloned().unwrap_or_else(|| json!({}));
+    if let Value::Object(map) = &mut metadata {
+        map.insert("discarded_at".to_string(), json!(chrono_like_now()));
+    }
+    let output_path = job
+        .get("output_path")
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    upsert_history_job(
+        job_id,
+        job.get("command")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        job.get("provider")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+        "failed",
+        output_path.as_deref(),
+        Some(
+            job.get("created_at")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        ),
+        metadata.clone(),
+    )
+    .map_err(app_error)?;
+    job["metadata"] = metadata;
+    Ok(json!({ "job_id": job_id, "job": job, "discarded": true }))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+#[derive(Debug, Deserialize)]
+pub(crate) struct FaultRequest {
+    #[serde(default)]
+    pub(crate) fail_at: Option<String>,
+    #[serde(default)]
+    pub(crate) kill_at: Option<String>,
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub(crate) async fn set_test_faults(Json(body): Json<FaultRequest>) -> ApiResult {
+    test_fault::set_faults(body.fail_at, body.kill_at);
+    Ok(Json(test_fault::faults_json()))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub(crate) async fn test_provider_http_attempts(Path(job_id): Path<String>) -> ApiResult {
+    Ok(Json(json!({
+        "total": test_fault::provider_http_attempts(&job_id),
+    })))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub(crate) async fn test_job_attempts(Path(job_id): Path<String>) -> ApiResult {
+    let job = show_history_job(&job_id)
+        .map_err(app_error)
+        .map_err(ApiError::not_found)?;
+    let (attempts, attempts_truncated_count) = gpt_image_2_core::recovery_attempts_from_metadata(
+        job.get("metadata").unwrap_or(&Value::Null),
+    );
+    Ok(Json(json!({
+        "attempts": attempts,
+        "attempts_truncated_count": attempts_truncated_count,
+    })))
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub(crate) async fn test_raw_response_hash(Path(job_id): Path<String>) -> ApiResult {
+    let job = show_history_job(&job_id)
+        .map_err(app_error)
+        .map_err(ApiError::not_found)?;
+    let metadata = job.get("metadata").cloned().unwrap_or(Value::Null);
+    let job_dir = recovery_job_dir(&metadata)
+        .ok_or_else(|| ApiError::not_found("Recovery job dir is missing."))?;
+    let sha256 = gpt_image_2_core::raw_response_sha256(&job_dir)
+        .map_err(app_error)
+        .map_err(ApiError::internal)?;
+    Ok(Json(json!({ "sha256": sha256 })))
+}

--- a/crates/gpt-image-2-web/src/retry_api.rs
+++ b/crates/gpt-image-2-web/src/retry_api.rs
@@ -159,7 +159,10 @@ pub(crate) async fn retry_job(
             requested_n(request.n).map_err(ApiError::bad_request)?;
             let (id, dir) = unique_job_dir().map_err(ApiError::internal)?;
             let provider = selected_provider_name(request.provider.as_deref());
-            let metadata = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));
+            let metadata = annotate_recovery_job_dir(
+                serde_json::to_value(&request).unwrap_or_else(|_| json!({})),
+                &dir,
+            );
             enqueue_job(
                 state,
                 QueuedJob {
@@ -185,7 +188,7 @@ pub(crate) async fn retry_job(
             requested_n(request.n).map_err(ApiError::bad_request)?;
             let (id, dir) = unique_job_dir().map_err(ApiError::internal)?;
             let provider = selected_provider_name(request.provider.as_deref());
-            let metadata = edit_request_metadata(&request);
+            let metadata = annotate_recovery_job_dir(edit_request_metadata(&request), &dir);
             enqueue_job(
                 state,
                 QueuedJob {

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -100,10 +100,34 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
         )
         .route("/jobs/{job_id}/cancel", post(cancel_job))
         .route("/jobs/{job_id}/retry", post(retry_job))
+        .route("/jobs/{job_id}/recovery", get(job_recovery))
+        .route("/jobs/{job_id}/resume", post(resume_job))
+        .route("/jobs/interrupted", get(interrupted_jobs))
+        .merge(test_router())
         .route("/queue", get(queue_status))
         .route("/queue/concurrency", post(set_queue_concurrency))
         .route("/images/generate", post(enqueue_generate_image))
         .route("/images/edit", post(enqueue_edit_image))
         .route("/files", get(file_response))
         .with_state(state)
+}
+
+#[cfg(feature = "recovery-fault-injection")]
+pub(crate) fn test_router() -> Router<JobQueueState> {
+    Router::new()
+        .route("/test/faults", post(set_test_faults))
+        .route(
+            "/test/jobs/{job_id}/provider-http-attempts",
+            get(test_provider_http_attempts),
+        )
+        .route("/test/jobs/{job_id}/attempts", get(test_job_attempts))
+        .route(
+            "/test/jobs/{job_id}/raw-response-hash",
+            get(test_raw_response_hash),
+        )
+}
+
+#[cfg(not(feature = "recovery-fault-injection"))]
+pub(crate) fn test_router() -> Router<JobQueueState> {
+    Router::new()
 }

--- a/docs/task-recovery-acceptance.md
+++ b/docs/task-recovery-acceptance.md
@@ -1,0 +1,406 @@
+# 任务恢复协议 V1 验收方案
+
+> Status: **Final v2** · 2026-05-16
+> 配套 [docs/task-recovery-design.md](./task-recovery-design.md)
+> 经 [issues#14](https://github.com/Wangnov/gpt-image-2-skill/issues/14) 完整对齐（含 Codex 三轮修正）
+
+## 1. 验收原则
+
+1. **三层 Tier 分工**：
+   - **Tier 1** 自动化集成测试 — V1 PR merge gate（每次 PR 必跑）
+   - **Tier 2** 真 DuckCoding + mitmproxy — release gate（发版前人工验收，**不卡 PR**）
+   - **Tier 3** 人工生产观察 — 发版后由用户主导
+2. **测试埋点用 cargo feature flag `recovery-fault-injection` 永久门控**，三层防泄漏
+3. **`continue_save` resume 阶段 `provider_http_attempts` delta = 0** 是验收硬阈值
+4. **稳定证明 `ambiguous` 用 deterministic local cutoff provider**，不依赖 mitm（mitm hook 时机不能精确切 wire-level body）
+5. **核心 descriptor 用 fixture 字节级 golden + 真实 e2e 用结构化等价**（mask 动态字段后比较）
+6. **门槛用 provider HTTP attempt 上限**，不写美元金额（价格/模型映射会变）
+
+## 2. 测试埋点契约（V1 PR 必带）
+
+### 2.1 cargo feature flag — core + app crate 双层
+
+```toml
+# crates/gpt-image-2-core/Cargo.toml
+[features]
+recovery-fault-injection = []
+
+# crates/gpt-image-2-web/Cargo.toml & apps/.../src-tauri/Cargo.toml
+[features]
+recovery-fault-injection = ["gpt-image-2-core/recovery-fault-injection"]
+```
+
+`gpt-image-2-core` 提供故障注入 primitive；`gpt-image-2-web` / Tauri crate 在同名 feature 下注册 `/test/*` route 或 Tauri test command。core 不暴露 route helper trait（route 是 transport 层职责）。
+
+### 2.2 三层防泄漏
+
+```rust
+// 编译期断言（防 release build 误启用）
+#[cfg(all(feature = "recovery-fault-injection", not(any(test, debug_assertions))))]
+compile_error!("recovery-fault-injection must not be enabled in release builds");
+```
+
+加上：
+- 所有 `/test/*` route 与 fault registry 完全 `#[cfg(feature = "recovery-fault-injection")]` 门控
+- CI smoke：release/default 构建的 binary `strings` 不应含 `RECOVERY_TEST_` 字面量
+- 自带运行时验证 case：default feature 下设置 fault 应**无效**
+
+### 2.3 故障注入点（最终命名）
+
+V1 必测 6 个点；通过 feature-gated `POST /test/faults` 运行时注册（不用 env var 因为已运行进程无法热更新 env）：
+
+```jsonc
+POST /test/faults
+{ "fail_at": "materialize_start" }   // 或 clear: { "fail_at": null }
+```
+
+V1 支持的 point：
+
+| Point | 注入位置 | 期望恢复分类 |
+|---|---|---|
+| `raw_spool_rename` | body 已读完，`.part → rename` 前抛 IoError | `terminal.local_recovery_unavailable` |
+| `materialize_start` | raw_response 已 rename，开始解析/写图前 | `recoverable.local_response_cached` |
+| `metadata_after_spool` | raw_response 已 rename，但 metadata 写入失败 | 启动扫描必须靠**文件证据**恢复 → `recoverable.local_response_cached` |
+
+```jsonc
+POST /test/faults
+{ "kill_at": "response_received" }
+```
+
+| Point | 注入位置 | 启动扫描期望分类 |
+|---|---|---|
+| `request_started` | 已开始 provider attempt，body 未完成时 `std::process::abort()` | `ambiguous.remote_maybe_accepted` |
+| `raw_spool_renamed` | raw_response 已存在但 stage/metadata 未更新 | `recoverable.local_response_cached`（靠文件证据）|
+| `response_received` | metadata 已写 response_received 后 abort | `recoverable.local_response_cached` |
+
+V2 才加：`upload_start` / `materialized` / `uploaded` 等。
+
+### 2.4 Provider HTTP attempt 计数器
+
+**关键**：必须数实际 HTTP attempt，不是 logical provider call。当前 retry 在 [`execute_openai_with_retry`](crates/gpt-image-2-core/src/image_requests/retry.rs:5)，trait 层只包一层会漏掉内部 retry 的 `.send()`。
+
+插桩位置：
+- [`request_openai_images_once`](crates/gpt-image-2-core/src/image_requests/openai.rs:5) `.send()` 周围
+- `request_openai_edit_once` 同
+- `request_codex_*` 同
+
+不假设 `ProviderClient` trait（**当前代码并不存在**）。
+
+```rust
+GET /test/jobs/{job_id}/provider-http-attempts
+→ { "total": 1 }
+```
+
+**验收断言写法**（修正版）：
+
+```text
+before = provider_http_attempts(job_id)
+POST /jobs/{id}/resume { "action": "continue_save" }
+after  = provider_http_attempts(job_id)
+assert after - before == 0
+```
+
+不能写 `count == 0`，因为初始真实 DuckCoding 调用必然 count=1。
+
+### 2.5 完整 attempts 暴露 — 仅 feature-gated
+
+**不污染生产 `GET /jobs/{id}` API**。raw_response_path / request id 类敏感字段走：
+
+```
+GET /test/jobs/{job_id}/attempts
+→ { "attempts": [...], "attempts_truncated_count": 0 }
+```
+
+生产 `GET /jobs/{id}/recovery` 的 `evidence` 仅保留 `raw_response_present` / `raw_response_bytes` / `outputs_present` / `outputs_expected`。
+
+### 2.6 raw_response hash — 仅 feature-gated
+
+```
+GET /test/jobs/{job_id}/raw-response-hash
+→ { "sha256": "abc..." }
+```
+
+用于"continue_save 前后 raw_response 未被改动"断言。
+
+## 3. Tier 1：自动化集成测试（V1 PR merge gate）
+
+### 3.1 前置条件
+
+- DuckCoding API key 由用户在 PR 验收时提供（仅 Case 1 真扣费）
+- 其他 case 用 deterministic **local cutoff provider** 覆盖
+- 启动后端时启用 feature `recovery-fault-injection`
+
+### 3.2 Local cutoff provider
+
+`scripts/local_cutoff_provider`（Rust binary 或 Python，`scripts/` 下）：用 `axum` / `hyper` 起 127.0.0.1 随机端口，实现 OpenAI 兼容 endpoint：
+
+```
+POST /v1/images/generations          标准生成入口（按当前模式响应）
+POST /v1/images/edits                标准编辑入口（按当前模式响应）
+POST /__test/cutoff                  test-only 控制端点，设置后续响应模式
+```
+
+cutoff 模式通过控制端点切换（**不放在 api_base query 里**——当前客户端会在 api_base 后追加 `/images/generations`，query 会被错误拼到中间）：
+
+```jsonc
+POST /__test/cutoff
+{ "mode": "ok" }                                        // 正常完整响应
+{ "mode": "body_after_n_bytes", "n": 512 }              // headers 后写 N byte 然后 close
+{ "mode": "headers_only" }                              // headers 后立即 close
+```
+
+被测后端 / app 仅通过 **`ProviderConfig.api_base = http://127.0.0.1:<port>/v1`**（参见 [provider_types.rs:17](crates/gpt-image-2-core/src/provider_types.rs:17)）或 CLI `--openai-api-base http://127.0.0.1:<port>/v1`（[provider_selection.rs:186](crates/gpt-image-2-core/src/provider_selection.rs:186)）指向 cutoff provider。测试 setup 阶段写一个临时 provider 配置，不使用 `OPENAI_BASE_URL` env var（当前代码不识别此名称）。
+
+测试用例 setup 流程：先 `POST /__test/cutoff` 设置模式，再发正常 `POST /v1/images/generations` 请求。
+
+### 3.3 V1 PR merge gate — 9 个 Case
+
+#### Case 1：场景 D + continue_save 零 API（**唯一真 DuckCoding case**）
+
+1. POST `/test/faults` `{ "fail_at": "materialize_start" }`
+2. POST `/api/images/generate` 真调 DuckCoding，`n=1`, prompt `"a small red cube on white background"`
+3. 等待 job 终态
+4. 断言：
+   - `recoverability == recoverable.local_response_cached`
+   - `<job_dir>/raw_response.json` 存在 & size > 0
+5. 记录 `before = GET /test/jobs/{id}/provider-http-attempts`（应 = 1）
+6. 记录 `hash_before = GET /test/jobs/{id}/raw-response-hash`
+7. POST `/test/faults` `{ "fail_at": null }` 清除注入
+8. POST `/jobs/{id}/resume` `{ "action": "continue_save" }`
+9. **核心断言**：
+   - `after - before == 0`
+   - `status == completed`
+   - `<job_dir>` 下完整 png 输出
+   - `hash_after == hash_before`
+
+#### Case 2：场景 D' terminal.local_recovery_unavailable（local cutoff）
+
+1. setup：`POST cutoff_provider/__test/cutoff { "mode": "ok" }` + provider api_base 指向 cutoff provider
+2. POST `/test/faults` `{ "fail_at": "raw_spool_rename" }`
+3. POST 生成请求
+4. 断言：
+   - `recoverability == terminal.local_recovery_unavailable`
+   - `attempts[-1].response_body_completed_at != null`
+   - `attempts[-1].raw_response_path == null`
+   - `GET /jobs/{id}/recovery` 的 `primary_action` 为 null
+   - `secondary_actions` 含 `resubmit`，warning 含"完整响应曾到达，但恢复源未保存成功"
+
+#### Case 3：场景 F kill after raw spool（local cutoff + abort）
+
+1. setup：`POST cutoff_provider/__test/cutoff { "mode": "ok" }` + provider api_base 指向 cutoff provider
+2. POST `/test/faults` `{ "kill_at": "raw_spool_renamed" }`
+3. POST 生成请求 → 后端在 raw_response 已存在但 metadata 未更新时 abort
+4. 重启后端
+5. 启动扫描后断言：
+   - `GET /jobs/interrupted` 包含此 job
+   - `recoverability == recoverable.local_response_cached`（靠**文件证据**恢复）
+   - `interrupted_reason == "process_killed"`
+6. POST `/jobs/{id}/resume` `{ "action": "continue_save" }`
+7. 断言 provider-http-attempts delta = 0、产物完整
+
+#### Case 4：continue_save 幂等
+
+1. 复用 Case 1 / Case 3 的失败任务
+2. 第一次 resume 成功后再发一次 resume
+3. 断言：
+   - 第二次返回 200，状态等同第一次
+   - provider-http-attempts delta = 0
+   - attempts 数组不新增 entry
+
+#### Case 5：双 worker 验证（分两个子 case）
+
+**5a. core descriptor 字节级 golden**：
+1. fixture：`tests/fixtures/recovery/local_response_cached/` 含 `metadata.json` + `raw_response.json` + `request_meta.json`
+2. 调 core 函数 `recovery::build_descriptor(fixture_dir)` 输出 canonical JSON
+3. 与 `tests/fixtures/recovery/local_response_cached/expected_descriptor.json` **字节级**比较
+
+**5b. 真实 e2e 结构化等价**：
+1. Tauri 模式跑 Case 1 步骤 → 保存 `GET /recovery` 响应 → `tauri.json`
+2. Docker Web 模式跑相同步骤 → `web.json`
+3. mask 字段（`job_id` / `client_request_id` / `provider_request_id` / `raw_response_bytes` / 所有 `*_at` 时间戳）后比较
+4. 断言剩余字段（`recoverability` / `primary_action.id` / `secondary_actions[].id` / `billable` / `evidence.stage_reached` / `raw_response_present` / `outputs_expected`）完全相同
+
+#### Case 6：attempts 限长
+
+1. setup：`POST cutoff_provider/__test/cutoff { "mode": "ok" }` + provider api_base 指向 cutoff provider
+2. POST `/test/faults` `{ "fail_at": "materialize_start" }`
+3. 对同一 job 连续 6 次 `resume?action=resubmit`
+4. 断言：
+   - `attempts.length == 5`
+   - `attempts_truncated_count == 1`
+   - 最旧的 attempt 被丢弃，最新的保留
+
+#### Case 7：conservative ambiguous（无效 base url）
+
+1. 配置一个无效 `api_base`（如 `https://invalid-host-recovery-test.invalid/v1`）触发 DNS 失败
+2. POST 生成请求
+3. **严格断言** `recoverability == ambiguous.remote_maybe_accepted`
+4. 不接受 `recoverable.never_dispatched`（V1 选择 conservative 路径，DNS 失败已进入 provider attempt 范畴）
+5. `never_dispatched` 仅给参数校验、本地排队前失败等"明确未进入 provider attempt"场景
+
+#### Case 8：local cutoff body 中断 → ambiguous
+
+1. setup：`POST cutoff_provider/__test/cutoff { "mode": "body_after_n_bytes", "n": 512 }` + provider api_base 指向 cutoff provider
+2. POST 生成请求
+3. local cutoff server 返回 headers 后写 512 byte 然后 close socket
+4. 断言：
+   - `attempts[-1].response_headers_received_at != null`
+   - `attempts[-1].response_body_completed_at == null`
+   - `recoverability == ambiguous.remote_maybe_accepted`
+   - `primary_action.id == "resubmit"`，`billable == true`，warning 含"上次请求可能已经被服务端接收"
+
+#### Case 9：release build 防泄漏
+
+1. `cargo build --release`（不带任何 feature）
+2. 断言：
+   - `strings target/release/<binary>` 不含 `RECOVERY_TEST_` 字面量
+   - `curl http://localhost:8787/test/faults` → 404
+   - 设置 `POST /test/faults` 的请求路径不存在
+   - 即使尝试通过运行时手段触发 fault registry，行为应等同 default
+
+### 3.4 总成本约束
+
+不写美元阈值。约束改成：
+
+> Tier 1 一轮完整执行：`sum(provider_http_attempts) <= 10`
+
+其中只有 Case 1 真调 DuckCoding（最多 1 次 + 调试容忍 ≤ 5 次）。其余 case 全部走 local cutoff provider 不产生真实费用。
+
+### 3.5 自动化脚本
+
+`scripts/recovery-acceptance-tier1.sh`：
+
+```bash
+#!/bin/bash
+# 启动 local cutoff provider
+# 启动后端 with feature recovery-fault-injection
+# 顺序跑 Case 1-9
+# 输出 JSON 报告
+```
+
+输出格式：
+
+```jsonc
+{
+  "started_at": "...",
+  "tier": "tier1",
+  "total_provider_http_attempts": 3,
+  "duckcoding_calls": 1,
+  "cases": [
+    { "id": "case-1", "passed": true, "duration_ms": 12431, "provider_http_attempts_delta": 0 },
+    // ...
+  ],
+  "overall": "PASSED"
+}
+```
+
+## 4. Tier 2：mitmproxy 现实演练（release gate）
+
+发版前人工跑，不卡每个 PR merge。
+
+### 4.1 mitmproxy 仅作"现实网络演练"
+
+不再用 `response()` hook 改 content-length —— hook 时机是 upstream 完整响应已收到后触发，改长度只能让客户端看到"完整但 JSON 损坏"，不能等价 wire-level body interrupted。
+
+正确用法：streaming addon 拦 raw flow，在传输中途主动 reset 上下游连接。
+
+### 4.2 准备
+
+```bash
+brew install mitmproxy
+mitmproxy --listen-port 8080  # 启动一次生成 CA
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain \
+  ~/.mitmproxy/mitmproxy-ca-cert.pem
+export HTTPS_PROXY=http://127.0.0.1:8080
+export SSL_CERT_FILE=~/.mitmproxy/mitmproxy-ca-cert.pem
+```
+
+发版后卸载证书：
+
+```bash
+sudo security delete-certificate -c mitmproxy /Library/Keychains/System.keychain
+```
+
+### 4.3 release gate case
+
+**Case M1：真 DuckCoding + 中途 RST**
+1. mitmproxy streaming addon 在 `api.duckcoding.com` 响应 body 的 N 个 byte 后强制 reset 双向连接
+2. 真扣费 1 次
+3. 期望 recoverability = `ambiguous.remote_maybe_accepted`
+4. 这 case **作为发版前对真实 wire 行为的最终演练**，不作为 PR gate
+
+### 4.4 release gate 通过标准
+
+发版前手动跑 1 次 Case M1，记录截图 + RecoveryDescriptor JSON 入发版 release notes。
+
+## 5. Tier 3：人工生产观察（发版后）
+
+`scripts/inspect-job.sh <job_id>`：
+
+```bash
+#!/bin/bash
+JOB_ID=$1
+echo "=== Job state ==="
+curl -s "http://localhost:8787/api/jobs/$JOB_ID" | jq '{stage, recoverability, status}'
+echo "=== Recovery descriptor ==="
+curl -s "http://localhost:8787/api/jobs/$JOB_ID/recovery" | jq
+echo "=== Job dir ==="
+ls -la "$HOME/.local/share/gpt-image-2/jobs/$JOB_ID" 2>/dev/null || \
+  ls -la "$HOME/.codex/gpt-image-2-skill/jobs/$JOB_ID"
+echo "=== raw_response present? ==="
+test -f "$HOME/.local/share/gpt-image-2/jobs/$JOB_ID/raw_response.json" && \
+  echo "yes ($(stat -f%z "$HOME/.local/share/gpt-image-2/jobs/$JOB_ID/raw_response.json") bytes)" || \
+  echo "no"
+```
+
+用户在生产环境遇到失败任务时跑此脚本，输出贴回 issue 协助分析。
+
+## 6. V1 PR merge gate 通过门槛
+
+V1 PR 合并前必须满足：
+
+- ✅ Tier 1 全 9 个 case 通过
+- ✅ Case 1 在真实 DuckCoding 下通过（其他 case 走 local cutoff provider）
+- ✅ Case 1 + Case 4：`continue_save` resume 阶段 `provider_http_attempts` delta = 0
+- ✅ Case 5a：core descriptor 字节级匹配 fixture golden
+- ✅ Case 5b：双 worker 真实 e2e 结构化等价
+- ✅ Case 9：release/default 构建无 `/test/*` route，binary 无 `RECOVERY_TEST_` 字面量
+- ✅ 一轮 `sum(provider_http_attempts) <= 10`
+
+Tier 2 与 Tier 3 不作合并门槛。
+
+## 7. 角色分工
+
+| 步骤 | 谁做 |
+|---|---|
+| 实现 V1 + 测试埋点（feature-flagged）| V1 实现者 |
+| 写 `scripts/local_cutoff_provider`（axum / hyper）| V1 实现者 |
+| 写 `scripts/recovery-acceptance-tier1.sh` | V1 实现者 |
+| 写 fixture `tests/fixtures/recovery/local_response_cached/` | V1 实现者 |
+| 写 `scripts/inspect-job.sh` | V1 实现者 |
+| 提供 `DUCKCODING_API_KEY`（仅 Case 1 用）| 用户 |
+| 跑 Tier 1（V1 完成后）| Claude |
+| 跑 Tier 2 release gate（V1 发版前）| Claude（用户授 mitm cert）|
+| 生产 sanity check | 用户 + Claude 辅助分析 |
+| V1 上线最终签字 | 用户 |
+
+## 8. 配套生产配置（防泄漏强约束）
+
+`recovery-fault-injection` feature **必须**在以下场景关闭：
+
+- `cargo-dist` 发布的 release artifact
+- `Tauri App Release` GitHub Actions workflow（参见 [docs/tauri-release.md](./tauri-release.md)）
+- `Dockerfile` 构建（参见 [docs/docker-web.md](./docker-web.md)）
+- 任何用户从源码编译的 default profile
+
+CI 中应有一条 smoke test：
+
+```bash
+# 在 release pipeline 末尾
+cargo build --release
+strings target/release/gpt-image-2-web | grep -q RECOVERY_TEST_ && exit 1
+strings target/release/gpt-image-2-web | grep -q '/test/faults' && exit 1
+echo "✓ no recovery-fault-injection symbols leaked"
+```
+
+并加 `compile_error!` 兜底（参见 §2.2）。

--- a/docs/task-recovery-design.md
+++ b/docs/task-recovery-design.md
@@ -1,0 +1,520 @@
+# 任务恢复协议（Task Recovery Protocol）
+
+> Status: **Final V1** · 2026-05-15
+> 经 [issues#14](https://github.com/Wangnov/gpt-image-2-skill/issues/14) 与 Codex 协同对齐，取代 V1/V2 草案。
+
+## 1. 背景与命名
+
+### 真实场景
+
+> 用户在高铁上发起一个生成任务。OpenAI 已处理完请求并把响应送回，
+> 但本地在接收/解析/落盘的某一步因弱网或进程切换失败。
+> 结果：**OpenAI 已扣费、本地无可用产物**，UI 停在 `failed`，
+> 用户能做的只有"重试"——而重试 = 再扣一次费。
+
+### 为什么不叫"断点续传"或"重试"
+
+OpenAI image API 当前实现使用非流式完整 JSON 调用（[openai.rs:36](crates/gpt-image-2-core/src/image_requests/openai.rs:36)），计费基于请求、无 idempotency-key、无结果回拉接口。**API 本身具备 streaming/event 能力，但当前未使用**；本协议在响应层增加 evidence capture，不改变 transport 形态。
+
+"重试"作为命名是错的——它把"前端断了、后端在跑"、"响应在本地、写盘失败"、"图在本地、上传失败" 等**完全不同的恢复路径**合并成一个动作，而每条路径的计费后果天差地别。
+
+正确命名是 **任务恢复（Task Recovery）**，包含五类**互不相同**的动作。下表 UI label 为最终用户面前的中文按钮文案（说明文风克制专业 + 按钮命名"完成/生成"，详见 §8）：
+
+| 动作（UI label） | 内部 action id | 触发条件 | 计费 | V1 |
+|---|---|---|---|---|
+| **继续完成** | `continue_save` | 远端响应已到本地，本地落盘失败 | ❌ 不计费 | ✅ |
+| **重新生成** | `resubmit` | 无法证明远端结果可恢复 | ✅ 全额，等同新请求 | ✅ |
+| **生成缺失的 N 张** | `fill_missing` | 多图任务部分成功 | ⚠️ 仅缺失部分 | V2 |
+| **重新上传** | `reupload` | 图已在本地，远端 Origin/Archive 上传失败 | ❌ 不计费 | V2 |
+| 同步状态 | （走 GET /recovery 幂等读取） | 前端断了、后端仍在跑 | ❌ 不计费 | 无独立动作 |
+
+绝不出现"重试"、"复活"、"抢救"、"挽回"这类词。
+
+## 2. 设计原则
+
+1. **任务是可审计事务**：每一阶段、每一次 attempt 的进入/退出/失败都有持久痕迹（在 metadata 内，不需要新表）。
+2. **计费透明**：每一个会触发 API 调用的按钮都必须有"将再次调用 API"明示。
+3. **后端推荐动作**：前端不做 `if failure_class == ... else ...` 派发；后端给一个 `RecoveryDescriptor`，前端只渲染。
+4. **REST 纯洁性**：`GET /recovery` 幂等只读，所有 reconcile 入口共用；`POST /resume` 只做有副作用动作。
+5. **单协议、双实施**：恢复协议放在 `gpt-image-2-core` 共享 crate，Tauri sidecar 与 `gpt-image-2-web` 都消费同一套定义。V1 不合并队列（`JobQueueInner`），只下沉业务层避免行为漂移。
+6. **不破坏现有契约**：V1 不动 retry/timeout 默认值（`DEFAULT_REQUEST_TIMEOUT=300`、`DEFAULT_RETRY_COUNT=3`），不动 top-level job status 枚举，不建新表。
+7. **不做无法兑现的承诺**：状态机里保留 `recoverable.remote_in_progress` 类别作为语义占位，但**V1 不会真正产生此状态**——它需要 provider 能力（远端状态查询/结果回拉）支持。
+
+## 3. 场景全景与动作映射
+
+| # | 场景 | recoverability | V1 主动作 |
+|---|---|---|---|
+| A | 请求未发出 | `recoverable.never_dispatched` | 重新生成 · 将再次调用 API |
+| B | 请求 in-flight、连接断 | `ambiguous.remote_maybe_accepted` | 重新生成 · 将再次调用 API（含警告）|
+| C | 响应 body 传输中断 | `ambiguous.remote_maybe_accepted` | 重新生成 · 将再次调用 API（含警告）|
+| D | 响应已收到、本地落盘成功、后续失败 | `recoverable.local_response_cached` | **继续完成** |
+| D' | 响应已收到、但 raw_response 未原子写入 | `terminal.local_recovery_unavailable` | 仅副按钮"重新生成 · 将再次调用 API"|
+| E | n=4 任务收 2 张后失败 | `recoverable.partial_outputs` | (V2) 生成缺失的 N 张 |
+| F | 进程被杀 | 启动扫描后归类到 A–E 之一 | 由扫描决定 |
+| G | 前端断网、后端在跑 | `recoverable.remote_in_progress` | (语义保留，V1 不产生) |
+| H | 图已存、上传失败 | `recoverable.upload_failed` | (V2) 重新上传 |
+| I | provider 拒绝（4xx） | `terminal.provider_rejected` | 仅显示原因 |
+| J | 用户取消 | `terminal.user_cancelled` | overflow 菜单"重新生成 · 将再次调用 API" |
+
+**核心洞察**：场景 D 是最痛的、也是唯一一类我们能 100% 解决的。把它和场景 B/C 区分清楚是整个协议的价值所在。
+
+## 4. 状态与恢复模型
+
+### 4.1 Stage 枚举
+
+精简到 6 阶段：
+
+```
+staged → submitted → response_received → materialized → uploaded → completed
+```
+
+任务在每次阶段转移时把 `stage` 字段写进 metadata。`failed_at_stage` = 出错时停留的 stage。
+
+### 4.2 Recoverability 命名空间（终版）
+
+```
+recoverable.never_dispatched              请求未发出
+recoverable.local_response_cached         响应完整收到且已 spool → 零 API 恢复
+recoverable.partial_outputs               (V2) 多图部分成功
+recoverable.upload_failed                 (V2) 图在本地、上传失败
+recoverable.remote_in_progress            (V1 不产生；需 provider 能力支持)
+ambiguous.remote_maybe_accepted           provider 是否扣费无法证明
+terminal.local_recovery_unavailable       完整响应曾到达但未成功 spool（罕见边角）
+terminal.provider_rejected                provider 4xx
+terminal.user_cancelled                   用户主动取消
+```
+
+`recoverable.*` → 主按钮做对应动作；`ambiguous.*` → 主按钮"重新提交" + 显著扣费风险提示；`terminal.*` → 不显示恢复按钮，仅显示原因。
+
+### 4.3 判定主规则（唯一权威）
+
+```text
+取 last_attempt = attempts[-1]
+
+IF !last_attempt.request_started_at
+  → recoverable.never_dispatched
+
+IF last_attempt.response_body_completed_at != null
+  AND last_attempt.raw_response_path != null
+  → recoverable.local_response_cached
+
+IF last_attempt.response_body_completed_at != null
+  AND last_attempt.raw_response_path == null
+  → terminal.local_recovery_unavailable
+     (UI: "完整响应曾到达，但未成功保存恢复源")
+
+IF provider 4xx
+  → terminal.provider_rejected
+
+IF user cancelled
+  → terminal.user_cancelled
+
+OTHERWISE (request_started but body not completed)
+  → ambiguous.remote_maybe_accepted
+```
+
+**事实锚点**：以 `response_body_completed_at` + `raw_response_path` 两个字段是否非空为唯一判据。不以 stage 名作判据。
+
+## 5. 数据模型
+
+### 5.1 任务目录文件契约
+
+| 文件 | 写入时机 | 关键契约 |
+|---|---|---|
+| `request_meta.json` | 阶段进入 `submitted` 之前 | atomic write |
+| `raw_response.json` | 响应 body 完整接收后 | **`.part` → fsync → atomic rename**；rename 成功**才允许**写 `raw_response_path` 字段 |
+| `partial/<index>.png` | (V2) 多图任务每张完成时 | atomic write |
+| `error.json` | 失败时 | `failed_at_stage` · `error_chain` · `raw_provider_headers` (debug only) |
+
+### 5.2 metadata JSON 扩展（V1 不动 schema）
+
+`jobs.metadata` 内新增字段：
+
+```jsonc
+{
+  // 现有字段不变
+  "stage": "response_received",
+  "recoverability": "recoverable.local_response_cached",
+  "attempts": [
+    {
+      "attempt_id": "uuid",
+      "client_request_id": "uuid",          // 本地生成；进 X-Client-Request-Id 头
+      "provider_request_id": null,           // 归一化自 provider 响应 header（x-request-id / request-id 等）
+      "request_started_at": "...",
+      "response_headers_received_at": null,
+      "response_body_completed_at": null,
+      "raw_response_path": null,             // 仅 atomic rename 成功后填入
+      "stage_at_failure": null,
+      "error_code": null
+    }
+  ],
+  "attempts_truncated_count": 0,             // 超过保留数后递增
+  "interrupted_reason": null                 // 仅启动扫描产生的 interrupted
+}
+```
+
+**护栏**：
+- `attempts` 最多保留最近 **5 条**，旧的归并到 `attempts_truncated_count`
+- `provider_request_id` 由 core 内 `normalize_provider_request_id(headers)` 归一化；原始 header 仅进 `error.json` 的 `raw_provider_headers` debug detail，不进 UI 主路径
+- `estimated_cost_label` 由后端可选填入 RecoveryDescriptor，前端只渲染；**V1 不内置成本估算逻辑**
+
+### 5.3 V2/V3 才评估的新表（V1 全部不建）
+
+| 表 | V1 | 理由 |
+|---|---|---|
+| `job_events` 时间线 | ❌ V3 | metadata + error.json 已能覆盖 V1 用户故事 |
+| `job_attempts` | ❌ V2 | V1 用 metadata 内 `attempts[]` 数组已足够 |
+| `job_outputs` / 生成 slot 表 | ❌ V2 | V1 不做 `fill_missing`；V2 先用 metadata `generation_slots` 数组，复杂度真上来再升表 |
+
+注意：**现有 [output_uploads](crates/gpt-image-2-core/src/history_db.rs:117) 表承载"上传"语义**（主键 `(job_id, output_index, target)`），**不能表达**"index 2 从未生成 / materialize 失败 / 已被用户接受为缺失"。V2 引入 `generation_slots` 时不要复用此表。
+
+## 6. 后端架构
+
+### 6.1 关键决定：协议下沉到 `gpt-image-2-core`
+
+仓库存在两套并行的工作线程实现：
+
+- [apps/gpt-image-2-app/src-tauri/src/queue_workers.rs](apps/gpt-image-2-app/src-tauri/src/queue_workers.rs)（400 行，Tauri 内嵌模式）
+- [crates/gpt-image-2-web/src/queue_workers.rs](crates/gpt-image-2-web/src/queue_workers.rs)（539 行，Docker Web 模式）
+
+各自的 `job_execution/` 子目录结构相似，但代码独立。
+**任何恢复协议改动如果不下沉，工作量直接 ×2，且会出现两边行为漂移。**
+
+V1 第 0 步：在 `gpt-image-2-core` 增加 `recovery` 模块，定义：
+
+- `Stage` / `Recoverability` / `RecoveryAction` 枚举与决策函数
+- `attempt metadata helpers`：stage timestamps · client_request_id · provider_request_id · raw_response_path
+- `RawResponseSpooler` trait（`.part` → fsync → atomic rename 契约）
+- `RecoveryDescriptor` 结构（API 返回值）
+- `classify(stage, evidence, error) -> Recoverability` 纯函数
+- `materialize_from_raw_response(job_dir) -> Result<Outputs>`（continue_save 的实现，**禁止调用 provider client**）
+- `classify_zombie(job_dir, metadata) -> ZombieClass`（启动扫描复用）
+
+**V1 不合并** `JobQueueInner`。两套 worker 虽重复，但还夹着 Tauri event emit / HTTP polling / notification dispatch / storage async 等差异，合并属于单独的 queue 重构。Tauri 与 web 各自的 worker 仅保留"调用上述 core 函数、把结果写进自己 SQLite"这一层薄壳。
+
+### 6.2 HTTP 层
+
+**V1 保持现有 transport policy 不变**：
+- `DEFAULT_REQUEST_TIMEOUT = 300` ([constants.rs:29](crates/gpt-image-2-core/src/constants.rs:29))
+- `DEFAULT_RETRY_COUNT = 3` ([constants.rs:25](crates/gpt-image-2-core/src/constants.rs:25))
+- 现有指数退避保留
+
+本协议**只在响应层增加 evidence capture**（headers_received_at / body_completed_at / raw_response_path），不改 transport policy。任何 retry/timeout 调整应单独评估。
+
+### 6.3 工作线程改造（核心抢救）
+
+修改 [streaming.rs](crates/gpt-image-2-web/src/job_execution/streaming.rs) +
+[generate_runner.rs](crates/gpt-image-2-web/src/job_execution/generate_runner.rs)（两套都改）：
+
+```
+1. 创建 attempt，分配 client_request_id，写 request_meta.json
+   stage = submitted
+2. 调用 provider，attempt.request_started_at = now()
+3. 收到 response headers → attempt.response_headers_received_at = now()
+   归一化 provider_request_id 写入 attempt
+4. body 完整接收 → attempt.response_body_completed_at = now()
+5. ★ raw_response 原子落盘：
+   write to raw_response.json.part → fsync → atomic rename
+   仅在 rename 成功后写 attempt.raw_response_path
+   stage = response_received
+6. 解析、写图  (stage = materialized)
+7. 上传到 storage  (stage = uploaded)
+8. stage = completed
+```
+
+CLI 工具增 `--raw-response-out <path>` flag。
+
+### 6.4 Recovery Service（V1 实现）
+
+`gpt-image-2-core::recovery::`：
+
+- `continue_save(job_id)` —— 调 `materialize_from_raw_response`，**禁止调用 provider client**。这是 V1 测试的必须断言项。UI label "继续完成"。
+- `resubmit(job_id)` —— 创建新 job、复用参数（=现有 retry，保留为兼容）。UI label "重新生成 · 将再次调用 API"。
+- `discard(job_id)` —— 显式归档失败任务。UI label "丢弃"。
+
+V2 才加：`fill_missing` / `reupload`。**API action id 保持英文不变**（contract）；UI 文案见 §8。
+
+### 6.5 启动扫描（Zombie reaper）
+
+```rust
+fn reap_on_startup(db, jobs_root) -> Vec<InterruptedJob> {
+    for job in db.find_jobs_in_status(&[
+        "staged", "submitted", "response_received", "materialized", "uploaded"
+    ]) {
+        let evidence = collect_evidence(job_dir(&job.id), &job.metadata);
+        let recoverability = classify(job.stage, evidence, None);
+        update_metadata(job, recoverability, interrupted_reason = "process_killed");
+    }
+}
+```
+
+启动后通过 `GET /jobs/interrupted` 暴露需用户决策的列表。
+
+### 6.6 Provider 能力扩展
+
+复用现有 [provider_capabilities.rs](apps/gpt-image-2-app/src-tauri/src/job_execution/provider_capabilities.rs)（已有 `supports_n`），扩展为：
+
+```rust
+struct ProviderCapabilities {
+    supports_n: bool,
+    supports_client_request_id: bool,        // 是否能带 X-Client-Request-Id
+    supports_idempotency_key: bool,          // 真 idempotency-key；OpenAI image: false
+    supports_remote_result_lookup: bool,     // 是否能用 remote id 回查结果
+    supports_streaming_events: bool,         // 是否提供 event stream / partial events
+    returns_ephemeral_urls: bool,            // 结果 URL 是否过期
+}
+```
+
+**V1 仅后端使用**，不暴露给前端。前端只消费 `RecoveryDescriptor`。
+
+## 7. API 设计
+
+### 7.1 GET /jobs/{id}/recovery（幂等只读，所有 reconcile 入口）
+
+```jsonc
+{
+  "job_id": "abc",
+  "recoverability": "recoverable.local_response_cached",
+  "primary_action": {
+    "id": "continue_save",
+    "label": "继续完成",
+    "endpoint": "POST /jobs/abc/resume",
+    "billable": false,
+    "explanation": "上次接收到了模型响应，但保存到本地时失败。可在不重新调用 API 的前提下完成。"
+  },
+  "secondary_actions": [
+    {
+      "id": "resubmit",
+      "label": "重新生成 · 将再次调用 API",
+      "endpoint": "POST /jobs/abc/resume",
+      "billable": true,
+      "estimated_cost_label": null,
+      "warning": "将再次调用 API"
+    }
+  ],
+  "evidence": {
+    "stage_reached": "response_received",
+    "raw_response_present": true,
+    "raw_response_bytes": 2418732,
+    "outputs_present": 0,
+    "outputs_expected": 4,
+    "last_attempt": { /* attempts[-1] 摘要 */ }
+  }
+}
+```
+
+**Label 约定**：
+- `billable: false` 的动作 → label 只写动词（"继续完成"），不加成本提示
+- `billable: true` 的动作 → label 嵌入"· 将再次调用 API"，作为视觉上的一体化按钮文字
+
+前端 reconnect、polling 恢复、打开 drawer 都调用此端点。
+
+### 7.2 POST /jobs/{id}/resume（只做有副作用动作）
+
+```jsonc
+{ "action": "continue_save" }   // V1 支持: continue_save | resubmit | discard
+```
+
+**`continue_save` 实现契约**：只走 `materialize_from_raw_response`，不创建 provider client，不发出任何出站请求。
+
+### 7.3 端点列表（V1 终版）
+
+| Method | Path | 用途 |
+|---|---|---|
+| GET | `/jobs/interrupted` | 启动扫描发现的中断任务 |
+| GET | `/jobs/{id}/recovery` | 推荐恢复动作 descriptor |
+| POST | `/jobs/{id}/resume` | 执行恢复（按 action） |
+| POST | `/jobs/{id}/retry` | 现有端点保留为 `resume?action=resubmit` 的别名，前端逐步迁移 |
+| GET | `/jobs/{id}` | 扩展返回 `stage` / `recoverability` |
+
+**不引入**：`sync_state` action、`/reconcile` 端点、`refresh_remote_status`（V1 不需要，未来 provider 能力出现再加）。
+
+## 8. 前端 UI/UX
+
+### 8.1 设计基调
+
+- 不戏剧化（无"复活"等词）
+- 以事实为先：先告知发生了什么，再告知能做什么
+- 计费透明：触发 API 的按钮必须有"将再次调用 API"提示
+- 危险操作收敛到 overflow 菜单
+- 参考品味：Linear / Stripe / Vercel 的失败处理风格
+
+### 8.2 文案混搭原则（用户拍板）
+
+- **Chip / 说明文字 / toast / 抽屉解释**：方案 A 风格——事实先行、克制专业、不戏剧化（"上次接收到了模型响应，但保存到本地时失败"）
+- **按钮命名**：方案 B 风格——动词为"完成 / 生成"而非"保存 / 提交"（"继续完成" / "重新生成"）
+- **计费提示**：方案 A 嵌入式——`billable: true` 的按钮 label 内嵌"· 将再次调用 API"，让用户看一眼按钮就知道
+- **Case 3（未发出）也加成本提示**：尽管上次未扣费，仍嵌入"· 将再次调用 API"，保持全局一致
+
+### 8.3 历史列表 chip
+
+| recoverability | chip 文字 | 颜色 |
+|---|---|---|
+| recoverable.never_dispatched | 待重新生成 | 中性灰 |
+| recoverable.local_response_cached | 响应已收到，待继续完成 | 警告橙 |
+| recoverable.partial_outputs *(V2)* | 2/4 已完成，可补齐 | 警告橙 |
+| recoverable.upload_failed *(V2)* | 已生成，上传失败 | 警告橙 |
+| ambiguous.remote_maybe_accepted | 状态未知，需确认 | 警告橙 |
+| terminal.local_recovery_unavailable | 响应已丢失 | 中性灰 |
+| terminal.provider_rejected | 已被拒绝 | 中性灰 |
+| terminal.user_cancelled | 已取消 | 中性灰 |
+
+### 8.4 卡片布局（高铁场景示例）
+
+```
+┌────────────────────────────────────────────────────┐
+│ [缩略图占位 4×]                                     │
+│                                                    │
+│ "Yokohama at golden hour, 35mm film"               │
+│ ───────────────────────────────────────────────    │
+│ ⚠ 响应已收到，待继续完成 · 2 分钟前                  │
+│ 上次接收到了模型响应，但保存到本地时失败。           │
+│ 可在不重新调用 API 的前提下完成。                    │
+│                                                    │
+│ [继续完成]  [重新生成 · 将再次调用 API]      ⋯      │
+└────────────────────────────────────────────────────┘
+```
+
+### 8.5 文案表（V1 终版）
+
+| recoverability | 说明文字 | 主按钮 | 副按钮 | Overflow ⋯ |
+|---|---|---|---|---|
+| recoverable.never_dispatched | 请求未送达，可安全重新生成。上次未产生费用。 | 重新生成 · 将再次调用 API | — | 丢弃 |
+| recoverable.local_response_cached | 上次接收到了模型响应，但保存到本地时失败。可在不重新调用 API 的前提下完成。 | **继续完成** | 重新生成 · 将再次调用 API | 查看详情 / 丢弃 |
+| ambiguous.remote_maybe_accepted | 未收到完整响应。上次请求可能已被服务端接收。 | 重新生成 · 将再次调用 API | — | 查看详情 / 丢弃 |
+| terminal.local_recovery_unavailable | 完整响应曾到达，但恢复源未保存成功。 | （无） | 重新生成 · 将再次调用 API | 查看详情 / 丢弃 |
+| terminal.provider_rejected | {provider 返回的具体原因，例如：内容策略限制} | （无） | （无） | 查看详情 / 丢弃 |
+| terminal.user_cancelled | 你在 {时间} 取消了这个任务。 | （无） | （无） | 重新生成 · 将再次调用 API / 丢弃 |
+
+**实施约束**：
+- `billable: false` 的 label = 纯动词，无后缀
+- `billable: true` 的 label = `{动词} · 将再次调用 API`，作为一体化按钮文字渲染
+- 后端如填 `estimated_cost_label`，前端拼接在 `· 将再次调用 API` 之后（如 `· 将再次调用 API · ~$0.04`）
+- terminal.user_cancelled 故意把"重新生成"藏进 overflow，不主动推动用户重提
+
+### 8.6 详情抽屉 timeline
+
+点 ⋯ → "查看详情" 打开 side drawer：
+
+```
+任务时间线
+─────────────────────────
+✓ 已排队            03:11:58
+✓ 已发送             03:12:00
+✓ 远端已接收         03:12:11
+✓ 已收到响应（4 张，2.4 MB）  03:12:38
+✗ 保存失败：ENOSPC  03:12:42
+
+可恢复性
+─────────────────────────
+响应已收到，待继续完成
+上次接收到了模型响应，但保存到本地时失败。
+点击「继续完成」可在不重新调用 API 的前提下完成。
+
+请求摘要
+  模型：gpt-image-2
+  参数：n=4, size=1536x1024, quality=high
+
+[继续完成]   [重新生成 · 将再次调用 API]   [复制错误信息]
+```
+
+### 8.7 启动后中断任务通知
+
+- toast 而非 modal（modal 太重）
+  > "上次有 3 个任务未正常完成。在历史中查看 →"
+- 历史筛选器加默认过滤"需要处理"，徽章数 = N
+- toast 关闭后本会话不再提示
+
+### 8.8 历史列表筛选器
+
+| 选项 | 文案 |
+|---|---|
+| 默认 quick filter | 需要处理（{N}）|
+| 全部 | 全部 |
+| 已完成 | 已完成 |
+| 进行中 | 进行中 |
+| 需要处理 | 需要处理 |
+| 已取消 | 已取消 |
+
+### 8.9 Docker Web 模式特殊提示
+
+Docker Web 部署下前端通过 HTTP 跨网访问后端。前端 reconnect 时**始终先调 `GET /jobs/{id}/recovery`** 拉取最新 descriptor，而非假设旧前端状态有效。无需独立 reconcile 端点。
+
+## 9. 落地切片
+
+### V0 — 文案修正（半天，纯前端，独立 PR）
+
+仅改前端 UI 上"会重新调用 provider、会创建新 job"动作的文案：
+- 历史列表 / 详情面板上的"重试" → "重新生成 · 将再次调用 API"
+- tooltip / aria 同步
+- 本地保存失败 retry / 配置测试 retry 等**不改**
+
+不动任何后端逻辑。立刻消除"重试 = 不会扣费"的误解。
+
+### V1 — 核心可恢复
+
+**后端（按顺序）**：
+1. `gpt-image-2-core::recovery` 模块（含纯函数 + traits + 单元测试覆盖 classify / materialize）
+2. CLI 增 `--raw-response-out`
+3. 改造 `crates/gpt-image-2-web/src/queue_workers.rs`：响应到达即 atomic spool；调用 core 完成判定
+4. mirror 到 `apps/.../src-tauri/src/queue_workers.rs`
+5. 启动扫描 + zombie 归类（共享 core）
+6. 新 API：`GET /recovery` / `POST /resume` / `GET /interrupted`；retry 端点保留为 `resume?action=resubmit` 别名
+7. 集成测试：双 worker 真实 e2e mask 动态字段后**结构化等价**；core descriptor 用 fixture **字节级 golden**（参见 acceptance §3.3 Case 5）
+
+**前端**：
+1. 接 `/recovery` 端点
+2. 历史卡片按 recoverability 渲染 chip + 主按钮
+3. 详情 drawer：timeline + 可恢复性说明 + 操作按钮
+4. 启动后中断任务 toast
+5. 移除把所有失败混成"红色 ⊘"的旧渲染
+
+### V2 — 补齐 + 补传
+
+- 多图任务每张落 `partial/<index>.png`，metadata 加 `generation_slots[]`
+- `POST /resume?action=fill_missing` / `reupload`
+- 前端对应主按钮 + 错误详情面板增强
+- 评估是否升级 `generation_slots` 为新表 `job_outputs`
+
+### V3（延后）
+
+- `job_events` 持久化时间线（替代 metadata 内的离散字段）
+- 离线草稿排队
+- Provider 能力表更细化 / 暴露给"切换 provider"页面
+
+## 10. 测试计划
+
+| 用例 | 模拟方法 | 期望 |
+|---|---|---|
+| D：响应已到、写盘失败 | `chmod -w job_dir` 后跑生成 | recoverability = `local_response_cached`，"继续保存" 可用 |
+| **continue_save 零 API**（必须）| mock provider client 禁止任何出站请求 | 调用次数 = **0**，最终产物完整 |
+| F：进程被杀 | `kill -9` 后重启 | `running` 任务被归类，不残留 |
+| G：前端断网 reconnect | 前端 mock 断 fetch，后端继续跑 | 前端调 GET /recovery 拿到 `completed`，**无需 POST** |
+| D'：原子写失败 | mock fsync 抛错 | recoverability = `terminal.local_recovery_unavailable`，UI 显示"完整响应曾到达，但未成功保存恢复源" |
+| 双扣防护 | 连点"继续保存" 两次 | 第二次幂等（基于 attempts 计数）|
+| ambiguous 警告 | mock submitted 阶段 reset by peer | recoverability = `ambiguous.remote_maybe_accepted`，主按钮"重新提交"显示风险提示 |
+| **双 worker 行为一致** | 同组用例分别跑 Tauri 与 Docker Web | RecoveryDescriptor 字节级一致 |
+| attempts 限长 | 强制连续 6 次 resubmit | `attempts.length == 5`，`attempts_truncated_count == 1` |
+
+## 11. 开放问题（V2 及之后再定）
+
+1. `ambiguous` 的精细化判定（V1 保守归一，V2 是否细分）
+2. raw_response.json 清理策略（建议默认成功后保留 7 天 + 设置项可调）
+3. `gpt-image-2-core` 抽取后是否继续合并 `JobQueueInner`（队列重构单独提案）
+4. 云端同步场景下 raw_response 的处理（V1 明确不入云同步）
+5. provider 能力表前端可见性（V2 起评估）
+
+## 12. 关键代码触点速查
+
+| 模块 | 文件 | V1 改动 |
+|---|---|---|
+| 状态枚举 | [types.ts:187](apps/gpt-image-2-app/src/lib/api/types.ts:187) | 扩展（加 `stage` / `recoverability`）|
+| 历史 DB | [history_db.rs:50](crates/gpt-image-2-core/src/history_db.rs:50) | metadata JSON 加 attempts/stage/recoverability 字段，schema 不动 |
+| 队列 worker（双套）| [src-tauri queue_workers.rs](apps/gpt-image-2-app/src-tauri/src/queue_workers.rs) · [web crate queue_workers.rs](crates/gpt-image-2-web/src/queue_workers.rs) | 改为薄壳，业务下沉到 core |
+| 流式输出（双套）| `**/job_execution/streaming.rs` | 改造：响应 → raw_response atomic spool |
+| 生成 runner（双套）| `**/job_execution/generate_runner.rs` | attempts 记录 + raw spool |
+| Provider 能力 | [provider_capabilities.rs](apps/gpt-image-2-app/src-tauri/src/job_execution/provider_capabilities.rs) | 扩展 5 个能力字段（仅后端） |
+| 重试 API | [retry_api.rs:149](crates/gpt-image-2-web/src/retry_api.rs:149) | 保留为 `resume?action=resubmit` 的实现 |
+| 任务 hook | [use-jobs.ts:35](apps/gpt-image-2-app/src/hooks/use-jobs.ts:35) | 接 `/recovery` 端点 |
+| 恢复模块 | (新) `crates/gpt-image-2-core/src/recovery/` | 新增 |
+| 启动扫描 | (新) 在两套 worker 启动路径调用 core 函数 | 新增 |

--- a/scripts/local_cutoff_provider.py
+++ b/scripts/local_cutoff_provider.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tiny OpenAI-compatible image endpoint for recovery acceptance tests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+PNG_1X1_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+class State:
+    mode = "ok"
+    n = 512
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("content-length", "0") or "0")
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except Exception:
+            return {}
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+
+    def do_POST(self) -> None:
+        if self.path == "/__test/cutoff":
+            payload = self._read_json()
+            State.mode = str(payload.get("mode") or "ok")
+            State.n = int(payload.get("n") or 512)
+            self._send_json(200, {"mode": State.mode, "n": State.n})
+            return
+
+        if self.path not in ("/v1/images/generations", "/v1/images/edits"):
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+
+        _ = self._read_json()
+        body = json.dumps(
+            {
+                "created": 1778865554,
+                "data": [{"b64_json": PNG_1X1_BASE64, "revised_prompt": "acceptance image"}],
+            }
+        ).encode("utf-8")
+
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("x-request-id", "local-cutoff-request")
+        if State.mode == "ok":
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            self.wfile.flush()
+            return
+
+        if State.mode == "headers_only":
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.close_connection = True
+            return
+
+        if State.mode == "body_after_n_bytes":
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body[: max(0, min(State.n, len(body) - 1))])
+            self.wfile.flush()
+            self.close_connection = True
+            return
+
+        self._send_json(400, {"error": {"message": f"unsupported cutoff mode: {State.mode}"}})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    args = parser.parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    host, port = server.server_address
+    print(json.dumps({"host": host, "port": port, "api_base": f"http://{host}:{port}/v1"}), flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add task recovery state capture for OpenAI-compatible image requests, including raw_response spooling, request metadata, recoverability classification, and startup interruption marking.
- Add web and Tauri recovery endpoints/commands for recovery descriptors, continue_save, resubmit, discard, and feature-gated acceptance probes.
- Update history UI actions to distinguish continuing a cached local response from billable regeneration.
- Add recovery design/acceptance docs and a local cutoff provider for deterministic failure testing.

## Validation
- cargo test -p gpt-image-2-core recovery
- cargo check -p gpt-image-2-core -p gpt-image-2-web -p gpt-image-2-app
- cargo check -p gpt-image-2-web --features recovery-fault-injection
- cargo check -p gpt-image-2-app --features recovery-fault-injection
- npm run typecheck
- DuckCoding live acceptance: materialize_start failure recovered with continue_save, provider attempt delta = 0, raw_response hash unchanged, output materialized.
- Local cutoff acceptance: local_response_cached, remote_maybe_accepted, and local_recovery_unavailable classifications verified.