### PR TITLE
生成队列：修复 filter 换行 + 文生图/图生图区分与参考图展示

### DIFF
--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -129,7 +129,8 @@ export function HistoryScreen({
           <span className="text-foreground font-medium">
             {finished.length} 条
           </span>{" "}
-          当前已加载的已完成 / 已失败任务。远端 Origin/Archive 不会被删除，此操作不可撤销。
+          当前已加载的已完成 / 已失败任务。远端 Origin/Archive
+          不会被删除，此操作不可撤销。
         </>
       ),
       confirmText: "清理",
@@ -328,11 +329,7 @@ export function HistoryScreen({
                   <motion.div
                     key={j.id}
                     layout="position"
-                    initial={
-                      reducedMotion
-                        ? false
-                        : { opacity: 0, y: 4 }
-                    }
+                    initial={reducedMotion ? false : { opacity: 0, y: 4 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={
                       reducedMotion

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -216,7 +216,7 @@ export function HistoryScreen({
       </header>
 
       {/* filters */}
-      <div className="mb-4 grid grid-cols-1 items-center gap-3 lg:grid-cols-[1fr_minmax(320px,560px)_1fr]">
+      <div className="mb-4 grid grid-cols-1 items-center gap-3 lg:grid-cols-[auto_1fr_auto]">
         <div className="flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-none">
           {FILTERS.map((f) => {
             const isActive = filter === f.value;
@@ -226,7 +226,7 @@ export function HistoryScreen({
                 type="button"
                 onClick={() => setFilter(f.value)}
                 className={cn(
-                  "relative px-3.5 h-8 rounded-full text-[12.5px] font-medium transition-colors",
+                  "relative shrink-0 whitespace-nowrap px-3.5 h-8 rounded-full text-[12.5px] font-medium transition-colors",
                   isActive
                     ? "text-foreground"
                     : "text-muted hover:text-foreground hover:bg-[color:var(--w-04)]",
@@ -250,7 +250,7 @@ export function HistoryScreen({
             );
           })}
         </div>
-        <label className="relative block min-w-0">
+        <label className="relative block w-full min-w-0 lg:mx-auto lg:max-w-[560px]">
           <Search
             size={15}
             className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-faint"

--- a/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-image-detail-drawer.tsx
@@ -26,6 +26,7 @@ import {
 import { imageAssetFromOutput } from "@/lib/image-actions/asset";
 import type { ImageAsset } from "@/lib/image-actions/types";
 import { PlaceholderImage } from "@/components/screens/shared/placeholder-image";
+import { JobReferenceCompare } from "./job-reference-compare";
 import {
   generationSlots,
   jobCanShowRecoveryAction,
@@ -524,6 +525,8 @@ export function JobImageDetailDrawer({
             </div>
           )}
 
+          {job && <JobReferenceCompare job={job} outputUrl={displayUrl} />}
+
           {/* Metadata panel */}
           <section className="surface-panel p-4 space-y-3.5">
             <div>
@@ -595,16 +598,16 @@ export function JobImageDetailDrawer({
                 {recovery &&
                   job &&
                   jobCanShowRecoveryAction(job, recoveryOptions) && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    icon="reload"
-                    title={recovery.title}
-                    onClick={() => onRetry?.(job.id)}
-                  >
-                    {recovery.label}
-                  </Button>
-                )}
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      icon="reload"
+                      title={recovery.title}
+                      onClick={() => onRetry?.(job.id)}
+                    >
+                      {recovery.label}
+                    </Button>
+                  )}
               </div>
 
               {slots.length > 0 && (

--- a/apps/gpt-image-2-app/src/components/screens/history/job-kind-icon.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-kind-icon.tsx
@@ -1,0 +1,97 @@
+import { Braces, CornerDownRight, Crop, Images, Sparkles } from "lucide-react";
+import { cn } from "@/lib/cn";
+import type { Job } from "@/lib/types";
+import { jobHasRegionEdit, jobKind } from "./shared";
+
+/**
+ * Icon-only affordance that tells text-to-image (`文生图`) apart from
+ * image-to-image (`图生图`, optionally a local `局部编辑`) and raw requests.
+ * Carries the human-readable kind in `title` + `aria-label` since the icon
+ * itself is the only visible cue.
+ */
+export function JobKindIcon({
+  job,
+  size = 13,
+  className,
+}: {
+  job: Job;
+  size?: number;
+  className?: string;
+}) {
+  const kind = jobKind(job);
+
+  if (kind === "edit") {
+    const region = jobHasRegionEdit(job);
+    const label = region ? "图生图 · 局部编辑" : "图生图";
+    const Icon = region ? Crop : Images;
+    return (
+      <span
+        title={label}
+        aria-label={label}
+        className={cn(
+          "inline-flex shrink-0 text-[color:var(--accent)]",
+          className,
+        )}
+      >
+        <Icon size={size} aria-hidden />
+      </span>
+    );
+  }
+
+  if (kind === "request") {
+    return (
+      <span
+        title="原始请求"
+        aria-label="原始请求"
+        className={cn("inline-flex shrink-0 text-faint", className)}
+      >
+        <Braces size={size} aria-hidden />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      title="文生图"
+      aria-label="文生图"
+      className={cn("inline-flex shrink-0 text-muted", className)}
+    >
+      <Sparkles size={size} aria-hidden />
+    </span>
+  );
+}
+
+/**
+ * `⤷N` corner badge marking how many input reference images fed an edit job.
+ * Renders nothing when there are none, so callers can drop it in
+ * unconditionally. Positioned bottom-right of a `relative` thumbnail by
+ * default; pass `className` to relocate.
+ */
+export function JobReferenceBadge({
+  count,
+  className,
+}: {
+  count: number;
+  className?: string;
+}) {
+  if (count <= 0) return null;
+  return (
+    <span
+      className={cn(
+        "absolute right-1 bottom-1 inline-flex items-center gap-0.5 rounded-md px-1 py-px text-[9.5px] font-mono font-semibold leading-none text-foreground",
+        className,
+      )}
+      style={{
+        background: "var(--k-65)",
+        backdropFilter: "blur(4px)",
+        WebkitBackdropFilter: "blur(4px)",
+        border: "1px solid var(--w-12)",
+      }}
+      aria-label={`${count} 张输入参考图`}
+      title={`${count} 张参考图`}
+    >
+      <CornerDownRight size={9} aria-hidden />
+      {count}
+    </span>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/screens/history/job-reference-compare.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-reference-compare.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/cn";
+import type { Job } from "@/lib/types";
+import { jobHasRegionEdit } from "./shared";
+import { useJobReferenceUrls } from "./job-reference-strip";
+
+const SHIMMER = {
+  background:
+    "linear-gradient(110deg, var(--bg-sunken) 0%, var(--bg-hover) 40%, var(--bg-sunken) 80%)",
+  backgroundSize: "200% 100%",
+} as const;
+
+/**
+ * Before/after wipe slider: the output is the base layer, the reference image is
+ * clipped on top and revealed left-to-right by a draggable handle. The range
+ * input is a full-bleed transparent control so it stays keyboard-accessible.
+ */
+function BeforeAfterSlider({ before, after }: { before: string; after: string }) {
+  const [pos, setPos] = useState(50);
+  return (
+    <div
+      className="relative w-full select-none overflow-hidden rounded-lg bg-[color:var(--k-18)] ring-1 ring-[color:var(--w-08)]"
+      style={{ height: 280 }}
+    >
+      <img
+        src={after}
+        alt="生成结果"
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+      />
+      <img
+        src={before}
+        alt="输入参考图"
+        draggable={false}
+        className="absolute inset-0 h-full w-full object-contain"
+        style={{ clipPath: `inset(0 ${100 - pos}% 0 0)` }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-0 bottom-0 w-px bg-[color:var(--accent)]"
+        style={{ left: `${pos}%` }}
+      >
+        <span className="absolute left-1/2 top-1/2 flex h-6 w-6 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[color:var(--accent)] text-[color:var(--bg)]">
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M8 7l-4 5 4 5M16 7l4 5-4 5" />
+          </svg>
+        </span>
+      </div>
+      <span
+        className="pointer-events-none absolute left-2 top-2 rounded px-1.5 py-0.5 text-[10px] font-mono text-foreground"
+        style={{ background: "var(--k-55)" }}
+      >
+        输入
+      </span>
+      <span
+        className="pointer-events-none absolute right-2 top-2 rounded px-1.5 py-0.5 text-[10px] font-mono text-foreground"
+        style={{ background: "var(--k-55)" }}
+      >
+        输出
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        value={pos}
+        onChange={(event) => setPos(Number(event.currentTarget.value))}
+        aria-label="对比输入与输出"
+        className="absolute inset-0 h-full w-full cursor-ew-resize opacity-0"
+      />
+    </div>
+  );
+}
+
+/**
+ * Detail-drawer section for an `images edit` job: shows the input reference
+ * images and, when an output exists, a before/after wipe against the selected
+ * reference. Renders nothing for text-to-image jobs.
+ */
+export function JobReferenceCompare({
+  job,
+  outputUrl,
+}: {
+  job: Job;
+  outputUrl?: string | null;
+}) {
+  const { urls, loading, count } = useJobReferenceUrls(job);
+  const [selected, setSelected] = useState(0);
+  useEffect(() => setSelected(0), [job.id]);
+  if (job.command !== "images edit" || count === 0) return null;
+  const region = jobHasRegionEdit(job);
+  const activeRef = urls[Math.min(selected, Math.max(0, urls.length - 1))];
+
+  return (
+    <section className="surface-panel space-y-3 p-4">
+      <div className="flex items-center gap-1.5">
+        <span className="t-caps">输入参考图</span>
+        <span className="font-mono text-[11px] text-faint">{count}</span>
+        {region && (
+          <span className="rounded bg-[color:var(--accent-10)] px-1 py-px text-[10px] text-[color:var(--accent)]">
+            局部编辑
+          </span>
+        )}
+      </div>
+
+      <div className="flex gap-2 overflow-x-auto scrollbar-none">
+        {loading && urls.length === 0
+          ? Array.from({ length: count }).map((_, i) => (
+              <div
+                key={i}
+                aria-hidden
+                className="h-14 w-14 shrink-0 rounded-md animate-shimmer"
+                style={SHIMMER}
+              />
+            ))
+          : urls.map((url, i) => (
+              <button
+                key={url}
+                type="button"
+                onClick={() => setSelected(i)}
+                className={cn(
+                  "relative h-14 w-14 shrink-0 overflow-hidden rounded-md ring-1 transition-all",
+                  i === selected
+                    ? "scale-[1.04] ring-[color:var(--accent-55)]"
+                    : "opacity-70 ring-[color:var(--w-10)] hover:opacity-100",
+                )}
+                aria-label={`参考图 ${i + 1}`}
+                aria-pressed={i === selected}
+                title={`参考图 ${i + 1}`}
+              >
+                <img
+                  src={url}
+                  alt=""
+                  loading="lazy"
+                  className="h-full w-full object-cover"
+                />
+              </button>
+            ))}
+      </div>
+
+      {activeRef && outputUrl ? (
+        <>
+          <BeforeAfterSlider before={activeRef} after={outputUrl} />
+          <p className="text-[10.5px] text-faint">
+            拖动滑块对比输入参考图与生成结果。
+          </p>
+        </>
+      ) : activeRef ? (
+        <div className="overflow-hidden rounded-lg ring-1 ring-[color:var(--w-08)]">
+          <img
+            src={activeRef}
+            alt="输入参考图"
+            className="block max-h-[280px] w-full bg-[color:var(--k-18)] object-contain"
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/screens/history/job-reference-compare.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-reference-compare.tsx
@@ -14,8 +14,19 @@ const SHIMMER = {
  * Before/after wipe slider: the output is the base layer, the reference image is
  * clipped on top and revealed left-to-right by a draggable handle. The range
  * input is a full-bleed transparent control so it stays keyboard-accessible.
+ *
+ * Both layers share one object-contain box, so the wipe lines up exactly when
+ * input and output share an aspect ratio (the common edit case). When ratios
+ * differ the contained images letterbox differently and the comparison is
+ * approximate — acceptable for a quick visual diff.
  */
-function BeforeAfterSlider({ before, after }: { before: string; after: string }) {
+function BeforeAfterSlider({
+  before,
+  after,
+}: {
+  before: string;
+  after: string;
+}) {
   const [pos, setPos] = useState(50);
   return (
     <div

--- a/apps/gpt-image-2-app/src/components/screens/history/job-reference-strip.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-reference-strip.tsx
@@ -15,6 +15,11 @@ export function useJobReferenceUrls(job: Job) {
   const [loading, setLoading] = useState(false);
   const count = jobReferenceCount(job);
   const isEdit = job.command === "images edit";
+  // Re-fetch when the reference set changes even if the count is stable (e.g.
+  // http/tauri resolving new paths), not just on id/count.
+  const refSig = Array.isArray(job.reference_images)
+    ? job.reference_images.map((ref) => `${ref.index}:${ref.path}`).join("|")
+    : "";
 
   useEffect(() => {
     if (!isEdit || count === 0) {
@@ -50,7 +55,7 @@ export function useJobReferenceUrls(job: Job) {
       revoke(acquired);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [job.id, isEdit, count]);
+  }, [job.id, isEdit, count, refSig]);
 
   return { urls, loading, count };
 }

--- a/apps/gpt-image-2-app/src/components/screens/history/job-reference-strip.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-reference-strip.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { cn } from "@/lib/cn";
+import type { Job } from "@/lib/types";
+import { jobHasRegionEdit, jobReferenceCount } from "./shared";
+
+/**
+ * Resolve displayable URLs for an edit job's input reference images. Handles the
+ * async nature of the browser runtime (IndexedDB → object URLs) uniformly with
+ * http/tauri (which resolve synchronously), and revokes any object URLs it
+ * created on unmount. Returns `[]` for text-to-image jobs.
+ */
+export function useJobReferenceUrls(job: Job) {
+  const [urls, setUrls] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const count = jobReferenceCount(job);
+  const isEdit = job.command === "images edit";
+
+  useEffect(() => {
+    if (!isEdit || count === 0) {
+      setUrls([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    let acquired: string[] = [];
+    const revoke = (list: string[]) =>
+      list.forEach((url) => {
+        if (url.startsWith("blob:")) URL.revokeObjectURL(url);
+      });
+    setLoading(true);
+    api
+      .jobReferenceUrls(job)
+      .then((next) => {
+        if (cancelled) {
+          revoke(next);
+          return;
+        }
+        acquired = next;
+        setUrls(next);
+      })
+      .catch(() => {
+        if (!cancelled) setUrls([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      revoke(acquired);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [job.id, isEdit, count]);
+
+  return { urls, loading, count };
+}
+
+/**
+ * Horizontal strip of input reference thumbnails for an `images edit` job, shown
+ * above the output grid in an expanded row so the input→output relationship is
+ * visible. Mirrors the editor's reference-strip visual language. Renders nothing
+ * for text-to-image jobs.
+ */
+export function JobReferenceStrip({
+  job,
+  onOpen,
+}: {
+  job: Job;
+  onOpen?: (index: number) => void;
+}) {
+  const { urls, loading, count } = useJobReferenceUrls(job);
+  if (job.command !== "images edit" || count === 0) return null;
+  const region = jobHasRegionEdit(job);
+
+  return (
+    <div className="mb-3">
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] text-faint">
+        <span className="t-caps">输入参考图</span>
+        <span className="font-mono">{count}</span>
+        {region && (
+          <span className="rounded px-1 py-px text-[10px] text-[color:var(--accent)] bg-[color:var(--accent-10)]">
+            局部编辑
+          </span>
+        )}
+      </div>
+      <div className="flex gap-2 overflow-x-auto scrollbar-none pb-0.5">
+        {loading && urls.length === 0
+          ? Array.from({ length: count }).map((_, i) => (
+              <div
+                key={i}
+                aria-hidden
+                className="h-16 w-16 shrink-0 rounded-md animate-shimmer"
+                style={{
+                  background:
+                    "linear-gradient(110deg, var(--bg-sunken) 0%, var(--bg-hover) 40%, var(--bg-sunken) 80%)",
+                  backgroundSize: "200% 100%",
+                }}
+              />
+            ))
+          : urls.map((url, i) => (
+              <button
+                key={url}
+                type="button"
+                onClick={
+                  onOpen
+                    ? (e) => {
+                        e.stopPropagation();
+                        onOpen(i);
+                      }
+                    : undefined
+                }
+                className={cn(
+                  "relative h-16 w-16 shrink-0 overflow-hidden rounded-md ring-1 ring-[color:var(--w-10)]",
+                  onOpen
+                    ? "transition-transform hover:scale-[1.03] hover:ring-[color:var(--accent-45)]"
+                    : "cursor-default",
+                )}
+                title={`参考图 ${i + 1}`}
+                aria-label={`参考图 ${i + 1}`}
+              >
+                <img
+                  src={url}
+                  alt={`参考图 ${i + 1}`}
+                  className="h-full w-full object-cover bg-[color:var(--k-18)]"
+                  loading="lazy"
+                />
+              </button>
+            ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
@@ -25,6 +25,8 @@ import {
 } from "@/lib/user-actions";
 import type { Job } from "@/lib/types";
 import { JobPreviewImage } from "./job-preview-image";
+import { JobKindIcon, JobReferenceBadge } from "./job-kind-icon";
+import { JobReferenceStrip } from "./job-reference-strip";
 import { StatusChip } from "./status-chip";
 import {
   jobErrorDetailText,
@@ -34,6 +36,7 @@ import {
   jobOutputErrors,
   jobPrompt,
   jobRatio,
+  jobReferenceCount,
   jobRecoveryAction,
   jobStatusLabel,
   jobThumbPath,
@@ -97,6 +100,7 @@ export function JobRowExpandable({
     return Array.from(indexes).sort((a, b) => a - b);
   }, [outputIndexes, outputErrors, planned]);
   const metaItems = jobMetaItems(job);
+  const refCount = jobReferenceCount(job);
   const errorMessage = jobErrorMessage(job);
   const errorDetail = jobErrorDetailText(job);
   const showPromptToggle = prompt.length > 240 || prompt.split("\n").length > 6;
@@ -195,10 +199,16 @@ export function JobRowExpandable({
               +{extraCount}
             </span>
           )}
+          <JobReferenceBadge count={refCount} />
         </div>
 
         <div className="min-w-0 self-center sm:flex-1">
-          <div className="text-[13px] text-foreground truncate">{prompt}</div>
+          <div className="flex items-center gap-1.5">
+            <JobKindIcon job={job} size={13} />
+            <span className="min-w-0 truncate text-[13px] text-foreground">
+              {prompt}
+            </span>
+          </div>
           <div className="text-[11px] text-faint mt-0.5 font-mono flex items-center gap-1.5">
             {metaItems.map((item, itemIndex) => (
               <span
@@ -329,6 +339,8 @@ export function JobRowExpandable({
                     </button>
                   </div>
                 </div>
+
+                <JobReferenceStrip job={job} />
 
                 {(status === "failed" || status === "partial_failed") &&
                   errorMessage && (

--- a/apps/gpt-image-2-app/src/components/screens/history/job-row.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-row.tsx
@@ -2,7 +2,7 @@ import { Fragment, useMemo, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { cn } from "@/lib/cn";
-import { Icon, type IconName } from "@/components/icon";
+import { Icon } from "@/components/icon";
 import { Badge } from "@/components/ui/badge";
 import { StatusDot } from "@/components/ui/status-dot";
 import { PlaceholderImage } from "@/components/screens/shared/placeholder-image";
@@ -13,13 +13,8 @@ import { api } from "@/lib/api";
 import { isActiveJobStatus } from "@/lib/api/types";
 import type { Job } from "@/lib/types";
 import { JobPreviewImage } from "./job-preview-image";
+import { JobKindIcon } from "./job-kind-icon";
 import { outputLabel } from "./shared";
-
-const CMD_ICON: Record<string, IconName> = {
-  "images generate": "generate",
-  "images edit": "edit",
-  "request create": "arrowin",
-};
 
 function badgeTone(status: Job["status"]) {
   if (status === "completed") return "ok" as const;
@@ -296,11 +291,7 @@ export function JobRow({
         <JobAvatar job={job} />
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
-            <Icon
-              name={CMD_ICON[job.command] ?? "sparkle"}
-              size={12}
-              style={{ color: "var(--text-faint)" }}
-            />
+            <JobKindIcon job={job} size={12} />
             <span className="truncate text-[12.5px] font-semibold">
               {title}
             </span>

--- a/apps/gpt-image-2-app/src/components/screens/history/shared.ts
+++ b/apps/gpt-image-2-app/src/components/screens/history/shared.ts
@@ -133,7 +133,10 @@ export type RecoveryActionCopy = {
   title: string;
   loading: string;
   success: string;
-  description: (resultJobId: string | undefined, originalJobId: string) => string;
+  description: (
+    resultJobId: string | undefined,
+    originalJobId: string,
+  ) => string;
 };
 
 export type RecoveryActionOptions = {
@@ -257,7 +260,11 @@ export function derivedRecoverability(job: Job): string {
   const storageFailed =
     job.storage_status === "failed" || job.storage_status === "partial_failed";
   const outputsPresent = jobOutputIndexes(job).length;
-  if (storageFailed && outputsPresent > 0 && outputsPresent >= plannedOutputCount(job)) {
+  if (
+    storageFailed &&
+    outputsPresent > 0 &&
+    outputsPresent >= plannedOutputCount(job)
+  ) {
     return "recoverable.upload_failed";
   }
 
@@ -396,7 +403,39 @@ export function jobMetaItems(job: Job): string[] {
   } else if (planned > 1 || produced > 0) {
     items.push(`${produced || planned} 张`);
   }
-  if (job.command === "images edit") items.push("编辑");
-  if (job.command === "request create") items.push("请求");
   return items;
+}
+
+export type JobKind = "generate" | "edit" | "request";
+
+/** Coarse creation kind for a job: text-to-image, image-to-image, or raw request. */
+export function jobKind(job: Job): JobKind {
+  if (job.command === "images edit") return "edit";
+  if (job.command === "request create") return "request";
+  return "generate";
+}
+
+/**
+ * Number of input reference images for an edit job. Prefers the backend-filled
+ * `reference_images` (works for http/tauri incl. legacy jobs); falls back to
+ * the browser runtime's `metadata.ref_count`.
+ */
+export function jobReferenceCount(job: Job): number {
+  if (Array.isArray(job.reference_images) && job.reference_images.length > 0) {
+    return job.reference_images.length;
+  }
+  const fromMeta = Number((job.metadata as Record<string, unknown>)?.ref_count);
+  return Number.isFinite(fromMeta) && fromMeta > 0 ? Math.floor(fromMeta) : 0;
+}
+
+/**
+ * Whether an edit job used a local region/mask (vs. plain reference images).
+ * Best-effort from metadata; absent markers degrade to `false` (no badge).
+ */
+export function jobHasRegionEdit(job: Job): boolean {
+  if (job.command !== "images edit") return false;
+  // The edit form persists `edit_region_mode` into metadata: "native-mask" /
+  // "reference-hint" for local region edits, "none" for plain reference edits.
+  const mode = (job.metadata as Record<string, unknown>)?.edit_region_mode;
+  return typeof mode === "string" && mode !== "" && mode !== "none";
 }

--- a/apps/gpt-image-2-app/src/components/screens/history/shared.ts
+++ b/apps/gpt-image-2-app/src/components/screens/history/shared.ts
@@ -421,7 +421,10 @@ export function jobKind(job: Job): JobKind {
  * the browser runtime's `metadata.ref_count`.
  */
 export function jobReferenceCount(job: Job): number {
-  if (Array.isArray(job.reference_images) && job.reference_images.length > 0) {
+  // The backend (http/tauri) always sends reference_images, so an empty array
+  // is authoritative ("no inputs"). Only fall back to the browser runtime's
+  // metadata.ref_count when the field is absent entirely.
+  if (Array.isArray(job.reference_images)) {
     return job.reference_images.length;
   }
   const fromMeta = Number((job.metadata as Record<string, unknown>)?.ref_count);

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -451,13 +451,17 @@ export const browserApi: ApiClient = {
     const path = jobOutputPath(job, index);
     return path ? browserApi.fileUrl(path) : "";
   },
+  // Returns disposable blob: URLs created from the IndexedDB-stored inputs; the
+  // caller (useJobReferenceUrls) revokes them on unmount. http/tauri instead
+  // return plain file URLs that need no cleanup. Filter/sort by `key` (the form
+  // field name like "ref_0"); `name` is the original filename like "cat.png".
   async jobReferenceUrls(job: Job) {
     const input = await browser.readJobInput(job.id);
     if (!input || input.kind !== "edit") return [];
-    const refIndex = (name: string) => Number(name.replace(/\D/g, "")) || 0;
+    const refIndex = (key: string) => Number(key.replace(/\D/g, "")) || 0;
     return input.files
-      .filter((file) => file.name.startsWith("ref_"))
-      .sort((a, b) => refIndex(a.name) - refIndex(b.name))
+      .filter((file) => file.key.startsWith("ref_"))
+      .sort((a, b) => refIndex(a.key) - refIndex(b.key))
       .map((file) => URL.createObjectURL(file.blob));
   },
   jobOutputPath,

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -425,10 +425,16 @@ export const browserApi: ApiClient = {
   },
   async resumeJob(
     jobId: string,
-    action: "continue_save" | "fill_missing" | "reupload" | "resubmit" | "discard",
+    action:
+      | "continue_save"
+      | "fill_missing"
+      | "reupload"
+      | "resubmit"
+      | "discard",
   ) {
     if (action === "resubmit") return browserApi.retryJob(jobId);
-    if (action === "discard") throw new Error("浏览器模式暂不支持丢弃恢复任务。");
+    if (action === "discard")
+      throw new Error("浏览器模式暂不支持丢弃恢复任务。");
     throw new Error("浏览器模式不支持继续完成，请改用 Docker/App。");
   },
   outputUrl(jobId: string, index = 0) {
@@ -444,6 +450,15 @@ export const browserApi: ApiClient = {
   jobOutputUrl(job: Job, index = 0) {
     const path = jobOutputPath(job, index);
     return path ? browserApi.fileUrl(path) : "";
+  },
+  async jobReferenceUrls(job: Job) {
+    const input = await browser.readJobInput(job.id);
+    if (!input || input.kind !== "edit") return [];
+    const refIndex = (name: string) => Number(name.replace(/\D/g, "")) || 0;
+    return input.files
+      .filter((file) => file.name.startsWith("ref_"))
+      .sort((a, b) => refIndex(a.name) - refIndex(b.name))
+      .map((file) => URL.createObjectURL(file.blob));
   },
   jobOutputPath,
   jobOutputPaths,

--- a/apps/gpt-image-2-app/src/lib/api/http-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http-transport.ts
@@ -296,7 +296,12 @@ export const httpApi: ApiClient = {
   },
   async resumeJob(
     jobId: string,
-    action: "continue_save" | "fill_missing" | "reupload" | "resubmit" | "discard",
+    action:
+      | "continue_save"
+      | "fill_missing"
+      | "reupload"
+      | "resubmit"
+      | "discard",
   ) {
     const result = await requestJson<TauriJobResponse>(
       `/jobs/${encodeURIComponent(jobId)}/resume`,
@@ -316,6 +321,11 @@ export const httpApi: ApiClient = {
   jobOutputUrl(job: Job, index = 0) {
     return apiResourceUrl(
       `/jobs/${encodeURIComponent(job.id)}/outputs/${index}`,
+    );
+  },
+  async jobReferenceUrls(job: Job) {
+    return (job.reference_images ?? []).map((ref) =>
+      apiResourceUrl(`/jobs/${encodeURIComponent(job.id)}/refs/${ref.index}`),
     );
   },
   jobOutputPath,

--- a/apps/gpt-image-2-app/src/lib/api/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/index.ts
@@ -156,9 +156,7 @@ export const api: ApiClient = {
       prompt,
       jobId,
       outputIndex,
-    ) as ReturnType<
-      ApiClient["copyImageToClipboard"]
-    >,
+    ) as ReturnType<ApiClient["copyImageToClipboard"]>,
   cancelJob: (id) =>
     invokeClient("cancelJob", id) as ReturnType<ApiClient["cancelJob"]>,
   queueStatus: () =>
@@ -199,7 +197,9 @@ export const api: ApiClient = {
     >,
   chooseFolder: (startDir) =>
     loadClient().then((client) =>
-      client.chooseFolder ? client.chooseFolder(startDir) : Promise.resolve(null),
+      client.chooseFolder
+        ? client.chooseFolder(startDir)
+        : Promise.resolve(null),
     ),
   createGenerate: (body) =>
     invokeClient("createGenerate", body) as ReturnType<
@@ -210,7 +210,9 @@ export const api: ApiClient = {
   retryJob: (jobId) =>
     invokeClient("retryJob", jobId) as ReturnType<ApiClient["retryJob"]>,
   resumeJob: (jobId, action) =>
-    invokeClient("resumeJob", jobId, action) as ReturnType<ApiClient["resumeJob"]>,
+    invokeClient("resumeJob", jobId, action) as ReturnType<
+      ApiClient["resumeJob"]
+    >,
   outputUrl(jobId, index) {
     return activeClient.outputUrl(jobId, index);
   },
@@ -222,6 +224,9 @@ export const api: ApiClient = {
   },
   jobOutputUrl(job, index) {
     return activeClient.jobOutputUrl(job, index);
+  },
+  jobReferenceUrls(job) {
+    return activeClient.jobReferenceUrls(job);
   },
   jobOutputPath(job, index) {
     return activeClient.jobOutputPath(job, index);

--- a/apps/gpt-image-2-app/src/lib/api/shared.ts
+++ b/apps/gpt-image-2-app/src/lib/api/shared.ts
@@ -65,9 +65,26 @@ export function normalizeJob(raw: Record<string, unknown>): Job {
   const outputPath =
     typeof raw.output_path === "string"
       ? raw.output_path
-      : indexZeroPath ?? (outputs.length === 0 ? metadataOutputPath : undefined);
+      : (indexZeroPath ??
+        (outputs.length === 0 ? metadataOutputPath : undefined));
   const rawStatus = String(raw.status ?? "completed");
   const status = rawStatus === "canceled" ? "cancelled" : rawStatus;
+  const referenceImages = Array.isArray(raw.reference_images)
+    ? raw.reference_images
+        .map((item) => {
+          const ref =
+            item && typeof item === "object"
+              ? (item as Record<string, unknown>)
+              : null;
+          if (!ref) return null;
+          const index = Number(ref.index);
+          const path = typeof ref.path === "string" ? ref.path : "";
+          if (!Number.isFinite(index) || !path) return null;
+          return { index, path };
+        })
+        .filter((ref): ref is { index: number; path: string } => ref !== null)
+        .sort((a, b) => a.index - b.index)
+    : undefined;
   const job: Job = {
     id: String(raw.id ?? ""),
     command: (raw.command as Job["command"]) ?? "images generate",
@@ -77,6 +94,7 @@ export function normalizeJob(raw: Record<string, unknown>): Job {
     updated_at: String(raw.updated_at ?? raw.created_at ?? ""),
     metadata,
     outputs,
+    reference_images: referenceImages,
     output_path: outputPath,
     storage_status:
       typeof raw.storage_status === "string"
@@ -253,9 +271,7 @@ function normalizePipelineConfig(
     : fallback.mode;
   const originRaw = value.origin;
   const origin =
-    typeof originRaw === "string" && originRaw.trim()
-      ? originRaw.trim()
-      : null;
+    typeof originRaw === "string" && originRaw.trim() ? originRaw.trim() : null;
   return {
     mode,
     origin,
@@ -367,11 +383,11 @@ export function migrateLegacyToPipeline(
  * `StorageTargetConfig::can_act_as_origin()`. Origin is limited to backends
  * with implemented readback in this build.
  */
-export function canActAsOrigin(target: StorageTargetConfig | undefined): boolean {
+export function canActAsOrigin(
+  target: StorageTargetConfig | undefined,
+): boolean {
   if (!target) return false;
-  return ["local", "s3", "webdav", "sftp"].includes(
-    storageTargetType(target),
-  );
+  return ["local", "s3", "webdav", "sftp"].includes(storageTargetType(target));
 }
 
 export function defaultPathConfig(): PathConfig {
@@ -581,12 +597,12 @@ export function normalizeStorageConfig(
   const policy = normalizeStorageManagementPolicy(config?.policy);
   const pipeline = applyStorageManagementPolicy(
     config?.pipeline
-    ? normalizePipelineConfig(config.pipeline)
-    : migrateLegacyToPipeline({
-        default_targets,
-        fallback_targets,
-        fallback_policy,
-      }),
+      ? normalizePipelineConfig(config.pipeline)
+      : migrateLegacyToPipeline({
+          default_targets,
+          fallback_targets,
+          fallback_policy,
+        }),
     policy,
   );
   return {

--- a/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
@@ -122,10 +122,14 @@ export const tauriApi: ApiClient = {
     return invoke<NotificationCapabilities>("notification_capabilities");
   },
   async updatePaths(config: PathConfig) {
-    return normalizeConfig(await invoke<ServerConfig>("update_paths", { config }));
+    return normalizeConfig(
+      await invoke<ServerConfig>("update_paths", { config }),
+    );
   },
   async updateStorage(config: StorageConfig) {
-    return normalizeConfig(await invoke<ServerConfig>("update_storage", { config }));
+    return normalizeConfig(
+      await invoke<ServerConfig>("update_storage", { config }),
+    );
   },
   async testStorageTarget(name: string, target?: StorageTargetConfig) {
     return invoke<StorageTestResult>("test_storage_target", { name, target });
@@ -300,7 +304,12 @@ export const tauriApi: ApiClient = {
   },
   async resumeJob(
     jobId: string,
-    action: "continue_save" | "fill_missing" | "reupload" | "resubmit" | "discard",
+    action:
+      | "continue_save"
+      | "fill_missing"
+      | "reupload"
+      | "resubmit"
+      | "discard",
   ) {
     const result = await invoke<TauriJobResponse>("resume_job", {
       jobId,
@@ -325,6 +334,11 @@ export const tauriApi: ApiClient = {
       return convertFileSrc(job.output_path);
     }
     return "";
+  },
+  async jobReferenceUrls(job: Job) {
+    return (job.reference_images ?? [])
+      .map((ref) => (ref.path ? convertFileSrc(ref.path) : ""))
+      .filter(Boolean);
   },
   jobOutputPath,
   jobOutputPaths,

--- a/apps/gpt-image-2-app/src/lib/api/types.ts
+++ b/apps/gpt-image-2-app/src/lib/api/types.ts
@@ -161,7 +161,10 @@ export type ApiClient = RuntimeCapabilities & {
     jobId: string,
     outputIndex: number,
   ): Promise<string[]>;
-  ensureJobOutputCached(jobId: string, outputIndex: number): Promise<string | null>;
+  ensureJobOutputCached(
+    jobId: string,
+    outputIndex: number,
+  ): Promise<string | null>;
   /**
    * Open the OS-native folder picker. Returns the selected absolute path or
    * `null` when the user cancels. Tauri-only — other runtimes do not expose
@@ -173,7 +176,12 @@ export type ApiClient = RuntimeCapabilities & {
   retryJob(jobId: string): Promise<TauriJobResponse>;
   resumeJob(
     jobId: string,
-    action: "continue_save" | "fill_missing" | "reupload" | "resubmit" | "discard",
+    action:
+      | "continue_save"
+      | "fill_missing"
+      | "reupload"
+      | "resubmit"
+      | "discard",
   ): Promise<TauriJobResponse>;
   outputUrl(jobId: string, index?: number): string;
   outputPath(jobId: string, index?: number): string | undefined;
@@ -181,6 +189,8 @@ export type ApiClient = RuntimeCapabilities & {
   jobOutputUrl(job: Job, index?: number): string;
   jobOutputPath(job: Job, index?: number): string | undefined;
   jobOutputPaths(job: Job): string[];
+  /** Resolve displayable URLs for an edit job's input reference images. */
+  jobReferenceUrls(job: Job): Promise<string[]>;
   subscribeJobEvents(
     jobId: string,
     onEvent: EventHandler,

--- a/apps/gpt-image-2-app/src/lib/types.ts
+++ b/apps/gpt-image-2-app/src/lib/types.ts
@@ -320,6 +320,16 @@ export interface OutputRef {
   uploads?: OutputUploadRef[];
 }
 
+/**
+ * A persisted input reference image for an `images edit` (image-to-image) job.
+ * The backend fills this by scanning `ref-{index}.png` in the job directory, so
+ * it works for legacy jobs too. Absent/empty for text-to-image jobs.
+ */
+export interface ReferenceImageRef {
+  index: number;
+  path: string;
+}
+
 export interface Job {
   id: string;
   command: "images generate" | "images edit" | "request create";
@@ -329,6 +339,7 @@ export interface Job {
   updated_at: string;
   metadata: Record<string, unknown>;
   outputs: OutputRef[];
+  reference_images?: ReferenceImageRef[];
   output_path?: string;
   storage_status?: StorageStatus | string;
   error?: Record<string, unknown> | null;

--- a/crates/gpt-image-2-core/src/history_list.rs
+++ b/crates/gpt-image-2-core/src/history_list.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use rusqlite::types::Value as SqlValue;
 use rusqlite::{Connection, Row, params, params_from_iter};
 use serde_json::{Value, json};
@@ -5,6 +7,7 @@ use serde_json::{Value, json};
 use crate::constants::{DEFAULT_HISTORY_PAGE_LIMIT, MAX_HISTORY_PAGE_LIMIT};
 use crate::errors::AppError;
 use crate::history_db::open_history_db;
+use crate::recovery::recovery_job_dir;
 use crate::storage::{
     OutputUploadRecord, enrich_outputs_with_uploads, list_output_upload_records_with_conn,
     storage_status_for_uploads,
@@ -61,6 +64,8 @@ pub(crate) fn history_row_to_value_with_uploads(
         .unwrap_or(&created_at)
         .to_string();
     let error = metadata.get("error").cloned().unwrap_or(Value::Null);
+    let reference_images =
+        reference_images_for_job(&metadata, output_path.as_deref(), &outputs);
     Ok(json!({
         "id": id,
         "command": row.get::<_, String>(1)?,
@@ -71,9 +76,79 @@ pub(crate) fn history_row_to_value_with_uploads(
         "updated_at": updated_at,
         "metadata": metadata,
         "outputs": enrich_outputs_with_uploads(outputs, uploads),
+        "reference_images": reference_images,
         "storage_status": storage_status_for_uploads(uploads),
         "error": error,
     }))
+}
+
+/// Locate the on-disk job directory for a history row.
+///
+/// Recovery/resume jobs persist the directory in metadata, but ordinary
+/// CLI/app edit jobs do not, so we fall back to the parent directory of any
+/// recorded output path (outputs live alongside the `ref-*.png` inputs).
+fn job_dir_for(metadata: &Value, output_path: Option<&str>, outputs: &Value) -> Option<PathBuf> {
+    if let Some(dir) = recovery_job_dir(metadata) {
+        return Some(dir);
+    }
+    let parent_of = |path: &str| Path::new(path).parent().map(Path::to_path_buf);
+    outputs
+        .as_array()
+        .and_then(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("path").and_then(Value::as_str))
+                .find_map(parent_of)
+        })
+        .or_else(|| output_path.and_then(parent_of))
+}
+
+/// Scan a job directory for reference input images named `ref-{index}.png`
+/// and return `[{ "index": <number>, "path": <absolute> }]` sorted by index.
+///
+/// Compatibility note: this reads the filesystem rather than any stored list,
+/// so older jobs (which never recorded reference metadata) still surface their
+/// inputs as long as the `ref-*.png` files exist on disk.
+fn scan_reference_images(job_dir: &Path) -> Vec<Value> {
+    let Ok(entries) = std::fs::read_dir(job_dir) else {
+        return Vec::new();
+    };
+    let mut refs: Vec<(u64, PathBuf)> = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_file() {
+                return None;
+            }
+            let index = parse_reference_index(path.file_name()?.to_str()?)?;
+            Some((index, path))
+        })
+        .collect();
+    refs.sort_by_key(|(index, _)| *index);
+    refs.into_iter()
+        .map(|(index, path)| json!({ "index": index, "path": path.display().to_string() }))
+        .collect()
+}
+
+/// Parse the numeric index from a `ref-{index}.png` file name, e.g.
+/// `ref-0.png` -> `Some(0)`. Returns `None` for any other name.
+fn parse_reference_index(file_name: &str) -> Option<u64> {
+    let stem = file_name.strip_suffix(".png")?;
+    let digits = stem.strip_prefix("ref-")?;
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse::<u64>().ok()
+}
+
+fn reference_images_for_job(
+    metadata: &Value,
+    output_path: Option<&str>,
+    outputs: &Value,
+) -> Value {
+    job_dir_for(metadata, output_path, outputs)
+        .map(|dir| Value::Array(scan_reference_images(&dir)))
+        .unwrap_or_else(|| Value::Array(Vec::new()))
 }
 
 fn redact_recovery_attempts(metadata: &mut Value) {

--- a/crates/gpt-image-2-core/src/history_list.rs
+++ b/crates/gpt-image-2-core/src/history_list.rs
@@ -64,11 +64,12 @@ pub(crate) fn history_row_to_value_with_uploads(
         .unwrap_or(&created_at)
         .to_string();
     let error = metadata.get("error").cloned().unwrap_or(Value::Null);
+    let command = row.get::<_, String>(1)?;
     let reference_images =
-        reference_images_for_job(&metadata, output_path.as_deref(), &outputs);
+        reference_images_for_job(&command, &metadata, output_path.as_deref(), &outputs);
     Ok(json!({
         "id": id,
-        "command": row.get::<_, String>(1)?,
+        "command": command,
         "provider": row.get::<_, String>(2)?,
         "status": row.get::<_, String>(3)?,
         "output_path": output_path,
@@ -103,13 +104,15 @@ fn job_dir_for(metadata: &Value, output_path: Option<&str>, outputs: &Value) -> 
         .or_else(|| output_path.and_then(parent_of))
 }
 
-/// Scan a job directory for reference input images named `ref-{index}.png`
+/// Scan a job directory for reference input images named `ref-{index}.{ext}`
 /// and return `[{ "index": <number>, "path": <absolute> }]` sorted by index.
 ///
 /// Compatibility note: this reads the filesystem rather than any stored list,
 /// so older jobs (which never recorded reference metadata) still surface their
-/// inputs as long as the `ref-*.png` files exist on disk.
+/// inputs as long as the `ref-*` files exist on disk.
 fn scan_reference_images(job_dir: &Path) -> Vec<Value> {
+    // A missing/unreadable directory means the job was cleaned up (or never had
+    // inputs); treating that as "no references" is correct, not an error.
     let Ok(entries) = std::fs::read_dir(job_dir) else {
         return Vec::new();
     };
@@ -130,11 +133,13 @@ fn scan_reference_images(job_dir: &Path) -> Vec<Value> {
         .collect()
 }
 
-/// Parse the numeric index from a `ref-{index}.png` file name, e.g.
-/// `ref-0.png` -> `Some(0)`. Returns `None` for any other name.
+/// Parse the numeric index from a `ref-{index}.{ext}` file name, e.g.
+/// `ref-0.png` / `ref-2.webp` -> `Some(0)` / `Some(2)`. Returns `None` otherwise.
 fn parse_reference_index(file_name: &str) -> Option<u64> {
-    let stem = file_name.strip_suffix(".png")?;
-    let digits = stem.strip_prefix("ref-")?;
+    // Inputs keep their original extension, so match `ref-{digits}.{ext}` for
+    // any extension rather than hard-coding `.png`.
+    let rest = file_name.strip_prefix("ref-")?;
+    let (digits, _ext) = rest.split_once('.')?;
     if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
         return None;
     }
@@ -142,10 +147,16 @@ fn parse_reference_index(file_name: &str) -> Option<u64> {
 }
 
 fn reference_images_for_job(
+    command: &str,
     metadata: &Value,
     output_path: Option<&str>,
     outputs: &Value,
 ) -> Value {
+    // Only edit jobs have reference inputs; skipping the scan for generate/
+    // request rows avoids a readdir per row on every history listing.
+    if command != "images edit" {
+        return Value::Array(Vec::new());
+    }
     job_dir_for(metadata, output_path, outputs)
         .map(|dir| Value::Array(scan_reference_images(&dir)))
         .unwrap_or_else(|| Value::Array(Vec::new()))

--- a/crates/gpt-image-2-web/src/file_api.rs
+++ b/crates/gpt-image-2-web/src/file_api.rs
@@ -99,7 +99,7 @@ pub(crate) async fn job_output_response(
         .map_err(|error| ApiError::internal(error.to_string()))
 }
 
-/// Serve a reference *input* image (`ref-{index}.png`) for an edit job.
+/// Serve a reference *input* image (`ref-{index}.{ext}`) for an edit job.
 ///
 /// Unlike outputs, reference images are the original source files written to
 /// the job directory at submission time, so we read them straight from disk
@@ -114,12 +114,21 @@ pub(crate) async fn job_reference_response(
     let job = show_history_job(&job_id)
         .map_err(app_error)
         .map_err(ApiError::not_found)?;
-    let job_dir = reference_job_dir_from_job(&job)
-        .ok_or_else(|| ApiError::not_found("找不到该任务的参考图目录。"))?;
-    // `reference_index` is a `usize` and the file name is pure digits, so the
-    // constructed path cannot introduce `..` or escape the job directory.
-    let candidate = job_dir.join(format!("ref-{reference_index}.png"));
-    let path = safe_job_file_path(&candidate.to_string_lossy())?;
+    // Resolve the actual reference path from the serialized `reference_images`
+    // (which honors the on-disk extension and is only populated for edit jobs),
+    // then funnel it through `safe_job_file_path` for canonicalization,
+    // managed-root checks, and path-traversal protection.
+    let reference_path = job
+        .get("reference_images")
+        .and_then(Value::as_array)
+        .and_then(|refs| {
+            refs.iter().find(|item| {
+                item.get("index").and_then(Value::as_u64) == Some(reference_index as u64)
+            })
+        })
+        .and_then(|item| item.get("path").and_then(Value::as_str))
+        .ok_or_else(|| ApiError::not_found("找不到该参考图。"))?;
+    let path = safe_job_file_path(reference_path)?;
     let bytes = tokio::fs::read(&path)
         .await
         .map_err(|error| ApiError::not_found(error.to_string()))?;
@@ -138,29 +147,6 @@ pub(crate) async fn job_reference_response(
         )
         .body(Body::from(bytes))
         .map_err(|error| ApiError::internal(error.to_string()))
-}
-
-/// Resolve the on-disk job directory from a serialized history job, mirroring
-/// the logic in `gpt-image-2-core`'s history serialization: prefer recovery
-/// metadata, then fall back to the parent directory of a recorded output path.
-fn reference_job_dir_from_job(job: &Value) -> Option<PathBuf> {
-    if let Some(dir) = job.get("metadata").and_then(recovery_job_dir) {
-        return Some(dir);
-    }
-    let parent_of = |path: &str| FsPath::new(path).parent().map(FsPath::to_path_buf);
-    job.get("outputs")
-        .and_then(Value::as_array)
-        .and_then(|outputs| {
-            outputs
-                .iter()
-                .filter_map(|output| output.get("path").and_then(Value::as_str))
-                .find_map(parent_of)
-        })
-        .or_else(|| {
-            job.get("output_path")
-                .and_then(Value::as_str)
-                .and_then(parent_of)
-        })
 }
 
 fn output_file_name_from_job(job: &Value, output_index: usize) -> String {

--- a/crates/gpt-image-2-web/src/file_api.rs
+++ b/crates/gpt-image-2-web/src/file_api.rs
@@ -99,6 +99,70 @@ pub(crate) async fn job_output_response(
         .map_err(|error| ApiError::internal(error.to_string()))
 }
 
+/// Serve a reference *input* image (`ref-{index}.png`) for an edit job.
+///
+/// Unlike outputs, reference images are the original source files written to
+/// the job directory at submission time, so we read them straight from disk
+/// rather than going through storage readback. The job directory is resolved
+/// the same way as in core history serialization (recovery metadata first,
+/// then the parent of a recorded output path), and the final path is funneled
+/// through `safe_job_file_path` for canonicalization, managed-root checks, and
+/// path-traversal protection.
+pub(crate) async fn job_reference_response(
+    Path((job_id, reference_index)): Path<(String, usize)>,
+) -> Result<Response, ApiError> {
+    let job = show_history_job(&job_id)
+        .map_err(app_error)
+        .map_err(ApiError::not_found)?;
+    let job_dir = reference_job_dir_from_job(&job)
+        .ok_or_else(|| ApiError::not_found("找不到该任务的参考图目录。"))?;
+    // `reference_index` is a `usize` and the file name is pure digits, so the
+    // constructed path cannot introduce `..` or escape the job directory.
+    let candidate = job_dir.join(format!("ref-{reference_index}.png"));
+    let path = safe_job_file_path(&candidate.to_string_lossy())?;
+    let bytes = tokio::fs::read(&path)
+        .await
+        .map_err(|error| ApiError::not_found(error.to_string()))?;
+    let mime = mime_guess::from_path(&path).first_or_octet_stream();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("reference.png");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, mime.as_ref())
+        .header(header::CACHE_CONTROL, "private, max-age=31536000")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("inline; filename=\"{file_name}\""),
+        )
+        .body(Body::from(bytes))
+        .map_err(|error| ApiError::internal(error.to_string()))
+}
+
+/// Resolve the on-disk job directory from a serialized history job, mirroring
+/// the logic in `gpt-image-2-core`'s history serialization: prefer recovery
+/// metadata, then fall back to the parent directory of a recorded output path.
+fn reference_job_dir_from_job(job: &Value) -> Option<PathBuf> {
+    if let Some(dir) = job.get("metadata").and_then(recovery_job_dir) {
+        return Some(dir);
+    }
+    let parent_of = |path: &str| FsPath::new(path).parent().map(FsPath::to_path_buf);
+    job.get("outputs")
+        .and_then(Value::as_array)
+        .and_then(|outputs| {
+            outputs
+                .iter()
+                .filter_map(|output| output.get("path").and_then(Value::as_str))
+                .find_map(parent_of)
+        })
+        .or_else(|| {
+            job.get("output_path")
+                .and_then(Value::as_str)
+                .and_then(parent_of)
+        })
+}
+
 fn output_file_name_from_job(job: &Value, output_index: usize) -> String {
     job.get("outputs")
         .and_then(Value::as_array)

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -98,6 +98,10 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
             "/jobs/{job_id}/outputs/{output_index}",
             get(job_output_response),
         )
+        .route(
+            "/jobs/{job_id}/refs/{index}",
+            get(job_reference_response),
+        )
         .route("/jobs/{job_id}/cancel", post(cancel_job))
         .route("/jobs/{job_id}/retry", post(retry_job))
         .route("/jobs/{job_id}/recovery", get(job_recovery))

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -98,10 +98,7 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
             "/jobs/{job_id}/outputs/{output_index}",
             get(job_output_response),
         )
-        .route(
-            "/jobs/{job_id}/refs/{index}",
-            get(job_reference_response),
-        )
+        .route("/jobs/{job_id}/refs/{index}", get(job_reference_response))
         .route("/jobs/{job_id}/cancel", post(cancel_job))
         .route("/jobs/{job_id}/retry", post(retry_job))
         .route("/jobs/{job_id}/recovery", get(job_recovery))


### PR DESCRIPTION
一并解决两个生成队列问题。

## 关联 issue
- Closes #18 — filter 栏「失败/部分失败」被迫换行
- Closes #19 — 未区分文生图/图生图、不展示输入参考图

## 进度
- [x] filter 换行修复（grid `auto_1fr_auto` + chip `shrink-0/nowrap` + 搜索框限宽居中）
- [ ] 类型标识层（icon-only 类型标 + 缩略图右下 `⤷N` 角标 + 局部标）
- [ ] 参考图取图 API（后端 `GET /api/jobs/{id}/refs/{index}` + history 序列化附加 ref 信息 + 前端三 transport）
- [ ] 展开/详情：参考图带 + before/after 滑块

> Draft，实现中。完成后转 Ready for review。
