### PR TITLE
feat(proxy): configurable network proxy (global + per-provider, SOCKS5)

### DIFF
--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -11,10 +11,9 @@ use std::{
 use gpt_image_2_core::{
     AppConfig, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions, KEYCHAIN_SERVICE,
     NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, ProxyConfig, StorageConfig,
-    StorageReadback,
-    StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    annotate_recovery_job_dir, append_history_job_event, batch_output_path, batch_recovery_job_dir,
-    batch_recovery_job_id, build_recovery_descriptor, default_config_path,
+    StorageReadback, StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides,
+    UploadFile, annotate_recovery_job_dir, append_history_job_event, batch_output_path,
+    batch_recovery_job_dir, batch_recovery_job_id, build_recovery_descriptor, default_config_path,
     default_keychain_account, delete_history_job, dispatch_task_notifications,
     edit_args_with_recovery, generate_args_with_recovery, generation_slots_from_batch_payload,
     generation_slots_from_outputs, history_db_path, initialize_product_runtime_paths,

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -10,7 +10,8 @@ use std::{
 
 use gpt_image_2_core::{
     AppConfig, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions, KEYCHAIN_SERVICE,
-    NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, StorageConfig, StorageReadback,
+    NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, ProxyConfig, StorageConfig,
+    StorageReadback,
     StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
     annotate_recovery_job_dir, append_history_job_event, batch_output_path, batch_recovery_job_dir,
     batch_recovery_job_id, build_recovery_descriptor, default_config_path,
@@ -107,6 +108,7 @@ pub fn run() {
             get_config,
             update_notifications,
             update_paths,
+            update_proxy,
             update_storage,
             test_notifications,
             test_storage_target,

--- a/apps/gpt-image-2-app/src-tauri/src/provider_config.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/provider_config.rs
@@ -60,6 +60,20 @@ pub(crate) fn convert_provider_input(
         };
         credentials.insert(secret, converted);
     }
+    // The UI always sends the full intended override (absent = inherit global),
+    // so take it verbatim — this lets "inherit" actually clear a previous
+    // override. Restore redacted credentials and validate before persisting so
+    // a bad per-provider proxy is rejected at save time, like the global one.
+    let proxy = match input.proxy {
+        Some(mut proxy) => {
+            if let Some(existing_proxy) = existing.and_then(|provider| provider.proxy.as_ref()) {
+                gpt_image_2_core::preserve_proxy_secrets(&mut proxy, existing_proxy);
+            }
+            gpt_image_2_core::validate_proxy_config(&proxy).map_err(app_error)?;
+            Some(proxy)
+        }
+        None => None,
+    };
     Ok((
         ProviderConfig {
             provider_type: input.provider_type,
@@ -69,10 +83,7 @@ pub(crate) fn convert_provider_input(
             credentials,
             supports_n: input.supports_n,
             edit_region_mode: input.edit_region_mode,
-            // The UI always sends the full intended override (absent = inherit
-            // global), so take it verbatim — this lets "inherit" actually clear
-            // a previous override.
-            proxy: input.proxy,
+            proxy,
         },
         input.set_default,
     ))

--- a/apps/gpt-image-2-app/src-tauri/src/provider_config.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/provider_config.rs
@@ -69,6 +69,10 @@ pub(crate) fn convert_provider_input(
             credentials,
             supports_n: input.supports_n,
             edit_region_mode: input.edit_region_mode,
+            // The UI always sends the full intended override (absent = inherit
+            // global), so take it verbatim — this lets "inherit" actually clear
+            // a previous override.
+            proxy: input.proxy,
         },
         input.set_default,
     ))

--- a/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
@@ -80,7 +80,12 @@ pub(crate) fn continue_save_job(job_id: &str) -> Result<Value, String> {
     let format = metadata.get("format").and_then(Value::as_str);
     let output_path = job_dir.join(format!("out.{}", output_extension(format)));
     let before_attempts = test_fault::provider_http_attempts(job_id);
-    let saved_files = materialize_openai_raw_response(&job_dir, &output_path).map_err(app_error)?;
+    let saved_files = materialize_openai_raw_response(
+        &job_dir,
+        &output_path,
+        job.get("provider").and_then(Value::as_str),
+    )
+    .map_err(app_error)?;
     let after_attempts = test_fault::provider_http_attempts(job_id);
     if after_attempts != before_attempts {
         return Err("continue_save attempted a provider HTTP request.".to_string());
@@ -186,12 +191,13 @@ fn merge_output_files(existing: Vec<Value>, filled: Vec<(usize, Value)>) -> Vec<
 fn materialize_cached_slot_payload(
     child_dir: &std::path::Path,
     output_path: &std::path::Path,
+    provider: Option<&str>,
 ) -> Option<Result<Value, String>> {
     if !raw_response_path(child_dir).is_file() {
         return None;
     }
     Some(
-        materialize_openai_raw_response(child_dir, output_path)
+        materialize_openai_raw_response(child_dir, output_path, provider)
             .map(|files| json!({ "output": normalize_batch_output(files) }))
             .map_err(app_error),
     )
@@ -234,7 +240,11 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 let child_id = batch_recovery_job_id(job_id, slot);
                 let child_dir = batch_recovery_job_dir(&job_dir, slot);
                 let out = batch_output_path(&job_dir, request.format.as_deref().or(format), slot);
-                if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
+                if let Some(cached) = materialize_cached_slot_payload(
+                    &child_dir,
+                    &out,
+                    job.get("provider").and_then(Value::as_str),
+                ) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
                         Err(message) => errors.push(BatchItemError {
@@ -268,7 +278,11 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 let child_id = batch_recovery_job_id(job_id, slot);
                 let child_dir = batch_recovery_job_dir(&job_dir, slot);
                 let out = batch_output_path(&job_dir, request.format.as_deref().or(format), slot);
-                if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
+                if let Some(cached) = materialize_cached_slot_payload(
+                    &child_dir,
+                    &out,
+                    job.get("provider").and_then(Value::as_str),
+                ) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
                         Err(message) => errors.push(BatchItemError {

--- a/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
@@ -58,9 +58,10 @@ pub(crate) fn update_paths(config: PathConfig, app: tauri::AppHandle) -> Result<
 }
 
 #[tauri::command]
-pub(crate) fn update_proxy(config: ProxyConfig) -> Result<Value, String> {
-    gpt_image_2_core::validate_proxy_config(&config).map_err(app_error)?;
+pub(crate) fn update_proxy(mut config: ProxyConfig) -> Result<Value, String> {
     let mut app_config = load_config()?;
+    gpt_image_2_core::preserve_proxy_secrets(&mut config, &app_config.proxy);
+    gpt_image_2_core::validate_proxy_config(&config).map_err(app_error)?;
     app_config.proxy = config;
     save_config(&app_config)?;
     Ok(config_for_ui(&app_config))

--- a/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
@@ -58,6 +58,15 @@ pub(crate) fn update_paths(config: PathConfig, app: tauri::AppHandle) -> Result<
 }
 
 #[tauri::command]
+pub(crate) fn update_proxy(config: ProxyConfig) -> Result<Value, String> {
+    gpt_image_2_core::validate_proxy_config(&config).map_err(app_error)?;
+    let mut app_config = load_config()?;
+    app_config.proxy = config;
+    save_config(&app_config)?;
+    Ok(config_for_ui(&app_config))
+}
+
+#[tauri::command]
 pub(crate) fn update_storage(mut config: StorageConfig) -> Result<Value, String> {
     let mut app_config = load_config()?;
     preserve_storage_secrets(&mut config, &app_config.storage);

--- a/apps/gpt-image-2-app/src-tauri/src/tests.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/tests.rs
@@ -13,6 +13,7 @@ fn openai_compatible_provider() -> ProviderConfig {
         credentials: BTreeMap::new(),
         supports_n: Some(false),
         edit_region_mode: Some("reference-hint".to_string()),
+        proxy: None,
     }
 }
 

--- a/apps/gpt-image-2-app/src-tauri/src/types.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/types.rs
@@ -19,6 +19,8 @@ pub(crate) struct ProviderInput {
     #[serde(default)]
     pub(crate) edit_region_mode: Option<String>,
     #[serde(default)]
+    pub(crate) proxy: Option<ProxyConfig>,
+    #[serde(default)]
     pub(crate) set_default: bool,
     #[serde(default)]
     pub(crate) allow_overwrite: bool,

--- a/apps/gpt-image-2-app/src/components/screens/providers/add-provider-dialog.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/providers/add-provider-dialog.tsx
@@ -518,7 +518,7 @@ export function AddProviderDialog({
           )}
         </div>
       )}
-      {!browserRuntime && (
+      {api.kind !== "browser" && (
         <div className="mt-1 grid gap-3.5 border-t border-border-faint pt-3.5">
           <Field
             label="网络代理"

--- a/apps/gpt-image-2-app/src/components/screens/providers/add-provider-dialog.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/providers/add-provider-dialog.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import {
+  PROVIDER_PROXY_MODE_OPTIONS,
+  type ProviderProxyMode,
+} from "@/components/screens/settings/constants";
+import { parseRecipients } from "@/components/screens/settings/settings-utils";
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { Field } from "@/components/ui/field";
@@ -8,13 +13,16 @@ import {
   Segmented,
   type SegmentedOption,
 } from "@/components/ui/segmented";
+import { Textarea } from "@/components/ui/textarea";
 import { useUpsertProvider } from "@/hooks/use-config";
 import { api } from "@/lib/api";
+import { normalizeProxyConfig } from "@/lib/api/shared";
 import { runtimeCopy } from "@/lib/runtime-copy";
 import type {
   CredentialSource,
   ProviderConfig,
   ProviderKind,
+  ProxyConfig,
 } from "@/lib/types";
 
 type EditRegionMode = NonNullable<ProviderConfig["edit_region_mode"]>;
@@ -23,6 +31,18 @@ function defaultEditRegionMode(kind: ProviderKind): EditRegionMode {
   if (kind === "openai") return "native-mask";
   if (kind === "codex") return "reference-hint";
   return "reference-hint";
+}
+
+/**
+ * Map a stored per-provider override onto the dialog's three-way picker.
+ * Absent override (or an explicit `system`, which behaves the same as having
+ * no override) reads as "inherit"; `none` / `custom` map directly.
+ */
+function providerProxyModeFromConfig(
+  proxy: ProxyConfig | undefined,
+): ProviderProxyMode {
+  if (!proxy || proxy.mode === "system") return "inherit";
+  return proxy.mode === "none" ? "none" : "custom";
 }
 
 export function AddProviderDialog({
@@ -54,6 +74,9 @@ export function AddProviderDialog({
   const [codexAccountId, setCodexAccountId] = useState("");
   const [codexAccessToken, setCodexAccessToken] = useState("");
   const [codexRefreshToken, setCodexRefreshToken] = useState("");
+  const [proxyMode, setProxyMode] = useState<ProviderProxyMode>("inherit");
+  const [proxyUrl, setProxyUrl] = useState("");
+  const [proxyNoProxyText, setProxyNoProxyText] = useState("");
 
   const upsert = useUpsertProvider();
   const editing = mode === "edit" && Boolean(providerName && provider);
@@ -105,6 +128,9 @@ export function AddProviderDialog({
     setCodexAccountId("");
     setCodexAccessToken("");
     setCodexRefreshToken("");
+    setProxyMode("inherit");
+    setProxyUrl("");
+    setProxyNoProxyText("");
   };
 
   useEffect(() => {
@@ -136,6 +162,16 @@ export function AddProviderDialog({
     setCodexAccountId("");
     setCodexAccessToken("");
     setCodexRefreshToken("");
+
+    setProxyMode(providerProxyModeFromConfig(provider.proxy));
+    setProxyUrl(
+      provider.proxy?.mode === "custom" ? (provider.proxy.url ?? "") : "",
+    );
+    setProxyNoProxyText(
+      provider.proxy?.mode === "custom"
+        ? (provider.proxy.no_proxy ?? []).join("\n")
+        : "",
+    );
   }, [browserRuntime, editing, open, provider, providerName]);
 
   const fileCredential = (value: string) =>
@@ -158,6 +194,19 @@ export function AddProviderDialog({
       });
       return;
     }
+    // inherit → no override (undefined). The backend preserves the previous
+    // value when this field is omitted, so an existing override can't be
+    // *cleared* through this dialog — only switched to 直连 / 自定义.
+    const proxyOverride: ProxyConfig | undefined =
+      proxyMode === "none"
+        ? { mode: "none" }
+        : proxyMode === "custom"
+          ? normalizeProxyConfig({
+              mode: "custom",
+              url: proxyUrl,
+              no_proxy: parseRecipients(proxyNoProxyText),
+            })
+          : undefined;
     try {
       await upsert.mutateAsync({
         name: trimmedName,
@@ -167,6 +216,7 @@ export function AddProviderDialog({
           model: model || undefined,
           supports_n: kind === "codex" ? false : supportsN,
           edit_region_mode: editRegionMode,
+          proxy: proxyOverride,
           credentials:
             kind === "codex"
               ? {
@@ -465,6 +515,58 @@ export function AddProviderDialog({
                 />
               </Field>
             </>
+          )}
+        </div>
+      )}
+      {!browserRuntime && (
+        <div className="mt-1 grid gap-3.5 border-t border-border-faint pt-3.5">
+          <Field
+            label="网络代理"
+            hint="默认跟随全局设置"
+          >
+            <Segmented
+              value={proxyMode}
+              onChange={setProxyMode}
+              ariaLabel="该凭证的网络代理"
+              className="w-full overflow-x-auto scrollbar-none"
+              options={PROVIDER_PROXY_MODE_OPTIONS}
+            />
+          </Field>
+          {proxyMode === "custom" && (
+            <>
+              <Field
+                label="代理地址"
+                hint="scheme://[user:pass@]host:port"
+              >
+                <Input
+                  value={proxyUrl}
+                  onChange={(e) => setProxyUrl(e.target.value)}
+                  placeholder="socks5h://127.0.0.1:1080"
+                  monospace
+                />
+              </Field>
+              <Field
+                label="绕过代理的主机"
+                hint="可选，每行一个或逗号分隔"
+              >
+                <Textarea
+                  value={proxyNoProxyText}
+                  onChange={(e) => setProxyNoProxyText(e.target.value)}
+                  placeholder={"localhost\n127.0.0.1"}
+                  monospace
+                  minHeight={64}
+                />
+              </Field>
+              <p className="text-[11px] text-faint">
+                支持 http / https / socks5 / socks5h；socks5h:// 由代理端做 DNS
+                解析。保存后地址只回显 scheme://host:port，重填完整地址才更新密码。
+              </p>
+            </>
+          )}
+          {proxyMode === "inherit" && editing && provider?.proxy && (
+            <p className="text-[11px] text-faint">
+              该供应商当前有单独的代理设置；保持「跟随全局」并保存即可清除它，恢复使用全局代理。
+            </p>
           )}
         </div>
       )}

--- a/apps/gpt-image-2-app/src/components/screens/settings/constants.ts
+++ b/apps/gpt-image-2-app/src/components/screens/settings/constants.ts
@@ -7,6 +7,7 @@ import {
   Info,
   KeyRound,
   ListChecks,
+  Network,
   Sparkles,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -44,6 +45,7 @@ export type SettingsTab =
   | "appearance"
   | "runtime"
   | "storage"
+  | "proxy"
   | "prompts"
   | "about";
 
@@ -52,11 +54,14 @@ export const NAV: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "外观", icon: Sparkles },
   { id: "runtime", label: "任务", icon: ListChecks },
   { id: "storage", label: "存储", icon: HardDrive },
+  { id: "proxy", label: "网络", icon: Network },
   { id: "prompts", label: "模板", icon: FileText },
   { id: "about", label: "关于", icon: Info },
 ];
 
-export const BROWSER_HIDDEN_TABS: SettingsTab[] = ["storage"];
+// Static Web routes provider traffic through the browser's own stack, so an
+// app-level proxy setting has nothing to act on — hide the tab there.
+export const BROWSER_HIDDEN_TABS: SettingsTab[] = ["storage", "proxy"];
 
 export const PARALLEL_OPTIONS = [1, 2, 3, 4, 6, 8].map((n) => ({
   value: String(n),
@@ -216,6 +221,26 @@ export const EXPORT_DIR_MODE_OPTIONS = [
   { value: "custom", label: "其他文件夹" },
 ] as const;
 
+/** Global proxy mode picker (settings → 网络). */
+export const PROXY_MODE_OPTIONS = [
+  { value: "system", label: "跟随系统" },
+  { value: "none", label: "直连" },
+  { value: "custom", label: "自定义" },
+] as const;
+
+/**
+ * Per-provider proxy override picker. `inherit` is a UI-only pseudo mode that
+ * maps to "no override" (provider.proxy === undefined); `none` / `custom` map
+ * to a real override.
+ */
+export type ProviderProxyMode = "inherit" | "none" | "custom";
+
+export const PROVIDER_PROXY_MODE_OPTIONS = [
+  { value: "inherit", label: "跟随全局" },
+  { value: "none", label: "强制直连" },
+  { value: "custom", label: "自定义" },
+] as const;
+
 export const TAB_TITLES: Record<
   SettingsTab,
   { title: string; subtitle: string }
@@ -235,6 +260,10 @@ export const TAB_TITLES: Record<
   storage: {
     title: "保存与归档",
     subtitle: "图片保存位置，以及是否自动归档到其他存储",
+  },
+  proxy: {
+    title: "网络代理",
+    subtitle: "供应商和 API 请求走系统代理、直连还是自定义代理",
   },
   prompts: {
     title: "提示词模板",

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -9,6 +9,7 @@ import { AppearancePanel } from "./appearance-panel";
 import { BROWSER_HIDDEN_TABS, type SettingsTab } from "./constants";
 import { CredsPanel } from "./credentials-panel";
 import { PanelHeader, SettingsNav } from "./layout";
+import { ProxyPanel } from "./proxy-panel";
 import { RuntimePanel } from "./runtime-panel";
 import { StoragePanel } from "./storage-panel";
 
@@ -75,6 +76,7 @@ export function SettingsScreen({ config }: { config?: ServerConfig } = {}) {
                 saveRef={storageSaveRef}
               />
             )}
+            {visibleTab === "proxy" && <ProxyPanel proxy={config?.proxy} />}
             {visibleTab === "prompts" && <PromptTemplatesPanel />}
             {visibleTab === "about" && <AboutPanel />}
           </motion.div>

--- a/apps/gpt-image-2-app/src/components/screens/settings/proxy-panel.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/proxy-panel.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from "react";
+import { Info } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Segmented } from "@/components/ui/segmented";
+import { Textarea } from "@/components/ui/textarea";
+import { useUpdateProxy } from "@/hooks/use-config";
+import type { ProxyConfig, ProxyMode } from "@/lib/types";
+import { PROXY_MODE_OPTIONS } from "./constants";
+import { Row, Section } from "./layout";
+import {
+  cloneProxyConfig,
+  parseRecipients,
+  prepareProxyConfigForSave,
+} from "./settings-utils";
+
+const PROXY_URL_PLACEHOLDER = "socks5h://127.0.0.1:1080";
+
+export function ProxyPanel({ proxy }: { proxy?: ProxyConfig }) {
+  const [draft, setDraft] = useState(() => cloneProxyConfig(proxy));
+  // The bypass list is edited as free text (one host per line or comma-
+  // separated) so typing a separator doesn't get re-flowed mid-edit; it is
+  // parsed back into draft.no_proxy on change and again at save time.
+  const [noProxyText, setNoProxyText] = useState(() =>
+    (proxy?.no_proxy ?? []).join("\n"),
+  );
+  const updateProxy = useUpdateProxy();
+
+  useEffect(() => {
+    setDraft(cloneProxyConfig(proxy));
+    setNoProxyText((proxy?.no_proxy ?? []).join("\n"));
+  }, [proxy]);
+
+  const isDirty = useMemo(
+    () =>
+      JSON.stringify(prepareProxyConfigForSave(draft)) !==
+      JSON.stringify(cloneProxyConfig(proxy)),
+    [draft, proxy],
+  );
+
+  const setMode = (mode: ProxyMode) => {
+    setDraft((current) => ({ ...current, mode }));
+  };
+
+  const setUrl = (url: string) => {
+    setDraft((current) => ({ ...current, url }));
+  };
+
+  const setNoProxy = (value: string) => {
+    setNoProxyText(value);
+    setDraft((current) => ({ ...current, no_proxy: parseRecipients(value) }));
+  };
+
+  const save = async () => {
+    try {
+      const saved = await updateProxy.mutateAsync(
+        prepareProxyConfigForSave(draft),
+      );
+      setDraft(cloneProxyConfig(saved.proxy));
+      setNoProxyText((saved.proxy?.no_proxy ?? []).join("\n"));
+      toast.success("代理设置已保存");
+    } catch (error) {
+      toast.error("保存代理设置失败", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  return (
+    <div className="flex-1 min-h-0 overflow-auto p-4 sm:p-5 space-y-4">
+      <Section
+        title="网络代理"
+        description="供应商和 API 请求的全局出站代理；单个凭证可在编辑里另行覆盖。"
+      >
+        <Row
+          title="代理模式"
+          description="跟随系统读取环境变量，直连忽略所有代理，自定义则使用下面的地址。"
+          control={
+            <Segmented<ProxyMode>
+              value={draft.mode}
+              onChange={setMode}
+              ariaLabel="代理模式"
+              options={PROXY_MODE_OPTIONS}
+            />
+          }
+        />
+
+        {draft.mode === "custom" && (
+          <>
+            <Row
+              title="代理地址"
+              description="scheme://[user:pass@]host:port"
+              control={
+                <div className="w-full sm:w-[320px]">
+                  <Input
+                    value={draft.url ?? ""}
+                    onChange={(event) => setUrl(event.target.value)}
+                    placeholder={PROXY_URL_PLACEHOLDER}
+                    monospace
+                    aria-label="代理地址"
+                  />
+                </div>
+              }
+            />
+            <Row
+              title="绕过代理的主机"
+              description="可选。每行一个，或用逗号分隔；命中的主机会直连。"
+              control={
+                <div className="w-full sm:w-[320px]">
+                  <Textarea
+                    value={noProxyText}
+                    onChange={(event) => setNoProxy(event.target.value)}
+                    placeholder={"localhost\n127.0.0.1\n*.example.com"}
+                    monospace
+                    minHeight={72}
+                    aria-label="绕过代理的主机"
+                  />
+                </div>
+              }
+            />
+            <div className="flex items-start gap-2 px-4 py-3 text-[12px] text-muted sm:px-5">
+              <Info size={14} className="mt-0.5 shrink-0" />
+              <div className="space-y-1">
+                <p>
+                  支持 http / https / socks5 / socks5h。推荐
+                  <span className="font-mono"> socks5h:// </span>
+                  —— 由代理端做 DNS 解析，可避免本机 DNS 污染（国内场景常用）。
+                </p>
+                <p>
+                  含账号密码时填完整
+                  <span className="font-mono">
+                    {" "}
+                    scheme://user:pass@host:port
+                  </span>
+                  ；出于安全，保存后只回显
+                  <span className="font-mono"> scheme://host:port</span>
+                  ，重新填写完整地址才会更新密码。
+                </p>
+              </div>
+            </div>
+          </>
+        )}
+
+        <div className="flex items-center justify-end gap-3 px-4 py-3.5 sm:px-5">
+          {isDirty && (
+            <span className="text-[12px] text-[color:var(--accent-70)]">
+              有未保存的改动
+            </span>
+          )}
+          <Button
+            variant="primary"
+            onClick={() => void save()}
+            disabled={!isDirty || updateProxy.isPending}
+          >
+            {updateProxy.isPending ? "保存中…" : "保存"}
+          </Button>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/gpt-image-2-app/src/components/screens/settings/settings-utils.ts
+++ b/apps/gpt-image-2-app/src/components/screens/settings/settings-utils.ts
@@ -1,8 +1,10 @@
 import {
   defaultNotificationConfig,
+  defaultProxyConfig,
   defaultStorageConfig,
   normalizeNotificationConfig,
   normalizePathConfig,
+  normalizeProxyConfig,
   normalizeStorageConfig,
   storageTargetType,
 } from "@/lib/api/shared";
@@ -11,6 +13,7 @@ import type {
   HttpStorageTargetConfig,
   NotificationConfig,
   PathConfig,
+  ProxyConfig,
   BaiduNetdiskStorageTargetConfig,
   Pan123OpenStorageTargetConfig,
   SftpStorageTargetConfig,
@@ -134,6 +137,20 @@ export function prepareNotificationConfigForSave(
       headers: webhookHeaders(webhook),
     })),
   };
+}
+
+export function cloneProxyConfig(value?: ProxyConfig) {
+  return normalizeProxyConfig(
+    value
+      ? (JSON.parse(JSON.stringify(value)) as ProxyConfig)
+      : defaultProxyConfig(),
+  );
+}
+
+export function prepareProxyConfigForSave(config: ProxyConfig): ProxyConfig {
+  // normalizeProxyConfig already trims the url, drops url / no_proxy outside
+  // custom mode, and de-dupes the bypass list — so saving is just a normalize.
+  return normalizeProxyConfig(config);
 }
 
 export function cloneStorageConfig(value?: StorageConfig) {

--- a/apps/gpt-image-2-app/src/hooks/use-config.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-config.ts
@@ -5,6 +5,7 @@ import type {
   NotificationConfig,
   PathConfig,
   ProviderConfig,
+  ProxyConfig,
   ServerConfig,
   StorageConfig,
   StorageTargetConfig,
@@ -93,6 +94,14 @@ export function useUpdateStorage() {
       }
       return api.updateStorage(config);
     },
+    onSuccess: (data) => qc.setQueryData(["config"], data),
+  });
+}
+
+export function useUpdateProxy() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (config: ProxyConfig) => api.updateProxy(config),
     onSuccess: (data) => qc.setQueryData(["config"], data),
   });
 }

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -4,6 +4,7 @@ import type {
   NotificationConfig,
   PathConfig,
   ProviderConfig,
+  ProxyConfig,
   ServerConfig,
   StorageConfig,
   StorageTargetConfig,
@@ -15,6 +16,7 @@ import {
   normalizeJobResponse,
   normalizeNotificationConfig,
   normalizePathConfig,
+  normalizeProxyConfig,
   normalizeStorageConfig,
   outputPath,
   storageTargetType,
@@ -114,6 +116,18 @@ export const browserApi: ApiClient = {
     return browser.browserConfigForUi(current);
   },
   testStorageTarget: browser.testBrowserStorageTarget,
+  async updateProxy(config: ProxyConfig) {
+    // Static Web has no local HTTP client whose proxy we could steer (fetch
+    // goes straight through the browser), so this is a best-effort round-trip:
+    // we persist the value to IndexedDB and hand it back. The settings UI hides
+    // the Proxy tab in this runtime, so this path is here only to satisfy the
+    // ApiClient contract.
+    await browser.prepareBrowserRuntime();
+    const current = await browser.readConfigRecord();
+    current.proxy = normalizeProxyConfig(config);
+    await browser.writeStoredConfig(browser.browserStoredConfig(current));
+    return browser.browserConfigForUi(current);
+  },
   async setDefault(name: string) {
     await browser.prepareBrowserRuntime();
     const config = await browser.readConfigRecord();

--- a/apps/gpt-image-2-app/src/lib/api/browser/config.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/config.ts
@@ -7,6 +7,7 @@ import type {
   StorageTargetConfig,
 } from "../../types";
 import {
+  defaultProxyConfig,
   normalizeConfig,
   normalizeNotificationConfig,
   normalizePathConfig,
@@ -330,6 +331,11 @@ export function browserConfigForUi(config: ServerConfig): ServerConfig {
     ),
     storage: sanitizeStorageConfig(config.storage),
     paths: normalizePathConfig(config.paths),
+    // Static Web has no local HTTP client to honor a proxy, so this value is
+    // never applied here — but we keep whatever is stored so the shape stays
+    // valid and round-trips cleanly. The settings UI hides the Proxy tab in
+    // this runtime (see BROWSER_HIDDEN_TABS).
+    proxy: config.proxy,
   });
 }
 
@@ -345,6 +351,7 @@ export function browserStoredConfig(config: ServerConfig): ServerConfig {
     notifications: normalizeNotificationConfig(config.notifications),
     storage: normalizeStorageConfig(config.storage),
     paths: normalizePathConfig(config.paths),
+    proxy: config.proxy ?? defaultProxyConfig(),
   };
 }
 

--- a/apps/gpt-image-2-app/src/lib/api/browser/store.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/store.ts
@@ -1,5 +1,5 @@
 import type { GenerateRequest, Job, OutputRef, ServerConfig } from "../../types";
-import { defaultNotificationConfig, defaultPathConfig, defaultStorageConfig, normalizeConfig, normalizeJob, outputPaths, rememberJobOutputs } from "../shared";
+import { defaultNotificationConfig, defaultPathConfig, defaultProxyConfig, defaultStorageConfig, normalizeConfig, normalizeJob, outputPaths, rememberJobOutputs } from "../shared";
 import type { JobListOptions, JobListPage } from "../types";
 import { isActiveJobStatus } from "../types";
 import { CONFIG_KEY, DB_NAME, DB_VERSION, blobsByPath, dbPromise, objectUrls } from "./state";
@@ -69,6 +69,7 @@ export async function readConfigRecord() {
       notifications: defaultNotificationConfig(),
       storage: defaultStorageConfig(),
       paths: defaultPathConfig(),
+      proxy: defaultProxyConfig(),
     },
   );
 }

--- a/apps/gpt-image-2-app/src/lib/api/http-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http-transport.ts
@@ -8,6 +8,7 @@ import type {
   NotificationTestResult,
   PathConfig,
   ProviderConfig,
+  ProxyConfig,
   QueueStatus,
   ServerConfig,
   StorageConfig,
@@ -113,6 +114,14 @@ export const httpApi: ApiClient = {
   async updateStorage(config: StorageConfig) {
     return normalizeConfig(
       await requestJson<ServerConfig>("/storage", {
+        method: "PUT",
+        body: jsonBody(config),
+      }),
+    );
+  },
+  async updateProxy(config: ProxyConfig) {
+    return normalizeConfig(
+      await requestJson<ServerConfig>("/proxy", {
         method: "PUT",
         body: jsonBody(config),
       }),

--- a/apps/gpt-image-2-app/src/lib/api/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/index.ts
@@ -108,6 +108,10 @@ export const api: ApiClient = {
       }
       return client.updateStorage(config);
     }),
+  updateProxy: (config) =>
+    invokeClient("updateProxy", config) as ReturnType<
+      ApiClient["updateProxy"]
+    >,
   testStorageTarget: (name, target) =>
     loadClient().then((client) => {
       if (!client.testStorageTarget) {

--- a/apps/gpt-image-2-app/src/lib/api/shared.ts
+++ b/apps/gpt-image-2-app/src/lib/api/shared.ts
@@ -8,6 +8,8 @@ import type {
   PathConfig,
   PipelineConfig,
   PipelineMode,
+  ProxyConfig,
+  ProxyMode,
   ServerConfig,
   StorageConfig,
   StorageFallbackPolicy,
@@ -402,6 +404,33 @@ export function defaultPathConfig(): PathConfig {
   };
 }
 
+export function defaultProxyConfig(): ProxyConfig {
+  return { mode: "system" };
+}
+
+const PROXY_MODES: ProxyMode[] = ["system", "none", "custom"];
+
+export function normalizeProxyConfig(
+  config?: Partial<ProxyConfig> | null,
+): ProxyConfig {
+  const mode = PROXY_MODES.includes(config?.mode as ProxyMode)
+    ? (config?.mode as ProxyMode)
+    : "system";
+  const url =
+    typeof config?.url === "string" && config.url.trim()
+      ? config.url.trim()
+      : undefined;
+  const noProxy = normalizeStringArray(config?.no_proxy);
+  const proxy: ProxyConfig = { mode };
+  // url / no_proxy only carry meaning in custom mode; drop them otherwise so
+  // the stored shape matches the backend (which skip-serializes empties).
+  if (mode === "custom") {
+    if (url) proxy.url = url;
+    if (noProxy.length > 0) proxy.no_proxy = noProxy;
+  }
+  return proxy;
+}
+
 export function storageTargetType(target?: StorageTargetConfig | null) {
   if (!target) return "local";
   if (target.type) return target.type;
@@ -713,12 +742,18 @@ export function normalizeConfig(config: ServerConfig): ServerConfig {
         {
           ...provider,
           credentials: provider.credentials ?? {},
+          // Preserve a per-provider override when present; leave it absent
+          // (= inherit global) otherwise so the UI can tell the two apart.
+          proxy: provider.proxy
+            ? normalizeProxyConfig(provider.proxy)
+            : undefined,
         },
       ]),
     ),
     notifications: normalizeNotificationConfig(config.notifications),
     storage: normalizeStorageConfig(config.storage),
     paths: normalizePathConfig(config.paths),
+    proxy: normalizeProxyConfig(config.proxy),
   };
 }
 

--- a/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
@@ -10,6 +10,7 @@ import type {
   NotificationTestResult,
   PathConfig,
   ProviderConfig,
+  ProxyConfig,
   QueueStatus,
   ServerConfig,
   StorageConfig,
@@ -129,6 +130,11 @@ export const tauriApi: ApiClient = {
   async updateStorage(config: StorageConfig) {
     return normalizeConfig(
       await invoke<ServerConfig>("update_storage", { config }),
+    );
+  },
+  async updateProxy(config: ProxyConfig) {
+    return normalizeConfig(
+      await invoke<ServerConfig>("update_proxy", { config }),
     );
   },
   async testStorageTarget(name: string, target?: StorageTargetConfig) {

--- a/apps/gpt-image-2-app/src/lib/api/types.ts
+++ b/apps/gpt-image-2-app/src/lib/api/types.ts
@@ -10,6 +10,7 @@ import type {
   ExportDirMode,
   PathConfig,
   ProviderConfig,
+  ProxyConfig,
   QueueStatus,
   ServerConfig,
   StorageConfig,
@@ -98,6 +99,7 @@ export type ApiClient = RuntimeCapabilities & {
   notificationCapabilities(): Promise<NotificationCapabilities>;
   updatePaths?(config: PathConfig): Promise<ServerConfig>;
   updateStorage?(config: StorageConfig): Promise<ServerConfig>;
+  updateProxy(config: ProxyConfig): Promise<ServerConfig>;
   testStorageTarget?(
     name: string,
     target?: StorageTargetConfig,

--- a/apps/gpt-image-2-app/src/lib/providers.test.ts
+++ b/apps/gpt-image-2-app/src/lib/providers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { defaultPathConfig, defaultStorageConfig } from "./api/shared";
+import {
+  defaultPathConfig,
+  defaultProxyConfig,
+  defaultStorageConfig,
+} from "./api/shared";
 import {
   effectiveDefaultProvider,
   reconcileProviderSelection,
@@ -45,6 +49,7 @@ function config(defaultProvider: string): ServerConfig {
     },
     storage: defaultStorageConfig(),
     paths: defaultPathConfig(),
+    proxy: defaultProxyConfig(),
   };
 }
 

--- a/apps/gpt-image-2-app/src/lib/types.ts
+++ b/apps/gpt-image-2-app/src/lib/types.ts
@@ -10,6 +10,28 @@ export interface CredentialRef {
   account?: string;
 }
 
+/**
+ * Outbound proxy mode for provider/API traffic.
+ * - `system`: inherit `HTTP(S)_PROXY` / `ALL_PROXY` / `NO_PROXY` from the
+ *   environment (default; preserves the HTTP client's built-in behavior).
+ * - `none`: force a direct connection, ignoring any environment proxy.
+ * - `custom`: use the explicit `url` (and `no_proxy`) below.
+ */
+export type ProxyMode = "system" | "none" | "custom";
+
+export interface ProxyConfig {
+  mode: ProxyMode;
+  /**
+   * `scheme://[user:pass@]host:port` where scheme ∈ http/https/socks5/socks5h.
+   * Only meaningful in `custom` mode. The backend strips credentials before
+   * returning config (same redaction as secrets), so values read back here are
+   * `scheme://host:port` with no password.
+   */
+  url?: string;
+  /** Hostnames/domains to bypass the proxy for. Custom mode only. */
+  no_proxy?: string[];
+}
+
 export interface ProviderConfig {
   type: ProviderKind;
   api_base?: string;
@@ -18,6 +40,11 @@ export interface ProviderConfig {
   supports_n?: boolean;
   edit_region_mode?: "native-mask" | "reference-hint" | "none";
   credentials: Record<string, CredentialRef>;
+  /**
+   * Per-provider proxy override. Absent/`undefined` inherits the global proxy;
+   * `{ mode: "none" }` forces a direct connection for this provider only.
+   */
+  proxy?: ProxyConfig;
   builtin?: boolean;
   disabled?: boolean;
   disabled_reason?: string;
@@ -294,6 +321,7 @@ export interface ServerConfig {
   notifications: NotificationConfig;
   storage: StorageConfig;
   paths: PathConfig;
+  proxy: ProxyConfig;
 }
 
 export type JobStatus =

--- a/crates/gpt-image-2-core/Cargo.toml
+++ b/crates/gpt-image-2-core/Cargo.toml
@@ -21,7 +21,7 @@ hmac = "0.12.1"
 lettre = { version = "0.11.21", default-features = false, features = ["builder", "hostname", "pool", "ring", "rustls", "smtp-transport", "webpki-roots"] }
 md-5 = "0.10.6"
 mime_guess = "2.0.5"
-reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "charset", "http2", "json", "multipart", "rustls-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "charset", "http2", "json", "multipart", "rustls-tls", "socks"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/gpt-image-2-core/src/auth/http.rs
+++ b/crates/gpt-image-2-core/src/auth/http.rs
@@ -2,15 +2,14 @@
 
 use super::*;
 
-pub(crate) fn make_client(timeout_seconds: u64) -> Result<Client, AppError> {
-    Client::builder()
+pub(crate) fn make_client(timeout_seconds: u64, proxy: &ProxyConfig) -> Result<Client, AppError> {
+    let builder = Client::builder()
         .timeout(Duration::from_secs(timeout_seconds))
-        .user_agent(build_user_agent())
-        .build()
-        .map_err(|error| {
-            AppError::new("http_client_error", "Unable to build HTTP client.")
-                .with_detail(json!({ "error": error.to_string() }))
-        })
+        .user_agent(build_user_agent());
+    apply_proxy(builder, proxy)?.build().map_err(|error| {
+        AppError::new("http_client_error", "Unable to build HTTP client.")
+            .with_detail(json!({ "error": error.to_string() }))
+    })
 }
 
 pub(crate) fn http_status_error(status: StatusCode, detail: String) -> AppError {

--- a/crates/gpt-image-2-core/src/auth/refresh.rs
+++ b/crates/gpt-image-2-core/src/auth/refresh.rs
@@ -2,14 +2,17 @@
 
 use super::*;
 
-pub(crate) fn refresh_access_token(auth_state: &mut CodexAuthState) -> Result<Value, AppError> {
+pub(crate) fn refresh_access_token(
+    auth_state: &mut CodexAuthState,
+    proxy: &ProxyConfig,
+) -> Result<Value, AppError> {
     let Some(refresh_token) = auth_state.refresh_token.clone() else {
         return Err(AppError::new(
             "refresh_token_missing",
             "Missing refresh_token in auth.json",
         ));
     };
-    let client = make_client(DEFAULT_REFRESH_TIMEOUT)?;
+    let client = make_client(DEFAULT_REFRESH_TIMEOUT, proxy)?;
     let response = client
         .post(REFRESH_ENDPOINT)
         .header(CONTENT_TYPE, "application/json")

--- a/crates/gpt-image-2-core/src/auth/refresh.rs
+++ b/crates/gpt-image-2-core/src/auth/refresh.rs
@@ -90,7 +90,7 @@ pub(crate) fn refresh_access_token(
     Ok(payload)
 }
 
-pub(crate) fn check_endpoint_reachability(endpoint: &str) -> Value {
+pub(crate) fn check_endpoint_reachability(endpoint: &str, proxy: &ProxyConfig) -> Value {
     let url = match Url::parse(endpoint) {
         Ok(url) => url,
         Err(error) => {
@@ -103,44 +103,47 @@ pub(crate) fn check_endpoint_reachability(endpoint: &str) -> Value {
     };
     let host = url.host_str().unwrap_or_default().to_string();
     let port = url.port_or_known_default().unwrap_or(443);
-    let mut reachable = false;
-    let mut dns_resolved = false;
-    let mut tcp_connected = false;
-    let mut addresses = Vec::<String>::new();
-    let mut error_text: Option<String> = None;
+    let proxy_mode = proxy_mode_str(proxy.mode);
 
-    match (host.as_str(), port).to_socket_addrs() {
-        Ok(iter) => {
-            dns_resolved = true;
-            for address in iter {
-                addresses.push(address.ip().to_string());
-                if TcpStream::connect_timeout(&address, Duration::from_secs(ENDPOINT_CHECK_TIMEOUT))
-                    .is_ok()
-                {
-                    tcp_connected = true;
-                    reachable = true;
-                    break;
-                }
-            }
-            if !tcp_connected {
-                error_text = Some("No address accepted a TCP connection.".to_string());
-            }
-        }
+    // Probe through the resolved proxy (System honors the environment, None
+    // forces direct, Custom uses the configured URL) so the result reflects the
+    // path real requests take — a direct TCP probe would wrongly report
+    // "unreachable" whenever the endpoint is only reachable via a proxy. Any
+    // HTTP response, including 4xx/5xx, proves the network path works.
+    let client = match make_client(ENDPOINT_CHECK_TIMEOUT, proxy) {
+        Ok(client) => client,
         Err(error) => {
-            error_text = Some(error.to_string());
+            return json!({
+                "endpoint": endpoint,
+                "host": host,
+                "port": port,
+                "scheme": url.scheme(),
+                "reachable": false,
+                "proxy": proxy_mode,
+                "error": error.message,
+            });
         }
+    };
+    match client.head(endpoint).send() {
+        Ok(response) => json!({
+            "endpoint": endpoint,
+            "host": host,
+            "port": port,
+            "scheme": url.scheme(),
+            "reachable": true,
+            "proxy": proxy_mode,
+            "status": response.status().as_u16(),
+            "tls_ok": if url.scheme() == "https" { Value::Bool(true) } else { Value::Null },
+            "error": Value::Null,
+        }),
+        Err(error) => json!({
+            "endpoint": endpoint,
+            "host": host,
+            "port": port,
+            "scheme": url.scheme(),
+            "reachable": false,
+            "proxy": proxy_mode,
+            "error": error.to_string(),
+        }),
     }
-
-    json!({
-        "endpoint": endpoint,
-        "host": host,
-        "port": port,
-        "scheme": url.scheme(),
-        "dns_resolved": dns_resolved,
-        "tcp_connected": tcp_connected,
-        "tls_ok": if url.scheme() == "https" { Value::Bool(reachable) } else { Value::Null },
-        "reachable": reachable,
-        "addresses": addresses,
-        "error": error_text,
-    })
 }

--- a/crates/gpt-image-2-core/src/config_commands.rs
+++ b/crates/gpt-image-2-core/src/config_commands.rs
@@ -188,6 +188,7 @@ pub(crate) fn run_config_add_provider(
             credentials,
             supports_n,
             edit_region_mode,
+            proxy: None,
         },
     );
     if args.set_default || config.default_provider.is_none() {

--- a/crates/gpt-image-2-core/src/config_commands.rs
+++ b/crates/gpt-image-2-core/src/config_commands.rs
@@ -88,9 +88,12 @@ pub(crate) fn run_config_command(
         }
         ConfigSubcommand::TestProvider(args) => {
             let selection = select_configured_provider(cli, &args.name, "config_test_provider")?;
+            let config = load_app_config(&cli_config_path(cli))?;
+            let proxy =
+                resolve_effective_proxy(&config.proxy, config.providers.get(&selection.resolved));
             let endpoint = match selection.kind {
-                ProviderKind::OpenAi => check_endpoint_reachability(&selection.api_base),
-                ProviderKind::Codex => check_endpoint_reachability(&selection.codex_endpoint),
+                ProviderKind::OpenAi => check_endpoint_reachability(&selection.api_base, &proxy),
+                ProviderKind::Codex => check_endpoint_reachability(&selection.codex_endpoint, &proxy),
             };
             Ok(CommandOutcome {
                 payload: json!({

--- a/crates/gpt-image-2-core/src/config_commands.rs
+++ b/crates/gpt-image-2-core/src/config_commands.rs
@@ -93,7 +93,9 @@ pub(crate) fn run_config_command(
                 resolve_effective_proxy(&config.proxy, config.providers.get(&selection.resolved));
             let endpoint = match selection.kind {
                 ProviderKind::OpenAi => check_endpoint_reachability(&selection.api_base, &proxy),
-                ProviderKind::Codex => check_endpoint_reachability(&selection.codex_endpoint, &proxy),
+                ProviderKind::Codex => {
+                    check_endpoint_reachability(&selection.codex_endpoint, &proxy)
+                }
             };
             Ok(CommandOutcome {
                 payload: json!({

--- a/crates/gpt-image-2-core/src/config_io.rs
+++ b/crates/gpt-image-2-core/src/config_io.rs
@@ -114,6 +114,7 @@ pub fn redact_app_config(config: &AppConfig) -> Value {
                     "model": provider.model,
                     "supports_n": provider.supports_n,
                     "credentials": credentials,
+                    "proxy": provider.proxy.as_ref().map(redact_proxy_config),
                 }),
             )
         })
@@ -125,6 +126,7 @@ pub fn redact_app_config(config: &AppConfig) -> Value {
         "notifications": redact_notification_config(&config.notifications),
         "storage": redact_storage_config(&config.storage),
         "paths": config.paths,
+        "proxy": redact_proxy_config(&config.proxy),
     })
 }
 

--- a/crates/gpt-image-2-core/src/config_types.rs
+++ b/crates/gpt-image-2-core/src/config_types.rs
@@ -24,6 +24,34 @@ pub enum CredentialRef {
     },
 }
 
+/// How outbound HTTP requests pick a proxy.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProxyMode {
+    /// Inherit from the environment (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY`).
+    /// This is the default and preserves reqwest's built-in behavior.
+    #[default]
+    System,
+    /// Force a direct connection, ignoring any environment proxy.
+    None,
+    /// Use the explicit `url` (and `no_proxy`) below.
+    Custom,
+}
+
+/// Proxy settings for outbound provider/API traffic. `no_proxy` only applies in
+/// `Custom` mode (in `System` mode the environment's `NO_PROXY` governs).
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct ProxyConfig {
+    #[serde(default)]
+    pub mode: ProxyMode,
+    /// `scheme://[user:pass@]host:port` where scheme is http/https/socks5/socks5h.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Hostnames/domains to bypass the proxy for (Custom mode only).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub no_proxy: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     pub version: u32,
@@ -37,6 +65,8 @@ pub struct AppConfig {
     pub storage: StorageConfig,
     #[serde(default)]
     pub paths: PathConfig,
+    #[serde(default)]
+    pub proxy: ProxyConfig,
 }
 
 impl Default for AppConfig {
@@ -48,6 +78,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             storage: StorageConfig::default(),
             paths: PathConfig::default(),
+            proxy: ProxyConfig::default(),
         }
     }
 }

--- a/crates/gpt-image-2-core/src/history_commands.rs
+++ b/crates/gpt-image-2-core/src/history_commands.rs
@@ -52,16 +52,20 @@ pub(crate) fn run_doctor(cli: &Cli) -> CommandOutcome {
     let config = load_app_config(&config_path).unwrap_or_default();
     let codex_auth = inspect_codex_auth_file(&auth_path);
     let openai_auth = inspect_openai_auth(cli.api_key.as_deref());
-    let codex_endpoint = check_endpoint_reachability(&cli.endpoint);
-    let openai_endpoint = check_endpoint_reachability(&cli.openai_api_base);
+    let codex_endpoint = check_endpoint_reachability(&cli.endpoint, &config.proxy);
+    let openai_endpoint = check_endpoint_reachability(&cli.openai_api_base, &config.proxy);
 
     let selection = select_image_provider(cli);
     let ready = selection
         .as_ref()
         .map(|selection| {
+            let proxy =
+                resolve_effective_proxy(&config.proxy, config.providers.get(&selection.resolved));
             let endpoint = match selection.kind {
-                ProviderKind::OpenAi => check_endpoint_reachability(&selection.api_base),
-                ProviderKind::Codex => check_endpoint_reachability(&selection.codex_endpoint),
+                ProviderKind::OpenAi => check_endpoint_reachability(&selection.api_base, &proxy),
+                ProviderKind::Codex => {
+                    check_endpoint_reachability(&selection.codex_endpoint, &proxy)
+                }
             };
             endpoint
                 .get("reachable")

--- a/crates/gpt-image-2-core/src/image_commands.rs
+++ b/crates/gpt-image-2-core/src/image_commands.rs
@@ -13,6 +13,7 @@ pub(crate) fn run_openai_image_command(
 ) -> Result<CommandOutcome, AppError> {
     let output_path = PathBuf::from(&shared.out);
     let auth_state = load_openai_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let resolved_ref_images = resolve_ref_images(ref_images)?;
     let resolved_mask = match mask {
         Some(mask) => Some(resolve_ref_image(mask)?),
@@ -53,9 +54,9 @@ pub(crate) fn run_openai_image_command(
     let mut logger = JsonEventLogger::new(cli.json_events);
     let request_result = execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
         if operation == "edit" {
-            request_openai_edit_once(&endpoint, &auth_state, &body, logger, recovery.as_mut())
+            request_openai_edit_once(&endpoint, &auth_state, &body, logger, recovery.as_mut(), &proxy)
         } else {
-            request_openai_images_once(&endpoint, &auth_state, &body, logger, recovery.as_mut())
+            request_openai_images_once(&endpoint, &auth_state, &body, logger, recovery.as_mut(), &proxy)
         }
     });
     let (payload, retry_count) = match request_result {
@@ -73,7 +74,7 @@ pub(crate) fn run_openai_image_command(
         let _ = ctx.finish_error(RecoveryStage::ResponseReceived, &error);
         return Err(error);
     }
-    let (image_bytes_list, revised_prompts) = match decode_openai_images(&payload) {
+    let (image_bytes_list, revised_prompts) = match decode_openai_images(&payload, &proxy) {
         Ok(value) => value,
         Err(error) => {
             if let Some(ctx) = recovery.as_mut() {
@@ -171,6 +172,7 @@ pub(crate) fn run_codex_image_command(
     ref_images: &[String],
 ) -> Result<CommandOutcome, AppError> {
     let mut auth_state = load_codex_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let output_path = PathBuf::from(&shared.out);
     let resolved_ref_images = resolve_ref_images(ref_images)?;
     let resolved_model = shared
@@ -195,6 +197,7 @@ pub(crate) fn run_codex_image_command(
         &mut auth_state,
         &body,
         &mut logger,
+        &proxy,
     )?;
     let output_items = outcome
         .get("output_items")

--- a/crates/gpt-image-2-core/src/image_commands.rs
+++ b/crates/gpt-image-2-core/src/image_commands.rs
@@ -54,9 +54,23 @@ pub(crate) fn run_openai_image_command(
     let mut logger = JsonEventLogger::new(cli.json_events);
     let request_result = execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
         if operation == "edit" {
-            request_openai_edit_once(&endpoint, &auth_state, &body, logger, recovery.as_mut(), &proxy)
+            request_openai_edit_once(
+                &endpoint,
+                &auth_state,
+                &body,
+                logger,
+                recovery.as_mut(),
+                &proxy,
+            )
         } else {
-            request_openai_images_once(&endpoint, &auth_state, &body, logger, recovery.as_mut(), &proxy)
+            request_openai_images_once(
+                &endpoint,
+                &auth_state,
+                &body,
+                logger,
+                recovery.as_mut(),
+                &proxy,
+            )
         }
     });
     let (payload, retry_count) = match request_result {

--- a/crates/gpt-image-2-core/src/image_requests/codex.rs
+++ b/crates/gpt-image-2-core/src/image_requests/codex.rs
@@ -7,6 +7,7 @@ pub(crate) fn request_codex_responses_once(
     auth_state: &CodexAuthState,
     body: &Value,
     logger: &mut JsonEventLogger,
+    proxy: &ProxyConfig,
 ) -> Result<Value, AppError> {
     logger.emit(
         "local",
@@ -22,7 +23,7 @@ pub(crate) fn request_codex_responses_once(
         Some(0),
         json!({ "endpoint": endpoint }),
     );
-    let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
+    let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
     let response = client
         .post(endpoint)
         .header(AUTHORIZATION, format!("Bearer {}", auth_state.access_token))

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -149,8 +149,8 @@ pub(crate) fn parse_data_url_image(value: &str) -> Result<(String, Vec<u8>), App
     Ok((mime_type, decode_base64_bytes(encoded)?))
 }
 
-pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, AppError> {
-    let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
+pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
+    let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
     let response = client.get(url).send().map_err(|error| {
         AppError::new("network_error", "Unable to download image bytes.")
             .with_detail(json!({ "error": error.to_string(), "url": url }))
@@ -172,6 +172,7 @@ pub(crate) fn download_bytes(url: &str) -> Result<Vec<u8>, AppError> {
 pub(crate) fn load_image_source_bytes(
     source: &str,
     fallback_name: &str,
+    proxy: &ProxyConfig,
 ) -> Result<(String, Vec<u8>, String), AppError> {
     if source.starts_with("data:image/") {
         let (mime_type, bytes) = parse_data_url_image(source)?;
@@ -184,7 +185,7 @@ pub(crate) fn load_image_source_bytes(
     if let Ok(url) = Url::parse(source) {
         match url.scheme() {
             "http" | "https" => {
-                let bytes = download_bytes(source)?;
+                let bytes = download_bytes(source, proxy)?;
                 let guessed_name = Path::new(url.path())
                     .file_name()
                     .and_then(|name| name.to_str())

--- a/crates/gpt-image-2-core/src/image_requests/openai.rs
+++ b/crates/gpt-image-2-core/src/image_requests/openai.rs
@@ -8,6 +8,7 @@ pub(crate) fn request_openai_images_once(
     body: &Value,
     logger: &mut JsonEventLogger,
     mut recovery: Option<&mut RecoveryContext>,
+    proxy: &ProxyConfig,
 ) -> Result<Value, AppError> {
     logger.emit(
         "local",
@@ -30,7 +31,7 @@ pub(crate) fn request_openai_images_once(
     } else {
         None
     };
-    let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
+    let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
     let mut request = client
         .post(endpoint)
         .header(AUTHORIZATION, format!("Bearer {}", auth_state.api_key))
@@ -53,6 +54,7 @@ pub(crate) fn request_openai_edit_once(
     body: &Value,
     logger: &mut JsonEventLogger,
     mut recovery: Option<&mut RecoveryContext>,
+    proxy: &ProxyConfig,
 ) -> Result<Value, AppError> {
     logger.emit(
         "local",
@@ -68,7 +70,7 @@ pub(crate) fn request_openai_edit_once(
         Some(0),
         json!({ "endpoint": endpoint, "transport": "multipart" }),
     );
-    let form = build_openai_edit_form(body)?;
+    let form = build_openai_edit_form(body, proxy)?;
     emit_progress_event(
         logger,
         "openai",
@@ -85,7 +87,7 @@ pub(crate) fn request_openai_edit_once(
     } else {
         None
     };
-    let client = make_client(DEFAULT_REQUEST_TIMEOUT)?;
+    let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
     let mut request = client
         .post(endpoint)
         .header(AUTHORIZATION, format!("Bearer {}", auth_state.api_key))
@@ -152,7 +154,7 @@ pub(crate) fn parse_openai_json_response(
     Ok(payload)
 }
 
-pub(crate) fn build_openai_edit_form(body: &Value) -> Result<Form, AppError> {
+pub(crate) fn build_openai_edit_form(body: &Value, proxy: &ProxyConfig) -> Result<Form, AppError> {
     let object = json_object(body)?;
     let mut form = Form::new();
     for key in [
@@ -182,7 +184,7 @@ pub(crate) fn build_openai_edit_form(body: &Value) -> Result<Form, AppError> {
     }
     for (index, source) in images.iter().enumerate() {
         let (mime_type, bytes, file_name) =
-            load_image_source_bytes(source, &format!("image-{}", index + 1))?;
+            load_image_source_bytes(source, &format!("image-{}", index + 1), proxy)?;
         let part = Part::bytes(bytes)
             .file_name(file_name)
             .mime_str(&mime_type)
@@ -196,7 +198,7 @@ pub(crate) fn build_openai_edit_form(body: &Value) -> Result<Form, AppError> {
         form = form.part("image[]", part);
     }
     if let Some(mask_source) = extract_openai_mask_source(body)? {
-        let (mime_type, bytes, file_name) = load_image_source_bytes(&mask_source, "mask")?;
+        let (mime_type, bytes, file_name) = load_image_source_bytes(&mask_source, "mask", proxy)?;
         let part = Part::bytes(bytes)
             .file_name(file_name)
             .mime_str(&mime_type)

--- a/crates/gpt-image-2-core/src/image_requests/output.rs
+++ b/crates/gpt-image-2-core/src/image_requests/output.rs
@@ -119,7 +119,10 @@ pub(crate) fn history_image_metadata(
 
 pub(crate) type DecodedOpenAiImages = (Vec<Vec<u8>>, Vec<Option<String>>);
 
-pub(crate) fn decode_openai_images(payload: &Value) -> Result<DecodedOpenAiImages, AppError> {
+pub(crate) fn decode_openai_images(
+    payload: &Value,
+    proxy: &ProxyConfig,
+) -> Result<DecodedOpenAiImages, AppError> {
     let mut result = Vec::new();
     let mut revised_prompts = Vec::new();
     for item in payload
@@ -138,7 +141,7 @@ pub(crate) fn decode_openai_images(payload: &Value) -> Result<DecodedOpenAiImage
             continue;
         }
         if let Some(url) = item.get("url").and_then(Value::as_str) {
-            result.push(download_bytes(url)?);
+            result.push(download_bytes(url, proxy)?);
         }
     }
     Ok((result, revised_prompts))

--- a/crates/gpt-image-2-core/src/image_requests/retry.rs
+++ b/crates/gpt-image-2-core/src/image_requests/retry.rs
@@ -46,11 +46,12 @@ pub(crate) fn request_codex_with_retry(
     auth_state: &mut CodexAuthState,
     body: &Value,
     logger: &mut JsonEventLogger,
+    proxy: &ProxyConfig,
 ) -> Result<(Value, bool, usize), AppError> {
     let mut auth_refreshed = false;
     let mut retry_count = 0;
     loop {
-        match request_codex_responses_once(endpoint, auth_state, body, logger) {
+        match request_codex_responses_once(endpoint, auth_state, body, logger, proxy) {
             Ok(value) => return Ok((value, auth_refreshed, retry_count)),
             Err(error) => {
                 if error.status_code == Some(401) && !auth_refreshed {
@@ -63,7 +64,7 @@ pub(crate) fn request_codex_with_retry(
                         Some(2),
                         json!({ "endpoint": REFRESH_ENDPOINT }),
                     );
-                    let payload = refresh_access_token(auth_state)?;
+                    let payload = refresh_access_token(auth_state, proxy)?;
                     logger.emit(
                         "local",
                         "auth.refresh.completed",

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -45,6 +45,7 @@ mod notifications;
 mod paths;
 mod provider_selection;
 mod provider_types;
+mod proxy;
 mod recovery;
 mod request_commands;
 mod request_payloads;
@@ -71,7 +72,7 @@ pub(crate) use config_commands::*;
 pub(crate) use config_io::*;
 pub use config_io::{load_app_config, redact_app_config, save_app_config};
 pub(crate) use config_types::*;
-pub use config_types::{AppConfig, CredentialRef};
+pub use config_types::{AppConfig, CredentialRef, ProxyConfig, ProxyMode};
 pub use constants::{
     CLI_NAME, CONFIG_DIR_NAME, CONFIG_FILE_NAME, DEFAULT_BACKGROUND, DEFAULT_CODEX_ENDPOINT,
     DEFAULT_CODEX_MODEL, DEFAULT_HISTORY_PAGE_LIMIT, DEFAULT_INSTRUCTIONS, DEFAULT_OPENAI_API_BASE,
@@ -126,6 +127,8 @@ pub(crate) use paths::{
 pub(crate) use provider_selection::*;
 pub use provider_types::ProviderConfig;
 pub(crate) use provider_types::*;
+pub(crate) use proxy::*;
+pub use proxy::validate_proxy_config;
 pub use recovery::{
     Recoverability, RecoveryAttempt, RecoveryContext, RecoveryStage, RecoveryState,
     annotate_recovery_job_dir, batch_recovery_job_dir, batch_recovery_job_id,

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -128,7 +128,7 @@ pub(crate) use provider_selection::*;
 pub use provider_types::ProviderConfig;
 pub(crate) use provider_types::*;
 pub(crate) use proxy::*;
-pub use proxy::validate_proxy_config;
+pub use proxy::{effective_proxy_for_provider, preserve_proxy_secrets, validate_proxy_config};
 pub use recovery::{
     Recoverability, RecoveryAttempt, RecoveryContext, RecoveryStage, RecoveryState,
     annotate_recovery_job_dir, batch_recovery_job_dir, batch_recovery_job_id,

--- a/crates/gpt-image-2-core/src/provider_types.rs
+++ b/crates/gpt-image-2-core/src/provider_types.rs
@@ -53,4 +53,8 @@ pub struct ProviderConfig {
     pub supports_n: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub edit_region_mode: Option<String>,
+    /// Per-provider proxy override. `None` inherits the global proxy;
+    /// `Some(mode = none)` forces a direct connection for this provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy: Option<ProxyConfig>,
 }

--- a/crates/gpt-image-2-core/src/proxy.rs
+++ b/crates/gpt-image-2-core/src/proxy.rs
@@ -21,18 +21,15 @@ pub(crate) fn proxy_mode_str(mode: ProxyMode) -> &'static str {
 /// behavior.
 pub(crate) fn validate_proxy_url(url_str: &str) -> Result<(), AppError> {
     let url = Url::parse(url_str).map_err(|error| {
-        AppError::new("proxy_url_invalid", "Proxy URL is not a valid URL.").with_detail(
-            json!({ "error": error.to_string(), "url": redact_proxy_url(url_str) }),
-        )
+        AppError::new("proxy_url_invalid", "Proxy URL is not a valid URL.")
+            .with_detail(json!({ "error": error.to_string(), "url": redact_proxy_url(url_str) }))
     })?;
     match url.scheme() {
         "http" | "https" | "socks5" | "socks5h" => {}
         other => {
             return Err(AppError::new(
                 "proxy_url_invalid",
-                format!(
-                    "Unsupported proxy scheme: {other}. Use http, https, socks5, or socks5h."
-                ),
+                format!("Unsupported proxy scheme: {other}. Use http, https, socks5, or socks5h."),
             )
             .with_detail(json!({
                 "scheme": other,
@@ -71,10 +68,7 @@ pub(crate) fn resolve_effective_proxy(
 
 /// Load config and resolve the effective proxy for `provider_name`, validating
 /// a Custom URL eagerly so a bad proxy fails fast with `proxy_url_invalid`.
-pub(crate) fn effective_proxy_for(
-    cli: &Cli,
-    provider_name: &str,
-) -> Result<ProxyConfig, AppError> {
+pub(crate) fn effective_proxy_for(cli: &Cli, provider_name: &str) -> Result<ProxyConfig, AppError> {
     let config = load_app_config(&cli_config_path(cli))?;
     let resolved = resolve_effective_proxy(&config.proxy, config.providers.get(provider_name));
     validate_proxy_config(&resolved)?;

--- a/crates/gpt-image-2-core/src/proxy.rs
+++ b/crates/gpt-image-2-core/src/proxy.rs
@@ -81,6 +81,51 @@ pub(crate) fn effective_proxy_for(
     Ok(resolved)
 }
 
+/// Resolve the effective proxy for a provider from the on-disk config, without
+/// a [`Cli`]. Used by recovery/materialization paths that only know the job's
+/// provider name. Falls back to the global proxy (or a direct connection) when
+/// config is unreadable.
+pub fn effective_proxy_for_provider(provider_name: Option<&str>) -> ProxyConfig {
+    let config = load_app_config(&default_config_path()).unwrap_or_default();
+    resolve_effective_proxy(
+        &config.proxy,
+        provider_name.and_then(|name| config.providers.get(name)),
+    )
+}
+
+/// Restore credentials onto a redacted Custom proxy URL.
+///
+/// `get_config` returns proxy URLs with credentials stripped, so a UI that
+/// re-saves an unchanged Custom proxy would otherwise persist the redacted
+/// `scheme://host:port` and silently drop the password. If `new` is a Custom
+/// URL pointing at the same scheme/host/port as a credentialed `existing`
+/// Custom URL but carries no credentials of its own, copy the old credentials
+/// back. A user supplying a fresh `user:pass@` is left untouched.
+pub fn preserve_proxy_secrets(new: &mut ProxyConfig, existing: &ProxyConfig) {
+    if new.mode != ProxyMode::Custom || existing.mode != ProxyMode::Custom {
+        return;
+    }
+    let (Some(new_url), Some(old_url)) = (new.url.as_deref(), existing.url.as_deref()) else {
+        return;
+    };
+    let (Ok(mut new_parsed), Ok(old_parsed)) = (Url::parse(new_url), Url::parse(old_url)) else {
+        return;
+    };
+    let old_has_creds = !old_parsed.username().is_empty() || old_parsed.password().is_some();
+    let new_has_creds = !new_parsed.username().is_empty() || new_parsed.password().is_some();
+    if !old_has_creds || new_has_creds {
+        return;
+    }
+    if new_parsed.scheme() == old_parsed.scheme()
+        && new_parsed.host_str() == old_parsed.host_str()
+        && new_parsed.port_or_known_default() == old_parsed.port_or_known_default()
+    {
+        let _ = new_parsed.set_username(old_parsed.username());
+        let _ = new_parsed.set_password(old_parsed.password());
+        new.url = Some(new_parsed.to_string());
+    }
+}
+
 /// Validate a [`ProxyConfig`] (only Custom mode has anything to check).
 pub fn validate_proxy_config(proxy: &ProxyConfig) -> Result<(), AppError> {
     if proxy.mode == ProxyMode::Custom {

--- a/crates/gpt-image-2-core/src/proxy.rs
+++ b/crates/gpt-image-2-core/src/proxy.rs
@@ -1,0 +1,160 @@
+#![allow(unused_imports)]
+
+use super::*;
+
+/// Stable string form of a [`ProxyMode`] for JSON payloads.
+pub(crate) fn proxy_mode_str(mode: ProxyMode) -> &'static str {
+    match mode {
+        ProxyMode::System => "system",
+        ProxyMode::None => "none",
+        ProxyMode::Custom => "custom",
+    }
+}
+
+/// Validate a Custom-mode proxy URL.
+///
+/// Accepts only `http`/`https`/`socks5`/`socks5h`. `socks4`/`socks4a` and any
+/// other scheme are rejected (we focus on SOCKS5 this round). Credentials must
+/// be either absent or a complete, non-empty `user:pass` pair — a username with
+/// no password silently becomes an empty-password auth attempt in the
+/// underlying client, so we reject it up front rather than depend on library
+/// behavior.
+pub(crate) fn validate_proxy_url(url_str: &str) -> Result<(), AppError> {
+    let url = Url::parse(url_str).map_err(|error| {
+        AppError::new("proxy_url_invalid", "Proxy URL is not a valid URL.").with_detail(
+            json!({ "error": error.to_string(), "url": redact_proxy_url(url_str) }),
+        )
+    })?;
+    match url.scheme() {
+        "http" | "https" | "socks5" | "socks5h" => {}
+        other => {
+            return Err(AppError::new(
+                "proxy_url_invalid",
+                format!(
+                    "Unsupported proxy scheme: {other}. Use http, https, socks5, or socks5h."
+                ),
+            )
+            .with_detail(json!({
+                "scheme": other,
+                "allowed": ["http", "https", "socks5", "socks5h"],
+            })));
+        }
+    }
+    if url.host_str().map(str::is_empty).unwrap_or(true) {
+        return Err(
+            AppError::new("proxy_url_invalid", "Proxy URL is missing a host.")
+                .with_detail(json!({ "url": redact_proxy_url(url_str) })),
+        );
+    }
+    let has_username = !url.username().is_empty();
+    let has_password = url.password().map(|pass| !pass.is_empty()).unwrap_or(false);
+    if has_username != has_password {
+        return Err(AppError::new(
+            "proxy_url_invalid",
+            "Proxy URL credentials must include both a username and a non-empty password.",
+        )
+        .with_detail(json!({ "url": redact_proxy_url(url_str) })));
+    }
+    Ok(())
+}
+
+/// Resolve the effective proxy for a provider: a per-provider override wins,
+/// otherwise the global proxy applies.
+pub(crate) fn resolve_effective_proxy(
+    global: &ProxyConfig,
+    provider: Option<&ProviderConfig>,
+) -> ProxyConfig {
+    provider
+        .and_then(|provider| provider.proxy.clone())
+        .unwrap_or_else(|| global.clone())
+}
+
+/// Load config and resolve the effective proxy for `provider_name`, validating
+/// a Custom URL eagerly so a bad proxy fails fast with `proxy_url_invalid`.
+pub(crate) fn effective_proxy_for(
+    cli: &Cli,
+    provider_name: &str,
+) -> Result<ProxyConfig, AppError> {
+    let config = load_app_config(&cli_config_path(cli))?;
+    let resolved = resolve_effective_proxy(&config.proxy, config.providers.get(provider_name));
+    validate_proxy_config(&resolved)?;
+    Ok(resolved)
+}
+
+/// Validate a [`ProxyConfig`] (only Custom mode has anything to check).
+pub fn validate_proxy_config(proxy: &ProxyConfig) -> Result<(), AppError> {
+    if proxy.mode == ProxyMode::Custom {
+        let url = custom_proxy_url(proxy)?;
+        validate_proxy_url(url)?;
+    }
+    Ok(())
+}
+
+fn custom_proxy_url(proxy: &ProxyConfig) -> Result<&str, AppError> {
+    proxy
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .ok_or_else(|| {
+            AppError::new(
+                "proxy_url_invalid",
+                "Custom proxy mode requires a proxy URL.",
+            )
+        })
+}
+
+/// Apply a [`ProxyConfig`] to a blocking client builder.
+///
+/// - `System`: leave the builder untouched so reqwest reads the environment.
+/// - `None`: disable all proxying (overrides any environment proxy).
+/// - `Custom`: route through the configured URL, applying `no_proxy` as a
+///   bypass list. SOCKS auth is taken from the URL's inline `user:pass`; never
+///   use `custom_http_auth()`/`headers()` for SOCKS (HTTP-only, ignored there).
+pub(crate) fn apply_proxy(
+    builder: reqwest::blocking::ClientBuilder,
+    proxy: &ProxyConfig,
+) -> Result<reqwest::blocking::ClientBuilder, AppError> {
+    match proxy.mode {
+        ProxyMode::System => Ok(builder),
+        ProxyMode::None => Ok(builder.no_proxy()),
+        ProxyMode::Custom => {
+            let url = custom_proxy_url(proxy)?;
+            validate_proxy_url(url)?;
+            let mut reqwest_proxy = reqwest::Proxy::all(url).map_err(|error| {
+                AppError::new("proxy_url_invalid", "Invalid proxy URL.").with_detail(
+                    json!({ "error": error.to_string(), "url": redact_proxy_url(url) }),
+                )
+            })?;
+            if !proxy.no_proxy.is_empty()
+                && let Some(no_proxy) = reqwest::NoProxy::from_string(&proxy.no_proxy.join(","))
+            {
+                reqwest_proxy = reqwest_proxy.no_proxy(Some(no_proxy));
+            }
+            Ok(builder.proxy(reqwest_proxy))
+        }
+    }
+}
+
+/// Strip any inline credentials from a proxy URL for display/logging.
+pub(crate) fn redact_proxy_url(url_str: &str) -> String {
+    match Url::parse(url_str) {
+        Ok(mut url) => {
+            if !url.username().is_empty() || url.password().is_some() {
+                let _ = url.set_username("");
+                let _ = url.set_password(None);
+            }
+            url.to_string()
+        }
+        Err(_) => "<invalid-proxy-url>".to_string(),
+    }
+}
+
+/// Redacted JSON form of a [`ProxyConfig`] (credentials stripped from `url`).
+pub(crate) fn redact_proxy_config(proxy: &ProxyConfig) -> Value {
+    json!({
+        "mode": proxy_mode_str(proxy.mode),
+        "url": proxy.url.as_deref().map(redact_proxy_url),
+        "no_proxy": proxy.no_proxy,
+    })
+}

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -558,7 +558,10 @@ pub fn materialize_openai_raw_response(
         )
         .with_detail(json!({"path": raw_path.display().to_string(), "error": error.to_string()}))
     })?;
-    let (image_bytes_list, _) = decode_openai_images(&payload)?;
+    let proxy = load_app_config(&default_config_path())
+        .map(|config| config.proxy)
+        .unwrap_or_default();
+    let (image_bytes_list, _) = decode_openai_images(&payload, &proxy)?;
     save_images(output_path, &image_bytes_list)
 }
 

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -542,6 +542,7 @@ pub fn normalize_provider_request_id(headers: &HeaderMap) -> Option<String> {
 pub fn materialize_openai_raw_response(
     job_dir: &Path,
     output_path: &Path,
+    provider_name: Option<&str>,
 ) -> Result<Vec<Value>, AppError> {
     let raw_path = raw_response_path(job_dir);
     let raw = fs::read_to_string(&raw_path).map_err(|error| {
@@ -558,9 +559,7 @@ pub fn materialize_openai_raw_response(
         )
         .with_detail(json!({"path": raw_path.display().to_string(), "error": error.to_string()}))
     })?;
-    let proxy = load_app_config(&default_config_path())
-        .map(|config| config.proxy)
-        .unwrap_or_default();
+    let proxy = effective_proxy_for_provider(provider_name);
     let (image_bytes_list, _) = decode_openai_images(&payload, &proxy)?;
     save_images(output_path, &image_bytes_list)
 }

--- a/crates/gpt-image-2-core/src/request_commands.rs
+++ b/crates/gpt-image-2-core/src/request_commands.rs
@@ -14,6 +14,7 @@ pub(crate) fn run_request_create_codex(
         ));
     }
     let mut auth_state = load_codex_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let body = read_body_json(&args.body_file)?;
     let mut logger = JsonEventLogger::new(cli.json_events);
     let (outcome, auth_refreshed, retry_count) = request_codex_with_retry(
@@ -21,6 +22,7 @@ pub(crate) fn run_request_create_codex(
         &mut auth_state,
         &body,
         &mut logger,
+        &proxy,
     )?;
     let response_meta = outcome
         .get("response")
@@ -137,6 +139,7 @@ pub(crate) fn run_request_create_openai(
         ));
     }
     let auth_state = load_openai_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let body = read_body_json(&args.body_file)?;
     let endpoint =
         build_openai_operation_endpoint(&selection.api_base, args.request_operation.as_str())?;
@@ -144,12 +147,12 @@ pub(crate) fn run_request_create_openai(
     let (payload, retry_count) =
         execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
             if args.request_operation == RequestOperation::Edit {
-                request_openai_edit_once(&endpoint, &auth_state, &body, logger, None)
+                request_openai_edit_once(&endpoint, &auth_state, &body, logger, None, &proxy)
             } else {
-                request_openai_images_once(&endpoint, &auth_state, &body, logger, None)
+                request_openai_images_once(&endpoint, &auth_state, &body, logger, None, &proxy)
             }
         })?;
-    let (image_bytes_list, revised_prompts) = decode_openai_images(&payload)?;
+    let (image_bytes_list, revised_prompts) = decode_openai_images(&payload, &proxy)?;
     let image_output = if image_bytes_list.is_empty() {
         None
     } else if let Some(out_image) = &args.out_image {

--- a/crates/gpt-image-2-core/src/tests.rs
+++ b/crates/gpt-image-2-core/src/tests.rs
@@ -35,5 +35,6 @@ mod image_requests;
 mod network_safety;
 mod notification_delivery;
 mod notifications;
+mod proxy;
 mod recovery;
 mod storage_config;

--- a/crates/gpt-image-2-core/src/tests/config_provider.rs
+++ b/crates/gpt-image-2-core/src/tests/config_provider.rs
@@ -23,6 +23,7 @@ fn app_config_round_trips_with_file_secret() {
             )]),
             supports_n: Some(false),
             edit_region_mode: Some(EDIT_REGION_REFERENCE_HINT.to_string()),
+            proxy: None,
         },
     );
     save_app_config(&config_path, &config).unwrap();
@@ -49,6 +50,7 @@ fn configured_openai_provider_resolves_with_file_secret() {
         )]),
         supports_n: Some(true),
         edit_region_mode: None,
+        proxy: None,
     };
     let selection = configured_provider_selection("local", &provider, "test", None).unwrap();
     assert_eq!(selection.resolved, "local");
@@ -77,6 +79,7 @@ fn explicit_builtin_name_uses_configured_provider_when_present() {
             )]),
             supports_n: Some(false),
             edit_region_mode: Some(EDIT_REGION_REFERENCE_HINT.to_string()),
+            proxy: None,
         },
     );
     save_app_config(&config_path, &config).unwrap();
@@ -120,6 +123,7 @@ fn configured_openai_name_loads_config_secret_for_image_auth() {
             )]),
             supports_n: Some(false),
             edit_region_mode: Some(EDIT_REGION_REFERENCE_HINT.to_string()),
+            proxy: None,
         },
     );
     save_app_config(&config_path, &config).unwrap();

--- a/crates/gpt-image-2-core/src/tests/image_requests.rs
+++ b/crates/gpt-image-2-core/src/tests/image_requests.rs
@@ -55,5 +55,5 @@ fn build_openai_edit_form_contains_required_parts() {
         "mask": {"image_url": "data:image/png;base64,YWJjZA=="},
         "size": "1024x1024",
     });
-    assert!(build_openai_edit_form(&body).is_ok());
+    assert!(build_openai_edit_form(&body, &ProxyConfig::default()).is_ok());
 }

--- a/crates/gpt-image-2-core/src/tests/proxy.rs
+++ b/crates/gpt-image-2-core/src/tests/proxy.rs
@@ -107,6 +107,35 @@ fn redact_proxy_config_hides_password() {
 }
 
 #[test]
+fn preserve_proxy_secrets_restores_redacted_credentials() {
+    let existing = custom("socks5h://user:secret@proxy.local:1080");
+
+    // Redacted round-trip (same target, no creds) -> credentials restored.
+    let mut redacted = custom("socks5h://proxy.local:1080");
+    preserve_proxy_secrets(&mut redacted, &existing);
+    assert_eq!(redacted.url.as_deref(), Some("socks5h://user:secret@proxy.local:1080"));
+
+    // User supplied fresh credentials -> left untouched.
+    let mut fresh = custom("socks5h://newuser:newpass@proxy.local:1080");
+    preserve_proxy_secrets(&mut fresh, &existing);
+    assert_eq!(fresh.url.as_deref(), Some("socks5h://newuser:newpass@proxy.local:1080"));
+
+    // Different host -> do NOT leak credentials across targets.
+    let mut other_host = custom("socks5h://other.local:1080");
+    preserve_proxy_secrets(&mut other_host, &existing);
+    assert_eq!(other_host.url.as_deref(), Some("socks5h://other.local:1080"));
+
+    // Switching to direct (None) -> untouched.
+    let mut direct = ProxyConfig {
+        mode: ProxyMode::None,
+        ..ProxyConfig::default()
+    };
+    preserve_proxy_secrets(&mut direct, &existing);
+    assert_eq!(direct.mode, ProxyMode::None);
+    assert!(direct.url.is_none());
+}
+
+#[test]
 fn make_client_builds_for_every_mode() {
     // System and None never fail to build.
     assert!(make_client(30, &ProxyConfig::default()).is_ok());

--- a/crates/gpt-image-2-core/src/tests/proxy.rs
+++ b/crates/gpt-image-2-core/src/tests/proxy.rs
@@ -72,10 +72,7 @@ fn resolve_effective_proxy_prefers_provider_override() {
         ..ProviderConfig::default()
     };
     // Provider override wins.
-    assert_eq!(
-        resolve_effective_proxy(&global, Some(&provider)),
-        direct
-    );
+    assert_eq!(resolve_effective_proxy(&global, Some(&provider)), direct);
     // No override inherits the global proxy.
     let inherit = ProviderConfig {
         provider_type: "openai".to_string(),
@@ -113,17 +110,26 @@ fn preserve_proxy_secrets_restores_redacted_credentials() {
     // Redacted round-trip (same target, no creds) -> credentials restored.
     let mut redacted = custom("socks5h://proxy.local:1080");
     preserve_proxy_secrets(&mut redacted, &existing);
-    assert_eq!(redacted.url.as_deref(), Some("socks5h://user:secret@proxy.local:1080"));
+    assert_eq!(
+        redacted.url.as_deref(),
+        Some("socks5h://user:secret@proxy.local:1080")
+    );
 
     // User supplied fresh credentials -> left untouched.
     let mut fresh = custom("socks5h://newuser:newpass@proxy.local:1080");
     preserve_proxy_secrets(&mut fresh, &existing);
-    assert_eq!(fresh.url.as_deref(), Some("socks5h://newuser:newpass@proxy.local:1080"));
+    assert_eq!(
+        fresh.url.as_deref(),
+        Some("socks5h://newuser:newpass@proxy.local:1080")
+    );
 
     // Different host -> do NOT leak credentials across targets.
     let mut other_host = custom("socks5h://other.local:1080");
     preserve_proxy_secrets(&mut other_host, &existing);
-    assert_eq!(other_host.url.as_deref(), Some("socks5h://other.local:1080"));
+    assert_eq!(
+        other_host.url.as_deref(),
+        Some("socks5h://other.local:1080")
+    );
 
     // Switching to direct (None) -> untouched.
     let mut direct = ProxyConfig {

--- a/crates/gpt-image-2-core/src/tests/proxy.rs
+++ b/crates/gpt-image-2-core/src/tests/proxy.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+fn custom(url: &str) -> ProxyConfig {
+    ProxyConfig {
+        mode: ProxyMode::Custom,
+        url: Some(url.to_string()),
+        no_proxy: Vec::new(),
+    }
+}
+
+#[test]
+fn validate_proxy_url_accepts_supported_schemes() {
+    for url in [
+        "http://proxy.local:8080",
+        "https://proxy.local:8443",
+        "socks5://proxy.local:1080",
+        "socks5h://proxy.local:1080",
+        "socks5h://user:pass@proxy.local:1080",
+    ] {
+        assert!(validate_proxy_url(url).is_ok(), "should accept {url}");
+    }
+}
+
+#[test]
+fn validate_proxy_url_rejects_unsupported_schemes() {
+    for url in [
+        "socks4://proxy.local:1080",
+        "socks4a://proxy.local:1080",
+        "ftp://proxy.local:21",
+        "ws://proxy.local:80",
+    ] {
+        let error = validate_proxy_url(url).unwrap_err();
+        assert_eq!(error.code, "proxy_url_invalid", "should reject {url}");
+    }
+}
+
+#[test]
+fn validate_proxy_url_rejects_incomplete_credentials() {
+    // username only, and empty password are both ambiguous -> rejected.
+    for url in [
+        "socks5h://user@proxy.local:1080",
+        "http://user@proxy.local:8080",
+        "http://user:@proxy.local:8080",
+    ] {
+        let error = validate_proxy_url(url).unwrap_err();
+        assert_eq!(error.code, "proxy_url_invalid", "should reject {url}");
+    }
+}
+
+#[test]
+fn validate_proxy_url_rejects_malformed() {
+    assert_eq!(
+        validate_proxy_url("not a url").unwrap_err().code,
+        "proxy_url_invalid"
+    );
+    assert_eq!(
+        validate_proxy_url("http://").unwrap_err().code,
+        "proxy_url_invalid"
+    );
+}
+
+#[test]
+fn resolve_effective_proxy_prefers_provider_override() {
+    let global = custom("http://global.local:8080");
+    let direct = ProxyConfig {
+        mode: ProxyMode::None,
+        ..ProxyConfig::default()
+    };
+    let provider = ProviderConfig {
+        provider_type: "openai".to_string(),
+        proxy: Some(direct.clone()),
+        ..ProviderConfig::default()
+    };
+    // Provider override wins.
+    assert_eq!(
+        resolve_effective_proxy(&global, Some(&provider)),
+        direct
+    );
+    // No override inherits the global proxy.
+    let inherit = ProviderConfig {
+        provider_type: "openai".to_string(),
+        proxy: None,
+        ..ProviderConfig::default()
+    };
+    assert_eq!(resolve_effective_proxy(&global, Some(&inherit)), global);
+    // Builtin/auto provider (no config entry) inherits the global proxy.
+    assert_eq!(resolve_effective_proxy(&global, None), global);
+}
+
+#[test]
+fn redact_proxy_url_strips_credentials() {
+    assert_eq!(
+        redact_proxy_url("socks5h://user:secret@proxy.local:1080"),
+        "socks5h://proxy.local:1080"
+    );
+    // No credentials -> unchanged host/port.
+    assert!(redact_proxy_url("http://proxy.local:8080").contains("proxy.local:8080"));
+    assert!(!redact_proxy_url("http://user:secret@proxy.local:8080").contains("secret"));
+}
+
+#[test]
+fn redact_proxy_config_hides_password() {
+    let value = redact_proxy_config(&custom("socks5h://user:secret@proxy.local:1080"));
+    assert_eq!(value["mode"], "custom");
+    let serialized = value.to_string();
+    assert!(!serialized.contains("secret"), "password must be redacted");
+}
+
+#[test]
+fn make_client_builds_for_every_mode() {
+    // System and None never fail to build.
+    assert!(make_client(30, &ProxyConfig::default()).is_ok());
+    assert!(
+        make_client(
+            30,
+            &ProxyConfig {
+                mode: ProxyMode::None,
+                ..ProxyConfig::default()
+            }
+        )
+        .is_ok()
+    );
+    // A valid SOCKS5h custom proxy builds (no connection attempted here).
+    assert!(make_client(30, &custom("socks5h://proxy.local:1080")).is_ok());
+    // An invalid custom proxy fails with a structured error, not a panic.
+    let error = make_client(30, &custom("socks4://proxy.local:1080")).unwrap_err();
+    assert_eq!(error.code, "proxy_url_invalid");
+}

--- a/crates/gpt-image-2-core/src/transparent/commands/source_generation.rs
+++ b/crates/gpt-image-2-core/src/transparent/commands/source_generation.rs
@@ -20,6 +20,7 @@ pub(crate) fn generate_openai_source_image(
     shared: &SharedImageArgs,
 ) -> Result<Value, AppError> {
     let auth_state = load_openai_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let resolved_model = shared
         .model
         .clone()
@@ -43,9 +44,9 @@ pub(crate) fn generate_openai_source_image(
     let mut logger = JsonEventLogger::new(cli.json_events);
     let (payload, retry_count) =
         execute_openai_with_retry(&mut logger, &selection.resolved, |logger| {
-            request_openai_images_once(&endpoint, &auth_state, &body, logger, None)
+            request_openai_images_once(&endpoint, &auth_state, &body, logger, None, &proxy)
         })?;
-    let (image_bytes_list, revised_prompts) = decode_openai_images(&payload)?;
+    let (image_bytes_list, revised_prompts) = decode_openai_images(&payload, &proxy)?;
     if image_bytes_list.is_empty() {
         return Err(AppError::new(
             "missing_image_result",
@@ -95,6 +96,7 @@ pub(crate) fn generate_codex_source_image(
     shared: &SharedImageArgs,
 ) -> Result<Value, AppError> {
     let mut auth_state = load_codex_auth_state_for(cli, selection)?;
+    let proxy = effective_proxy_for(cli, &selection.resolved)?;
     let resolved_model = shared
         .model
         .clone()
@@ -117,6 +119,7 @@ pub(crate) fn generate_codex_source_image(
         &mut auth_state,
         &body,
         &mut logger,
+        &proxy,
     )?;
     let output_items = outcome
         .get("output_items")

--- a/crates/gpt-image-2-web/src/config_api.rs
+++ b/crates/gpt-image-2-web/src/config_api.rs
@@ -67,6 +67,15 @@ pub(crate) async fn update_paths(Json(body): Json<PathConfig>) -> ApiResult {
     Ok(Json(config_for_ui(&config)))
 }
 
+pub(crate) async fn update_proxy(Json(body): Json<ProxyConfig>) -> ApiResult {
+    gpt_image_2_core::validate_proxy_config(&body)
+        .map_err(|error| ApiError::bad_request(app_error(error)))?;
+    let mut config = load_config().map_err(ApiError::internal)?;
+    config.proxy = body;
+    save_config(&config).map_err(ApiError::internal)?;
+    Ok(Json(config_for_ui(&config)))
+}
+
 pub(crate) async fn update_storage(Json(mut body): Json<StorageConfig>) -> ApiResult {
     let mut config = load_config().map_err(ApiError::internal)?;
     preserve_storage_secrets(&mut body, &config.storage);

--- a/crates/gpt-image-2-web/src/config_api.rs
+++ b/crates/gpt-image-2-web/src/config_api.rs
@@ -67,10 +67,11 @@ pub(crate) async fn update_paths(Json(body): Json<PathConfig>) -> ApiResult {
     Ok(Json(config_for_ui(&config)))
 }
 
-pub(crate) async fn update_proxy(Json(body): Json<ProxyConfig>) -> ApiResult {
+pub(crate) async fn update_proxy(Json(mut body): Json<ProxyConfig>) -> ApiResult {
+    let mut config = load_config().map_err(ApiError::internal)?;
+    gpt_image_2_core::preserve_proxy_secrets(&mut body, &config.proxy);
     gpt_image_2_core::validate_proxy_config(&body)
         .map_err(|error| ApiError::bad_request(app_error(error)))?;
-    let mut config = load_config().map_err(ApiError::internal)?;
     config.proxy = body;
     save_config(&config).map_err(ApiError::internal)?;
     Ok(Json(config_for_ui(&config)))

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -17,7 +17,7 @@ use axum::{
 };
 use gpt_image_2_core::{
     AppConfig, CONFIG_DIR_NAME, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions,
-    KEYCHAIN_SERVICE, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig,
+    KEYCHAIN_SERVICE, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, ProxyConfig,
     StorageConfig, StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
     annotate_recovery_job_dir, append_history_job_event, batch_output_path, batch_recovery_job_dir,
     batch_recovery_job_id, build_recovery_descriptor, default_config_path,

--- a/crates/gpt-image-2-web/src/provider_config.rs
+++ b/crates/gpt-image-2-web/src/provider_config.rs
@@ -60,6 +60,20 @@ pub(crate) fn convert_provider_input(
         };
         credentials.insert(secret, converted);
     }
+    // The UI always sends the full intended override (absent = inherit global),
+    // so take it verbatim — this lets "inherit" actually clear a previous
+    // override. Restore redacted credentials and validate before persisting so
+    // a bad per-provider proxy is rejected at save time, like the global one.
+    let proxy = match input.proxy {
+        Some(mut proxy) => {
+            if let Some(existing_proxy) = existing.and_then(|provider| provider.proxy.as_ref()) {
+                gpt_image_2_core::preserve_proxy_secrets(&mut proxy, existing_proxy);
+            }
+            gpt_image_2_core::validate_proxy_config(&proxy).map_err(app_error)?;
+            Some(proxy)
+        }
+        None => None,
+    };
     Ok((
         ProviderConfig {
             provider_type: input.provider_type,
@@ -69,10 +83,7 @@ pub(crate) fn convert_provider_input(
             credentials,
             supports_n: input.supports_n,
             edit_region_mode: input.edit_region_mode,
-            // The UI always sends the full intended override (absent = inherit
-            // global), so take it verbatim — this lets "inherit" actually clear
-            // a previous override.
-            proxy: input.proxy,
+            proxy,
         },
         input.set_default,
     ))

--- a/crates/gpt-image-2-web/src/provider_config.rs
+++ b/crates/gpt-image-2-web/src/provider_config.rs
@@ -69,6 +69,10 @@ pub(crate) fn convert_provider_input(
             credentials,
             supports_n: input.supports_n,
             edit_region_mode: input.edit_region_mode,
+            // The UI always sends the full intended override (absent = inherit
+            // global), so take it verbatim — this lets "inherit" actually clear
+            // a previous override.
+            proxy: input.proxy,
         },
         input.set_default,
     ))

--- a/crates/gpt-image-2-web/src/recovery_api.rs
+++ b/crates/gpt-image-2-web/src/recovery_api.rs
@@ -87,7 +87,12 @@ pub(crate) fn continue_save_job(job_id: &str) -> Result<Value, String> {
     let format = metadata.get("format").and_then(Value::as_str);
     let output_path = job_dir.join(format!("out.{}", output_extension(format)));
     let before_attempts = test_fault::provider_http_attempts(job_id);
-    let saved_files = materialize_openai_raw_response(&job_dir, &output_path).map_err(app_error)?;
+    let saved_files = materialize_openai_raw_response(
+        &job_dir,
+        &output_path,
+        job.get("provider").and_then(Value::as_str),
+    )
+    .map_err(app_error)?;
     let after_attempts = test_fault::provider_http_attempts(job_id);
     if after_attempts != before_attempts {
         return Err("continue_save attempted a provider HTTP request.".to_string());
@@ -193,12 +198,13 @@ fn merge_output_files(existing: Vec<Value>, filled: Vec<(usize, Value)>) -> Vec<
 fn materialize_cached_slot_payload(
     child_dir: &std::path::Path,
     output_path: &std::path::Path,
+    provider: Option<&str>,
 ) -> Option<Result<Value, String>> {
     if !raw_response_path(child_dir).is_file() {
         return None;
     }
     Some(
-        materialize_openai_raw_response(child_dir, output_path)
+        materialize_openai_raw_response(child_dir, output_path, provider)
             .map(|files| json!({ "output": normalize_batch_output(files) }))
             .map_err(app_error),
     )
@@ -241,7 +247,11 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 let child_id = batch_recovery_job_id(job_id, slot);
                 let child_dir = batch_recovery_job_dir(&job_dir, slot);
                 let out = batch_output_path(&job_dir, request.format.as_deref().or(format), slot);
-                if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
+                if let Some(cached) = materialize_cached_slot_payload(
+                    &child_dir,
+                    &out,
+                    job.get("provider").and_then(Value::as_str),
+                ) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
                         Err(message) => errors.push(BatchItemError {
@@ -275,7 +285,11 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 let child_id = batch_recovery_job_id(job_id, slot);
                 let child_dir = batch_recovery_job_dir(&job_dir, slot);
                 let out = batch_output_path(&job_dir, request.format.as_deref().or(format), slot);
-                if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
+                if let Some(cached) = materialize_cached_slot_payload(
+                    &child_dir,
+                    &out,
+                    job.get("provider").and_then(Value::as_str),
+                ) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
                         Err(message) => errors.push(BatchItemError {

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -79,6 +79,7 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
             get(notification_capabilities),
         )
         .route("/paths", put(update_paths))
+        .route("/proxy", put(update_proxy))
         .route("/storage", put(update_storage))
         .route("/storage/{name}/test", post(test_storage))
         .route("/providers/default", post(set_default_provider))

--- a/crates/gpt-image-2-web/src/types.rs
+++ b/crates/gpt-image-2-web/src/types.rs
@@ -19,6 +19,8 @@ pub(crate) struct ProviderInput {
     #[serde(default)]
     pub(crate) edit_region_mode: Option<String>,
     #[serde(default)]
+    pub(crate) proxy: Option<ProxyConfig>,
+    #[serde(default)]
     pub(crate) set_default: bool,
     #[serde(default)]
     pub(crate) allow_overwrite: bool,


### PR DESCRIPTION
Closes #23.

In-app proxy configuration so GUI users behind a proxy/GFW can route provider traffic without shell env vars (the CLI already honors `HTTP(S)_PROXY`).

## Design (per the adversarial-reviewed #23 spec)
- **Global proxy** with three modes: `System` (default, inherit env) / `None` (force direct) / `Custom` (explicit URL + `no_proxy` bypass list, Custom-only).
- **Per-provider override** wins over global — e.g. OpenAI via proxy while a domestic relay stays direct (`{mode: none}`).
- **Single chokepoint**: `make_client(timeout, &ProxyConfig)` threaded through every provider egress — OpenAI generate/edit, Codex SSE, **Codex token refresh** (same provider proxy), remote ref-image download, and result-by-URL download.
- **SOCKS5/socks5h**: reqwest `socks` feature (vendored connector, no new external crate). `socks5h://` does proxy-side DNS (avoids DNS pollution). `socks5`/`socks5h` only — `socks4`/`socks4a` rejected.
- **Validation**: scheme whitelist + reject username-only / empty-password credentials → structured `proxy_url_invalid` (no panic, no silent empty-password auth).
- **Redaction**: proxy URL credentials stripped from `get_config` / `config inspect`.

## Surfaces
- `update_proxy`: web `PUT /proxy` + Tauri command.
- Settings → 「网络」 panel (global) + per-provider override control.

## Verification
- `cargo test -p gpt-image-2-core`: 121 passed (8 new proxy tests — validation, redaction, resolution, client build for every mode).
- All four crates build; frontend `tsc --noEmit` clean; frontend tests pass.

## Notes
- Storage uploads and notification webhooks are intentionally out of scope this round (separate egress; storage has its own SSRF pinning).
- Per-provider custom proxy URLs with inline credentials follow the same redaction round-trip caveat as API keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)