### PR TITLE
Add Linux static fallback packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,13 +47,7 @@ jobs:
       - name: Dry run npm publish
         if: ${{ env.DRY_RUN == 'true' }}
         run: |
-          for package_dir in \
-            packages/npm/gpt-image-2-skill-darwin-arm64 \
-            packages/npm/gpt-image-2-skill-darwin-x64 \
-            packages/npm/gpt-image-2-skill-linux-arm64-gnu \
-            packages/npm/gpt-image-2-skill-linux-x64-gnu \
-            packages/npm/gpt-image-2-skill-windows-arm64-msvc \
-            packages/npm/gpt-image-2-skill-windows-x64-msvc
+          for package_dir in $(find packages/npm -mindepth 1 -maxdepth 1 -type d ! -name gpt-image-2-skill | sort)
           do
             npm publish "$package_dir" --access public --dry-run
           done
@@ -61,13 +55,7 @@ jobs:
       - name: Publish platform packages
         if: ${{ env.DRY_RUN != 'true' }}
         run: |
-          for package_dir in \
-            packages/npm/gpt-image-2-skill-darwin-arm64 \
-            packages/npm/gpt-image-2-skill-darwin-x64 \
-            packages/npm/gpt-image-2-skill-linux-arm64-gnu \
-            packages/npm/gpt-image-2-skill-linux-x64-gnu \
-            packages/npm/gpt-image-2-skill-windows-arm64-msvc \
-            packages/npm/gpt-image-2-skill-windows-x64-msvc
+          for package_dir in $(find packages/npm -mindepth 1 -maxdepth 1 -type d ! -name gpt-image-2-skill | sort)
           do
             npm publish "$package_dir" --access public --provenance
           done

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -95,13 +95,21 @@ jobs:
         run: |
           node <<'NODE'
           const childProcess = require("node:child_process");
+          const fs = require("node:fs");
           const path = require("node:path");
 
           const packageName = process.arch === "arm64"
             ? "gpt-image-2-skill-linux-arm64-static"
             : "gpt-image-2-skill-linux-x64-static";
           const globalRoot = childProcess.execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
-          const binary = path.join(globalRoot, packageName, "bin", "gpt-image-2-skill");
+          const candidates = [
+            path.join(globalRoot, "gpt-image-2-skill", "node_modules", packageName, "bin", "gpt-image-2-skill"),
+            path.join(globalRoot, packageName, "bin", "gpt-image-2-skill"),
+          ];
+          const binary = candidates.find((candidate) => fs.existsSync(candidate));
+          if (!binary) {
+            throw new Error(`Unable to locate ${packageName} binary. Tried: ${candidates.join(", ")}`);
+          }
           childProcess.execFileSync(binary, ["--json", "doctor"], { stdio: "inherit" });
           NODE
 

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -23,6 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - runner: ubuntu-22.04
+            binary: gpt-image-2-skill
+          - runner: ubuntu-22.04-arm
+            binary: gpt-image-2-skill
           - runner: ubuntu-24.04
             binary: gpt-image-2-skill
           - runner: macos-15
@@ -54,6 +58,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
           - runner: ubuntu-24.04
           - runner: macos-15
           - runner: windows-2025
@@ -83,6 +89,21 @@ jobs:
       - name: Smoke test
         shell: bash
         run: gpt-image-2-skill --json doctor >/tmp/gpt-image-2-skill-npm-doctor.json
+      - name: Smoke test static fallback package
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          node <<'NODE'
+          const childProcess = require("node:child_process");
+          const path = require("node:path");
+
+          const packageName = process.arch === "arm64"
+            ? "gpt-image-2-skill-linux-arm64-static"
+            : "gpt-image-2-skill-linux-x64-static";
+          const globalRoot = childProcess.execFileSync("npm", ["root", "-g"], { encoding: "utf8" }).trim();
+          const binary = path.join(globalRoot, packageName, "bin", "gpt-image-2-skill");
+          childProcess.execFileSync(binary, ["--json", "doctor"], { stdio: "inherit" });
+          NODE
 
   homebrew:
     runs-on: macos-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,22 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Configure musl toolchain
+        if: ${{ runner.os == 'Linux' && contains(join(matrix.targets, ','), 'unknown-linux-musl') }}
+        shell: bash
+        run: |
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y musl-tools
+          else
+            apt-get update
+            apt-get install -y musl-tools
+          fi
+
+          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
       - name: Refresh WiX path
         if: ${{ contains(join(matrix.targets, ','), 'aarch64-pc-windows-msvc') }}
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ docker run --rm -p 8787:8787 \
 
 ## Skill 集成
 
-源码位于 [`skills/gpt-image-2-skill`](skills/gpt-image-2-skill)。入口是 [`scripts/gpt_image_2_skill.cjs`](skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs),它本身不执行图像逻辑,而是按下面的顺序解析底层 Rust 二进制并转发参数。
+源码位于 [`skills/gpt-image-2-skill`](skills/gpt-image-2-skill)。入口是 [`scripts/gpt_image_2_skill.cjs`](skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs),它本身不执行图像逻辑,而是按下面的顺序解析底层 Rust 二进制并转发参数。Linux glibc 沙箱会先试 GNU release asset,再用 static musl asset 兜底。
 
 **安装**:
 
@@ -447,11 +447,14 @@ cp -r /tmp/gpt-image-2-skill/skills/gpt-image-2-skill ~/.claude/skills/
 **Wrapper 解析顺序**:
 
 1. `GPT_IMAGE_2_SKILL_BIN` 环境变量(指向具体二进制)
-2. `PATH` 上的 `gpt-image-2-skill`(cargo / brew / npm 安装)
-3. Tauri App bundled CLI(`GPT_IMAGE_2_SKILL_APP_BIN` 或标准 app bundle 路径)
-4. 仓库内 `cargo run -q -p gpt-image-2-skill --`(仅当 `Cargo.toml` 与 `cargo` 都存在)
-5. `${XDG_CACHE_HOME:-~/.cache}/gpt-image-2-skill/<version>/<target>/` 缓存
-6. Bootstrap:下载对应版本的 GitHub Release 资产并缓存
+2. Skill 包内置 binary(`bin/<target-triple>/gpt-image-2-skill`,如果存在)
+3. `PATH` 上的 `gpt-image-2-skill`(cargo / brew / npm 安装)
+4. Tauri App bundled CLI(`GPT_IMAGE_2_SKILL_APP_BIN` 或标准 app bundle 路径)
+5. 仓库内 `cargo run -q -p gpt-image-2-skill --`(仅当 `Cargo.toml` 与 `cargo` 都存在)
+6. `${XDG_CACHE_HOME:-~/.cache}/gpt-image-2-skill/<version>/<target>/` 缓存
+7. Bootstrap:下载对应版本的 GitHub Release 资产并缓存
+
+Linux glibc 沙箱下,缓存与 bootstrap 阶段会先检查 GNU target(`*-unknown-linux-gnu`),再尝试 static musl target(`*-unknown-linux-musl`)。
 
 设 `GPT_IMAGE_2_SKILL_SKIP_BOOTSTRAP=1` 关闭最后一步下载。
 
@@ -995,7 +998,7 @@ Open [http://localhost:8787](http://localhost:8787). Full notes: [`docs/docker-w
 
 ## Skill integration
 
-Source: [`skills/gpt-image-2-skill`](skills/gpt-image-2-skill). The entry point is [`scripts/gpt_image_2_skill.cjs`](skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs); it does not run image logic itself but resolves the underlying Rust binary in the order below and forwards every flag.
+Source: [`skills/gpt-image-2-skill`](skills/gpt-image-2-skill). The entry point is [`scripts/gpt_image_2_skill.cjs`](skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs); it does not run image logic itself but resolves the underlying Rust binary in the order below and forwards every flag. On Linux glibc sandboxes, it tries the GNU release asset first and then the static musl asset as fallback.
 
 **Install**:
 
@@ -1011,11 +1014,14 @@ cp -r /tmp/gpt-image-2-skill/skills/gpt-image-2-skill ~/.claude/skills/
 **Wrapper resolution order**:
 
 1. `GPT_IMAGE_2_SKILL_BIN` env (absolute binary path)
-2. `gpt-image-2-skill` on `PATH` (cargo / brew / npm install)
-3. Tauri App bundled CLI (`GPT_IMAGE_2_SKILL_APP_BIN` or standard app bundle paths)
-4. Repo-local `cargo run -q -p gpt-image-2-skill --` (only when both `Cargo.toml` and `cargo` exist)
-5. `${XDG_CACHE_HOME:-~/.cache}/gpt-image-2-skill/<version>/<target>/` cache
-6. Bootstrap: download the matching GitHub Release asset and cache it
+2. Bundled Skill binary (`bin/<target-triple>/gpt-image-2-skill`, when present)
+3. `gpt-image-2-skill` on `PATH` (cargo / brew / npm install)
+4. Tauri App bundled CLI (`GPT_IMAGE_2_SKILL_APP_BIN` or standard app bundle paths)
+5. Repo-local `cargo run -q -p gpt-image-2-skill --` (only when both `Cargo.toml` and `cargo` exist)
+6. `${XDG_CACHE_HOME:-~/.cache}/gpt-image-2-skill/<version>/<target>/` cache
+7. Bootstrap: download the matching GitHub Release asset and cache it
+
+On Linux glibc sandboxes, cache/bootstrap tries the GNU target (`*-unknown-linux-gnu`) and then the static musl target (`*-unknown-linux-musl`).
 
 Set `GPT_IMAGE_2_SKILL_SKIP_BOOTSTRAP=1` to disable the download step.
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -18,7 +18,7 @@ installers = ["shell", "powershell", "homebrew", "msi"]
 # and pulling in the Tauri app's Linux WebKit/GTK dependencies.
 precise-builds = true
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "aarch64-pc-windows-msvc", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Where to host releases
@@ -36,8 +36,10 @@ tap = "Wangnov/homebrew-tap"
 wixtoolset = { version = "3.14.1.20250415", targets = ["aarch64-pc-windows-msvc"] }
 
 [dist.github-custom-runners]
-x86_64-unknown-linux-gnu = "ubuntu-24.04"
-aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"
+x86_64-unknown-linux-musl = "ubuntu-22.04"
+aarch64-unknown-linux-gnu = "ubuntu-22.04-arm"
+aarch64-unknown-linux-musl = "ubuntu-22.04-arm"
 x86_64-apple-darwin = "macos-15-intel"
 aarch64-apple-darwin = "macos-15"
 x86_64-pc-windows-msvc = "windows-2025"

--- a/packages/npm/gpt-image-2-skill-linux-arm64-static/README.md
+++ b/packages/npm/gpt-image-2-skill-linux-arm64-static/README.md
@@ -1,0 +1,5 @@
+# gpt-image-2-skill-linux-arm64-static
+
+Published from https://github.com/Wangnov/gpt-image-2-skill.
+
+This package carries the aarch64-unknown-linux-musl binary.

--- a/packages/npm/gpt-image-2-skill-linux-arm64-static/package.json
+++ b/packages/npm/gpt-image-2-skill-linux-arm64-static/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gpt-image-2-skill-linux-arm64-static",
+  "version": "0.6.2",
+  "description": "Platform binary for gpt-image-2-skill (aarch64-unknown-linux-musl).",
+  "license": "MIT",
+  "homepage": "https://github.com/Wangnov/gpt-image-2-skill",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Wangnov/gpt-image-2-skill.git"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "bin": {
+    "gpt-image-2-skill": "bin/gpt-image-2-skill"
+  }
+}

--- a/packages/npm/gpt-image-2-skill-linux-x64-static/README.md
+++ b/packages/npm/gpt-image-2-skill-linux-x64-static/README.md
@@ -1,0 +1,5 @@
+# gpt-image-2-skill-linux-x64-static
+
+Published from https://github.com/Wangnov/gpt-image-2-skill.
+
+This package carries the x86_64-unknown-linux-musl binary.

--- a/packages/npm/gpt-image-2-skill-linux-x64-static/package.json
+++ b/packages/npm/gpt-image-2-skill-linux-x64-static/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "gpt-image-2-skill-linux-x64-static",
+  "version": "0.6.2",
+  "description": "Platform binary for gpt-image-2-skill (x86_64-unknown-linux-musl).",
+  "license": "MIT",
+  "homepage": "https://github.com/Wangnov/gpt-image-2-skill",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Wangnov/gpt-image-2-skill.git"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "bin": {
+    "gpt-image-2-skill": "bin/gpt-image-2-skill"
+  }
+}

--- a/packages/npm/gpt-image-2-skill/index.cjs
+++ b/packages/npm/gpt-image-2-skill/index.cjs
@@ -5,8 +5,10 @@ const childProcess = require("node:child_process");
 const TARGETS = [
   { platform: "darwin", arch: "arm64", packageName: "gpt-image-2-skill-darwin-arm64" },
   { platform: "darwin", arch: "x64", packageName: "gpt-image-2-skill-darwin-x64" },
-  { platform: "linux", arch: "arm64", packageName: "gpt-image-2-skill-linux-arm64-gnu", libc: "glibc" },
-  { platform: "linux", arch: "x64", packageName: "gpt-image-2-skill-linux-x64-gnu", libc: "glibc" },
+  { platform: "linux", arch: "arm64", packageName: "gpt-image-2-skill-linux-arm64-gnu", libc: "glibc", flavor: "gnu" },
+  { platform: "linux", arch: "arm64", packageName: "gpt-image-2-skill-linux-arm64-static", flavor: "static" },
+  { platform: "linux", arch: "x64", packageName: "gpt-image-2-skill-linux-x64-gnu", libc: "glibc", flavor: "gnu" },
+  { platform: "linux", arch: "x64", packageName: "gpt-image-2-skill-linux-x64-static", flavor: "static" },
   { platform: "win32", arch: "arm64", packageName: "gpt-image-2-skill-windows-arm64-msvc" },
   { platform: "win32", arch: "x64", packageName: "gpt-image-2-skill-windows-x64-msvc" }
 ];
@@ -28,32 +30,93 @@ function detectLibc() {
   }
 }
 
-function resolvePackageName() {
+function packageMatchesRuntime(target, libc) {
+  if (target.platform !== process.platform || target.arch !== process.arch) {
+    return false;
+  }
+  if (process.platform !== "linux") {
+    return true;
+  }
+  if (!target.libc) {
+    return true;
+  }
+  return target.libc === libc;
+}
+
+function packagePriority(target, libc) {
+  if (process.platform !== "linux") {
+    return 0;
+  }
+  if (target.flavor === "static") {
+    return libc === "musl" ? 0 : 1;
+  }
+  return 0;
+}
+
+function candidatePackages() {
   const libc = detectLibc();
-  const match = TARGETS.find((target) => {
-    if (target.platform !== process.platform) {
-      return false;
-    }
-    if (target.arch !== process.arch) {
-      return false;
-    }
-    if (!target.libc) {
-      return true;
-    }
-    return target.libc === libc;
-  });
-  if (!match) {
+  const candidates = TARGETS
+    .filter((target) => packageMatchesRuntime(target, libc))
+    .sort((left, right) => packagePriority(left, libc) - packagePriority(right, libc));
+  if (candidates.length === 0) {
     throw new Error(`unsupported platform: ${process.platform} ${process.arch}`);
   }
-  return match.packageName;
+  return candidates;
+}
+
+function resolveBinaryCandidates() {
+  const binaryName = process.platform === "win32" ? "gpt-image-2-skill.exe" : "gpt-image-2-skill";
+  const missing = [];
+  const candidates = [];
+  for (const target of candidatePackages()) {
+    try {
+      const packageJsonPath = require.resolve(`${target.packageName}/package.json`);
+      const packageDir = path.dirname(packageJsonPath);
+      candidates.push({
+        ...target,
+        binaryPath: path.join(packageDir, "bin", binaryName),
+      });
+    } catch (error) {
+      missing.push(`${target.packageName}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (candidates.length === 0) {
+    throw new Error(`No platform package is installed for ${process.platform} ${process.arch}. Tried: ${missing.join("; ")}`);
+  }
+  return candidates;
+}
+
+function isGlibcLoadError(stderr) {
+  return /GLIBC_[0-9.]+.*not found|version [`']GLIBC_[^`']+[`'] not found/.test(stderr || "");
+}
+
+function probeBinary(binaryPath) {
+  const result = childProcess.spawnSync(binaryPath, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  if (result.error) {
+    return { ok: false, message: result.error.message, stderr: "" };
+  }
+  if (result.status !== 0) {
+    return { ok: false, message: `${binaryPath} --version failed with status ${result.status}`, stderr: result.stderr || "" };
+  }
+  return { ok: true, message: "", stderr: "" };
 }
 
 function resolveBinaryPath() {
-  const packageName = resolvePackageName();
-  const packageJsonPath = require.resolve(`${packageName}/package.json`);
-  const packageDir = path.dirname(packageJsonPath);
-  const binaryName = process.platform === "win32" ? "gpt-image-2-skill.exe" : "gpt-image-2-skill";
-  return path.join(packageDir, "bin", binaryName);
+  const failures = [];
+  for (const candidate of resolveBinaryCandidates()) {
+    const probe = probeBinary(candidate.binaryPath);
+    if (probe.ok) {
+      return candidate.binaryPath;
+    }
+    failures.push(`${candidate.packageName}: ${probe.stderr || probe.message}`);
+    if (candidate.flavor !== "gnu" || !isGlibcLoadError(probe.stderr)) {
+      break;
+    }
+  }
+  throw new Error(`No usable gpt-image-2-skill binary found. ${failures.join("; ")}`);
 }
 
 function runCli(argv = process.argv.slice(2)) {
@@ -66,6 +129,7 @@ function runCli(argv = process.argv.slice(2)) {
 }
 
 module.exports = {
+  resolveBinaryCandidates,
   resolveBinaryPath,
   runCli,
 };

--- a/packages/npm/gpt-image-2-skill/package.json
+++ b/packages/npm/gpt-image-2-skill/package.json
@@ -23,7 +23,9 @@
     "gpt-image-2-skill-darwin-arm64": "0.6.2",
     "gpt-image-2-skill-darwin-x64": "0.6.2",
     "gpt-image-2-skill-linux-arm64-gnu": "0.6.2",
+    "gpt-image-2-skill-linux-arm64-static": "0.6.2",
     "gpt-image-2-skill-linux-x64-gnu": "0.6.2",
+    "gpt-image-2-skill-linux-x64-static": "0.6.2",
     "gpt-image-2-skill-windows-arm64-msvc": "0.6.2",
     "gpt-image-2-skill-windows-x64-msvc": "0.6.2"
   }

--- a/scripts/npm/build-matrix.mjs
+++ b/scripts/npm/build-matrix.mjs
@@ -39,6 +39,18 @@ const TARGETS = [
     os: ["linux"],
     cpu: ["arm64"],
     libc: ["glibc"],
+    flavor: "gnu",
+    archiveExtension: ".tar.xz",
+    binaryName: "gpt-image-2-skill",
+  },
+  {
+    target: "aarch64-unknown-linux-musl",
+    packageName: "gpt-image-2-skill-linux-arm64-static",
+    directory: "gpt-image-2-skill-linux-arm64-static",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: undefined,
+    flavor: "static",
     archiveExtension: ".tar.xz",
     binaryName: "gpt-image-2-skill",
   },
@@ -49,6 +61,18 @@ const TARGETS = [
     os: ["linux"],
     cpu: ["x64"],
     libc: ["glibc"],
+    flavor: "gnu",
+    archiveExtension: ".tar.xz",
+    binaryName: "gpt-image-2-skill",
+  },
+  {
+    target: "x86_64-unknown-linux-musl",
+    packageName: "gpt-image-2-skill-linux-x64-static",
+    directory: "gpt-image-2-skill-linux-x64-static",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: undefined,
+    flavor: "static",
     archiveExtension: ".tar.xz",
     binaryName: "gpt-image-2-skill",
   },
@@ -132,9 +156,12 @@ function rootPackageIndex() {
     if (target.libc?.length) {
       entries.push(`libc: ${JSON.stringify(target.libc[0])}`);
     }
+    if (target.flavor) {
+      entries.push(`flavor: ${JSON.stringify(target.flavor)}`);
+    }
     return `  { ${entries.join(", ")} }`;
   }).join(",\n");
-  return `const fs = require("node:fs");\nconst path = require("node:path");\nconst childProcess = require("node:child_process");\n\nconst TARGETS = [\n${targetTable}\n];\n\nfunction detectLibc() {\n  if (process.platform !== "linux") {\n    return null;\n  }\n  if (process.report && typeof process.report.getReport === "function") {\n    const report = process.report.getReport();\n    if (report && report.header && report.header.glibcVersionRuntime) {\n      return "glibc";\n    }\n  }\n  try {\n    return fs.existsSync("/etc/alpine-release") ? "musl" : "glibc";\n  } catch {\n    return "glibc";\n  }\n}\n\nfunction resolvePackageName() {\n  const libc = detectLibc();\n  const match = TARGETS.find((target) => {\n    if (target.platform !== process.platform) {\n      return false;\n    }\n    if (target.arch !== process.arch) {\n      return false;\n    }\n    if (!target.libc) {\n      return true;\n    }\n    return target.libc === libc;\n  });\n  if (!match) {\n    throw new Error(\`unsupported platform: \${process.platform} \${process.arch}\`);\n  }\n  return match.packageName;\n}\n\nfunction resolveBinaryPath() {\n  const packageName = resolvePackageName();\n  const packageJsonPath = require.resolve(\`\${packageName}/package.json\`);\n  const packageDir = path.dirname(packageJsonPath);\n  const binaryName = process.platform === "win32" ? "gpt-image-2-skill.exe" : "gpt-image-2-skill";\n  return path.join(packageDir, "bin", binaryName);\n}\n\nfunction runCli(argv = process.argv.slice(2)) {\n  const binaryPath = resolveBinaryPath();\n  const result = childProcess.spawnSync(binaryPath, argv, { stdio: "inherit" });\n  if (result.error) {\n    throw result.error;\n  }\n  return result.status ?? 1;\n}\n\nmodule.exports = {\n  resolveBinaryPath,\n  runCli,\n};\n`;
+  return `const fs = require("node:fs");\nconst path = require("node:path");\nconst childProcess = require("node:child_process");\n\nconst TARGETS = [\n${targetTable}\n];\n\nfunction detectLibc() {\n  if (process.platform !== "linux") {\n    return null;\n  }\n  if (process.report && typeof process.report.getReport === "function") {\n    const report = process.report.getReport();\n    if (report && report.header && report.header.glibcVersionRuntime) {\n      return "glibc";\n    }\n  }\n  try {\n    return fs.existsSync("/etc/alpine-release") ? "musl" : "glibc";\n  } catch {\n    return "glibc";\n  }\n}\n\nfunction packageMatchesRuntime(target, libc) {\n  if (target.platform !== process.platform || target.arch !== process.arch) {\n    return false;\n  }\n  if (process.platform !== "linux") {\n    return true;\n  }\n  if (!target.libc) {\n    return true;\n  }\n  return target.libc === libc;\n}\n\nfunction packagePriority(target, libc) {\n  if (process.platform !== "linux") {\n    return 0;\n  }\n  if (target.flavor === "static") {\n    return libc === "musl" ? 0 : 1;\n  }\n  return 0;\n}\n\nfunction candidatePackages() {\n  const libc = detectLibc();\n  const candidates = TARGETS\n    .filter((target) => packageMatchesRuntime(target, libc))\n    .sort((left, right) => packagePriority(left, libc) - packagePriority(right, libc));\n  if (candidates.length === 0) {\n    throw new Error(\`unsupported platform: \${process.platform} \${process.arch}\`);\n  }\n  return candidates;\n}\n\nfunction resolveBinaryCandidates() {\n  const binaryName = process.platform === "win32" ? "gpt-image-2-skill.exe" : "gpt-image-2-skill";\n  const missing = [];\n  const candidates = [];\n  for (const target of candidatePackages()) {\n    try {\n      const packageJsonPath = require.resolve(\`\${target.packageName}/package.json\`);\n      const packageDir = path.dirname(packageJsonPath);\n      candidates.push({\n        ...target,\n        binaryPath: path.join(packageDir, "bin", binaryName),\n      });\n    } catch (error) {\n      missing.push(\`\${target.packageName}: \${error instanceof Error ? error.message : String(error)}\`);\n    }\n  }\n  if (candidates.length === 0) {\n    throw new Error(\`No platform package is installed for \${process.platform} \${process.arch}. Tried: \${missing.join("; ")}\`);\n  }\n  return candidates;\n}\n\nfunction isGlibcLoadError(stderr) {\n  return /GLIBC_[0-9.]+.*not found|version [\`']GLIBC_[^\`']+[\`'] not found/.test(stderr || "");\n}\n\nfunction probeBinary(binaryPath) {\n  const result = childProcess.spawnSync(binaryPath, ["--version"], {\n    encoding: "utf8",\n    stdio: ["ignore", "ignore", "pipe"],\n  });\n  if (result.error) {\n    return { ok: false, message: result.error.message, stderr: "" };\n  }\n  if (result.status !== 0) {\n    return { ok: false, message: \`\${binaryPath} --version failed with status \${result.status}\`, stderr: result.stderr || "" };\n  }\n  return { ok: true, message: "", stderr: "" };\n}\n\nfunction resolveBinaryPath() {\n  const failures = [];\n  for (const candidate of resolveBinaryCandidates()) {\n    const probe = probeBinary(candidate.binaryPath);\n    if (probe.ok) {\n      return candidate.binaryPath;\n    }\n    failures.push(\`\${candidate.packageName}: \${probe.stderr || probe.message}\`);\n    if (candidate.flavor !== "gnu" || !isGlibcLoadError(probe.stderr)) {\n      break;\n    }\n  }\n  throw new Error(\`No usable gpt-image-2-skill binary found. \${failures.join("; ")}\`);\n}\n\nfunction runCli(argv = process.argv.slice(2)) {\n  const binaryPath = resolveBinaryPath();\n  const result = childProcess.spawnSync(binaryPath, argv, { stdio: "inherit" });\n  if (result.error) {\n    throw result.error;\n  }\n  return result.status ?? 1;\n}\n\nmodule.exports = {\n  resolveBinaryCandidates,\n  resolveBinaryPath,\n  runCli,\n};\n`;
 }
 
 function rootBinScript() {

--- a/scripts/release/configure-npm-trust.sh
+++ b/scripts/release/configure-npm-trust.sh
@@ -22,7 +22,9 @@ PACKAGES=(
   gpt-image-2-skill-darwin-arm64
   gpt-image-2-skill-darwin-x64
   gpt-image-2-skill-linux-arm64-gnu
+  gpt-image-2-skill-linux-arm64-static
   gpt-image-2-skill-linux-x64-gnu
+  gpt-image-2-skill-linux-x64-static
   gpt-image-2-skill-windows-arm64-msvc
   gpt-image-2-skill-windows-x64-msvc
 )

--- a/scripts/release/patch-release-workflow.mjs
+++ b/scripts/release/patch-release-workflow.mjs
@@ -13,6 +13,7 @@ const insertAfter = `      - name: Install dependencies
 `;
 
 const buildMarker = "      - name: Build artifacts";
+const muslStepName = "      - name: Configure musl toolchain";
 const wixStepName = "      - name: Refresh WiX path";
 const announceSectionMarker = "  announce:\n";
 const announceCheckoutMarker = `      - uses: actions/checkout@v6
@@ -52,6 +53,24 @@ const wixStep = `      - name: Refresh WiX path
           Write-Host "Using WiX root $wixRoot"
 `;
 
+const muslStep = `      - name: Configure musl toolchain
+        if: \${{ runner.os == 'Linux' && contains(join(matrix.targets, ','), 'unknown-linux-musl') }}
+        shell: bash
+        run: |
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y musl-tools
+          else
+            apt-get update
+            apt-get install -y musl-tools
+          fi
+
+          echo "CC_x86_64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+          echo "CC_aarch64_unknown_linux_musl=musl-gcc" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc" >> "$GITHUB_ENV"
+`;
+
 const dispatchSteps = `      - name: Dispatch npm publish workflow
         run: gh workflow run "Publish npm Packages" --repo "\${{ github.repository }}" -f tag="\${{ needs.plan.outputs.tag }}"
       - name: Dispatch static Pages deploy workflow
@@ -63,6 +82,19 @@ const legacyLinuxDepsStepPattern =
 let source = fs.readFileSync(workflowPath, "utf8");
 
 source = source.replace(legacyLinuxDepsStepPattern, "");
+source = source.replace(
+  `          sudo apt-get update
+          sudo apt-get install -y musl-tools
+`,
+  `          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y musl-tools
+          else
+            apt-get update
+            apt-get install -y musl-tools
+          fi
+`,
+);
 
 if (source.includes(permissionsBlock) && !source.includes(`  "actions": "write"`)) {
   source = source.replace(permissionsBlock, expandedPermissionsBlock);
@@ -77,6 +109,10 @@ if (!source.includes(wixStepName)) {
     `${insertAfter}${buildMarker}`,
     `${insertAfter}${wixStep}${buildMarker}`,
   );
+}
+
+if (!source.includes(muslStepName)) {
+  source = source.replace(insertAfter, `${insertAfter}${muslStep}`);
 }
 
 source = source.replace(dispatchStepPattern, "");

--- a/skills/gpt-image-2-skill/SKILL.md
+++ b/skills/gpt-image-2-skill/SKILL.md
@@ -3,7 +3,7 @@ name: gpt-image-2-skill
 description: This skill should be used when the user asks to "generate an image", "create a logo", "draw an icon", "edit this photo", "change background to transparent", "remove background", "use GPT image", "use Codex to draw", "用 GPT image 生成图片", "用 Codex 画图", "帮我生成一张图", "改成透明背景", "把这张图编辑一下", or any prompt-to-image or reference-image-edit task that benefits from a structured CLI returning JSON results and JSONL progress events. Supports OpenAI `gpt-image-2` (via `OPENAI_API_KEY` or OpenAI-compatible base URL) and Codex `image_generation` (via `~/.codex/auth.json`) under one command surface, with masks, custom sizes up to 4K, transparent backgrounds, and a raw request escape hatch.
 ---
 
-Run image generation and editing through one CLI surface that hides provider differences. The Node wrapper at `scripts/gpt_image_2_skill.cjs` resolves an underlying Rust binary (env override → installed binary → Tauri App bundled CLI → repo `cargo run` → cached release → bootstrap download) and forwards every flag.
+Run image generation and editing through one CLI surface that hides provider differences. The Node wrapper at `scripts/gpt_image_2_skill.cjs` resolves an underlying Rust binary (env override → bundled Skill binary → installed binary → Tauri App bundled CLI → repo `cargo run` → cached release → bootstrap download) and forwards every flag. On glibc Linux, release bootstrap tries the GNU archive first and then the static musl archive as the sandbox fallback.
 
 ## When to use this skill
 

--- a/skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs
+++ b/skills/gpt-image-2-skill/scripts/gpt_image_2_skill.cjs
@@ -19,6 +19,7 @@ const BIN_ENV = "GPT_IMAGE_2_SKILL_BIN";
 const APP_BIN_ENV = "GPT_IMAGE_2_SKILL_APP_BIN";
 const REPO_ENV = "GPT_IMAGE_2_SKILL_REPO_ROOT";
 const SKIP_BOOTSTRAP_ENV = "GPT_IMAGE_2_SKILL_SKIP_BOOTSTRAP";
+const SKILL_ROOT = path.resolve(__dirname, "..");
 
 function wantsJson(argv) {
   return argv.includes("--json");
@@ -106,6 +107,20 @@ function resolveFromEnvBinary() {
     return null;
   }
   return { argvPrefix: [candidate], cwd: null, source: "env" };
+}
+
+function resolveFromBundledBinary() {
+  const binaryName = process.platform === "win32" ? `${CLI_NAME}.exe` : CLI_NAME;
+  for (const { triple } of detectTargets()) {
+    const candidate = path.join(SKILL_ROOT, "bin", triple, binaryName);
+    if (isExecutableFile(candidate)) {
+      const runtime = { argvPrefix: [candidate], cwd: null, source: "bundled" };
+      if (runtimeSupportsSharedConfig(runtime)) {
+        return runtime;
+      }
+    }
+  }
+  return null;
 }
 
 function resolveFromPath() {
@@ -198,13 +213,13 @@ function detectLibc() {
   return fs.existsSync("/etc/alpine-release") ? "musl" : "gnu";
 }
 
-function detectTarget() {
+function detectTargets() {
   if (process.platform === "darwin") {
     if (process.arch === "arm64") {
-      return { triple: "aarch64-apple-darwin", extension: "" };
+      return [{ triple: "aarch64-apple-darwin", extension: "" }];
     }
     if (process.arch === "x64") {
-      return { triple: "x86_64-apple-darwin", extension: "" };
+      return [{ triple: "x86_64-apple-darwin", extension: "" }];
     }
     throw new Error(`Unsupported macOS architecture: ${process.arch}`);
   }
@@ -213,14 +228,19 @@ function detectTarget() {
     if (!arch) {
       throw new Error(`Unsupported Linux architecture: ${process.arch}`);
     }
-    return { triple: `${arch}-unknown-linux-${detectLibc()}`, extension: "" };
+    const libc = detectLibc();
+    const preferred = { triple: `${arch}-unknown-linux-${libc}`, extension: "" };
+    if (libc === "gnu") {
+      return [preferred, { triple: `${arch}-unknown-linux-musl`, extension: "" }];
+    }
+    return [preferred];
   }
   if (process.platform === "win32") {
     const arch = process.arch === "arm64" ? "aarch64" : process.arch === "x64" ? "x86_64" : null;
     if (!arch) {
       throw new Error(`Unsupported Windows architecture: ${process.arch}`);
     }
-    return { triple: `${arch}-pc-windows-msvc`, extension: ".exe" };
+    return [{ triple: `${arch}-pc-windows-msvc`, extension: ".exe" }];
   }
   throw new Error(`Unsupported platform: ${process.platform}`);
 }
@@ -230,12 +250,17 @@ function cacheBinaryPath(target, extension) {
 }
 
 function resolveFromCache() {
-  const { triple, extension } = detectTarget();
-  const candidate = cacheBinaryPath(triple, extension);
-  if (!isExecutableFile(candidate)) {
-    return null;
+  for (const { triple, extension } of detectTargets()) {
+    const candidate = cacheBinaryPath(triple, extension);
+    if (!isExecutableFile(candidate)) {
+      continue;
+    }
+    const runtime = { argvPrefix: [candidate], cwd: null, source: "cache" };
+    if (runtimeSupportsSharedConfig(runtime)) {
+      return runtime;
+    }
   }
-  return { argvPrefix: [candidate], cwd: null, source: "cache" };
+  return null;
 }
 
 function assetName(target) {
@@ -292,35 +317,49 @@ async function bootstrapReleaseBinary() {
   if (truthyEnv(SKIP_BOOTSTRAP_ENV)) {
     return null;
   }
-  const { triple, extension } = detectTarget();
-  const destination = cacheBinaryPath(triple, extension);
-  if (isExecutableFile(destination)) {
-    return { argvPrefix: [destination], cwd: null, source: "cache" };
+  const errors = [];
+
+  for (const { triple, extension } of detectTargets()) {
+    const destination = cacheBinaryPath(triple, extension);
+    if (isExecutableFile(destination)) {
+      const runtime = { argvPrefix: [destination], cwd: null, source: "cache" };
+      if (runtimeSupportsSharedConfig(runtime)) {
+        return runtime;
+      }
+    }
+
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${CLI_NAME}-bootstrap-`));
+    try {
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      const archiveName = assetName(triple);
+      const archivePath = path.join(tempRoot, archiveName);
+      await downloadArchive(`${RELEASE_BASE_URL}/${archiveName}`, archivePath);
+      const extractDir = path.join(tempRoot, "extract");
+      fs.mkdirSync(extractDir, { recursive: true });
+      extractArchive(archivePath, extractDir);
+
+      const binaryName = `${CLI_NAME}${extension}`;
+      const extractedBinary = findFile(extractDir, binaryName);
+      if (!extractedBinary) {
+        throw new Error(`Unable to locate ${binaryName} inside ${archiveName}`);
+      }
+      fs.copyFileSync(extractedBinary, destination);
+      if (process.platform !== "win32") {
+        fs.chmodSync(destination, 0o755);
+      }
+      const runtime = { argvPrefix: [destination], cwd: null, source: "bootstrap" };
+      if (runtimeSupportsSharedConfig(runtime)) {
+        return runtime;
+      }
+      errors.push(`${triple}: downloaded runtime failed self-check`);
+    } catch (error) {
+      errors.push(`${triple}: ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   }
 
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `${CLI_NAME}-bootstrap-`));
-  try {
-    fs.mkdirSync(path.dirname(destination), { recursive: true });
-    const archiveName = assetName(triple);
-    const archivePath = path.join(tempRoot, archiveName);
-    await downloadArchive(`${RELEASE_BASE_URL}/${archiveName}`, archivePath);
-    const extractDir = path.join(tempRoot, "extract");
-    fs.mkdirSync(extractDir, { recursive: true });
-    extractArchive(archivePath, extractDir);
-
-    const binaryName = `${CLI_NAME}${extension}`;
-    const extractedBinary = findFile(extractDir, binaryName);
-    if (!extractedBinary) {
-      throw new Error(`Unable to locate ${binaryName} inside ${archiveName}`);
-    }
-    fs.copyFileSync(extractedBinary, destination);
-    if (process.platform !== "win32") {
-      fs.chmodSync(destination, 0o755);
-    }
-    return { argvPrefix: [destination], cwd: null, source: "bootstrap" };
-  } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
-  }
+  throw new Error(`Unable to bootstrap a compatible ${CLI_NAME} runtime. Tried: ${errors.join("; ")}`);
 }
 
 function runtimeSupportsSharedConfig(runtime) {
@@ -345,7 +384,7 @@ function runtimeSupportsSharedConfig(runtime) {
 }
 
 async function resolveRuntime() {
-  for (const resolver of [resolveFromEnvBinary, resolveFromPath, resolveFromAppBundle, resolveFromRepo, resolveFromCache]) {
+  for (const resolver of [resolveFromEnvBinary, resolveFromBundledBinary, resolveFromPath, resolveFromAppBundle, resolveFromRepo, resolveFromCache]) {
     const runtime = resolver();
     if (runtime && runtimeSupportsSharedConfig(runtime)) {
       return runtime;


### PR DESCRIPTION
## Summary
- build Linux GNU release assets on Ubuntu 22.04 / 22.04 ARM and add musl static release targets
- publish linux-arm64-static and linux-x64-static npm platform packages, with GNU probing and static fallback in the npm wrapper
- teach the Skill wrapper cache/bootstrap path to try static musl on glibc Linux sandboxes and document the runtime resolution order
- expand post-release verification to Ubuntu 22.04, Ubuntu 22.04 ARM, and direct static package smoke checks

## Verification
- scripts/release/verify.sh
- cargo test -p gpt-image-2-skill
- node scripts/smoke_skill_install.cjs
- node scripts/npm/build-matrix.mjs --check
- simulated npm GLIBC_2.39 failure resolves to linux-arm64-static
- actionlint .github/workflows/release.yml .github/workflows/npm-publish.yml .github/workflows/post-release-verify.yml
- git diff --check
- dist plan --output-format=json confirmed GNU and musl targets on ubuntu-22.04 / ubuntu-22.04-arm
