### PR TITLE
fix(ci): 修复 Homebrew cask 的 brew style 失败

### DIFF
--- a/.github/workflows/tauri-app-release.yml
+++ b/.github/workflows/tauri-app-release.yml
@@ -448,7 +448,7 @@ jobs:
             homepage "https://github.com/Wangnov/gpt-image-2-skill"
 
             auto_updates true
-            depends_on macos: ">= :big_sur"
+            depends_on macos: :big_sur
 
             app "GPT Image 2.app"
 


### PR DESCRIPTION
publish-homebrew-cask 因 cask 里 macos 依赖写法触发新版 Homebrew rubocop 而失败。改用 symbol 形式 :big_sur（语义不变）。修复后发版的 cask 步骤不再失败。