### PR TITLE
fix(errors)+feat(logging): structured error detail (P0) + persistent logs (P1)

### DIFF
--- a/apps/gpt-image-2-app/src-tauri/src/export_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/export_commands.rs
@@ -21,6 +21,16 @@ pub(crate) fn reveal_path(path: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub(crate) fn open_logs_dir() -> Result<String, String> {
+    let dir = logs_dir(Some(&load_config_or_default()), ProductRuntime::Tauri);
+    // The directory may not exist yet if nothing has been logged; create it so
+    // the reveal lands somewhere instead of erroring.
+    fs::create_dir_all(&dir).map_err(|error| format!("无法创建日志目录：{error}"))?;
+    open_system_path(&dir, false)?;
+    Ok(dir.display().to_string())
+}
+
+#[tauri::command]
 pub(crate) fn export_files_to_downloads(paths: Vec<String>) -> Result<Vec<String>, String> {
     export_files_to_configured_folder(paths)
 }

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/batch_payloads.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/batch_payloads.rs
@@ -80,10 +80,17 @@ pub(crate) fn batch_errors_json(errors: &[BatchItemError]) -> Value {
         errors
             .iter()
             .map(|error| {
-                json!({
+                let mut item = json!({
                     "index": error.index,
                     "message": error.message,
-                })
+                });
+                if let (Value::Object(map), Some(code)) = (&mut item, error.code.as_ref()) {
+                    map.insert("code".to_string(), json!(code));
+                }
+                if let (Value::Object(map), Some(detail)) = (&mut item, error.detail.as_ref()) {
+                    map.insert("detail".to_string(), detail.clone());
+                }
+                item
             })
             .collect(),
     )
@@ -293,7 +300,9 @@ mod tests {
             vec![(0, payload("/tmp/a.png")), (2, payload("/tmp/c.png"))],
             vec![BatchItemError {
                 index: 1,
+                code: None,
                 message: "upstream rejected candidate B".to_string(),
+                detail: None,
             }],
         );
 
@@ -322,11 +331,15 @@ mod tests {
             vec![
                 BatchItemError {
                     index: 0,
+                    code: None,
                     message: "candidate A failed".to_string(),
+                    detail: None,
                 },
                 BatchItemError {
                     index: 1,
+                    code: None,
                     message: "candidate B failed".to_string(),
+                    detail: None,
                 },
             ],
         );
@@ -344,5 +357,37 @@ mod tests {
         assert_eq!(job["status"], "failed");
         assert_eq!(terminal_event_type(job["status"].as_str()), "job.failed");
         assert!(!terminal_status_runs_storage_upload(job["status"].as_str()));
+    }
+
+    #[test]
+    fn batch_errors_json_preserves_code_and_detail_per_item() {
+        // P0 regression: per-slot batch errors must keep code/detail so
+        // `error.items[*]` carry the real cause, not just a flat message.
+        let errors = vec![
+            BatchItemError::from_error_value(
+                0,
+                json!({
+                    "code": "network_error",
+                    "message": "OpenAI request failed.",
+                    "detail": { "error": "connection refused" },
+                }),
+            ),
+            BatchItemError::from_error_value(2, json!({ "message": "plain failure" })),
+        ];
+
+        let items = batch_errors_json(&errors);
+        assert_eq!(items[0]["index"], 0);
+        assert_eq!(items[0]["code"], "network_error");
+        assert_eq!(items[0]["message"], "OpenAI request failed.");
+        assert_eq!(items[0]["detail"]["error"], "connection refused");
+        // An item without code/detail stays minimal (no null spam).
+        assert_eq!(items[1]["index"], 2);
+        assert_eq!(items[1]["message"], "plain failure");
+        assert!(items[1].get("code").is_none());
+        assert!(items[1].get("detail").is_none());
+
+        let merged = merge_batch_payloads("images generate", 3, vec![], errors);
+        assert_eq!(merged["error"]["items"][0]["detail"]["error"], "connection refused");
+        assert_eq!(merged["error"]["items"][0]["code"], "network_error");
     }
 }

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/batch_payloads.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/batch_payloads.rs
@@ -387,7 +387,10 @@ mod tests {
         assert!(items[1].get("detail").is_none());
 
         let merged = merge_batch_payloads("images generate", 3, vec![], errors);
-        assert_eq!(merged["error"]["items"][0]["detail"]["error"], "connection refused");
+        assert_eq!(
+            merged["error"]["items"][0]["detail"]["error"],
+            "connection refused"
+        );
         assert_eq!(merged["error"]["items"][0]["code"], "network_error");
     }
 }

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/edit_runner.rs
@@ -77,18 +77,21 @@ pub(crate) fn run_edit_request(
     fallback_id: String,
     dir: PathBuf,
     stream: Option<StreamContext>,
-) -> Result<Value, String> {
+) -> Result<Value, Value> {
     if request.prompt.trim().is_empty() {
-        return Err("Prompt is required.".to_string());
+        return Err(error_value_from_message("Prompt is required."));
     }
     if request.refs.is_empty() {
-        return Err("At least one reference image is required.".to_string());
+        return Err(error_value_from_message(
+            "At least one reference image is required.",
+        ));
     }
-    let output_count = requested_n(request.n)?;
+    let output_count = requested_n(request.n).map_err(error_value_from_message)?;
     if request.n.is_some() {
         request.n = Some(output_count);
     }
-    let (ref_paths, mask_path, edit_region_mode) = write_edit_inputs(&request, &dir)?;
+    let (ref_paths, mask_path, edit_region_mode) =
+        write_edit_inputs(&request, &dir).map_err(error_value_from_message)?;
     let provider_supports_n = provider_supports_n(request.provider.as_deref());
     let payload = if provider_supports_n || output_count == 1 {
         let out = dir.join(format!(
@@ -176,7 +179,7 @@ pub(crate) fn run_edit_request(
             failures,
             generation_slots,
         )
-        .map_err(app_error)?;
+        .map_err(|error| error_value_from_message(app_error(error)))?;
         merged
     };
     let request_meta = edit_request_metadata(&request);

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/generate_runner.rs
@@ -7,11 +7,11 @@ pub(crate) fn run_generate_request(
     fallback_id: String,
     dir: PathBuf,
     stream: Option<StreamContext>,
-) -> Result<Value, String> {
+) -> Result<Value, Value> {
     if request.prompt.trim().is_empty() {
-        return Err("Prompt is required.".to_string());
+        return Err(error_value_from_message("Prompt is required."));
     }
-    let output_count = requested_n(request.n)?;
+    let output_count = requested_n(request.n).map_err(error_value_from_message)?;
     if request.n.is_some() {
         request.n = Some(output_count);
     }
@@ -90,7 +90,7 @@ pub(crate) fn run_generate_request(
             failures,
             generation_slots,
         )
-        .map_err(app_error)?;
+        .map_err(|error| error_value_from_message(app_error(error)))?;
         merged
     };
     let request_meta = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/streaming.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/streaming.rs
@@ -73,9 +73,7 @@ pub(crate) fn run_payloads_concurrently_streaming(
                 on_partial(index, &payload);
                 results[index] = Some(payload);
             }
-            Ok((index, Err(error))) => {
-                errors.push(BatchItemError::from_error_value(index, error))
-            }
+            Ok((index, Err(error))) => errors.push(BatchItemError::from_error_value(index, error)),
             Err(_) => break,
         }
         received += 1;

--- a/apps/gpt-image-2-app/src-tauri/src/job_execution/streaming.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/job_execution/streaming.rs
@@ -16,7 +16,26 @@ pub(crate) struct StreamContext {
 #[derive(Debug, Clone)]
 pub(crate) struct BatchItemError {
     pub(crate) index: usize,
+    pub(crate) code: Option<String>,
     pub(crate) message: String,
+    pub(crate) detail: Option<Value>,
+}
+
+impl BatchItemError {
+    /// Build a structured per-slot error from a JobError-shaped `Value`
+    /// (`{ code, message, detail }`) as produced by `cli_json_result`, keeping
+    /// `code`/`detail` so the merged payload's `error.items[*]` stay rich.
+    pub(crate) fn from_error_value(index: usize, error: Value) -> Self {
+        Self {
+            index,
+            code: error
+                .get("code")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            message: error_message_from_value(&error),
+            detail: error.get("detail").cloned(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -36,7 +55,7 @@ pub(crate) fn run_payloads_concurrently_streaming(
             errors: Vec::new(),
         };
     }
-    let (tx, rx) = mpsc::channel::<(usize, Result<Value, String>)>();
+    let (tx, rx) = mpsc::channel::<(usize, Result<Value, Value>)>();
     for (index, args) in arg_sets.into_iter().enumerate() {
         let tx = tx.clone();
         thread::spawn(move || {
@@ -54,10 +73,9 @@ pub(crate) fn run_payloads_concurrently_streaming(
                 on_partial(index, &payload);
                 results[index] = Some(payload);
             }
-            Ok((index, Err(error))) => errors.push(BatchItemError {
-                index,
-                message: error,
-            }),
+            Ok((index, Err(error))) => {
+                errors.push(BatchItemError::from_error_value(index, error))
+            }
             Err(_) => break,
         }
         received += 1;

--- a/apps/gpt-image-2-app/src-tauri/src/lib.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/lib.rs
@@ -10,25 +10,25 @@ use std::{
 
 use gpt_image_2_core::{
     AppConfig, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions, KEYCHAIN_SERVICE,
-    NotificationConfig, PathConfig, ProductRuntime, ProviderConfig, StorageConfig, StorageReadback,
-    StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    annotate_recovery_job_dir, append_history_job_event, batch_output_path, batch_recovery_job_dir,
-    batch_recovery_job_id, build_recovery_descriptor, default_config_path,
-    default_keychain_account, delete_history_job, dispatch_task_notifications,
-    edit_args_with_recovery, generate_args_with_recovery, generation_slots_from_batch_payload,
-    generation_slots_from_outputs, history_db_path, initialize_product_runtime_paths,
-    legacy_jobs_dir, legacy_shared_codex_dir, list_active_history_jobs,
-    list_expired_deleted_history_jobs, list_history_job_events, list_history_jobs_page,
-    load_app_config, mark_interrupted_jobs_on_startup, materialize_openai_raw_response,
-    merge_recovery_metadata, missing_generation_slot_indices, notification_status_allowed,
-    output_extension, preserve_notification_secrets, preserve_storage_secrets,
-    product_app_data_dir, product_default_export_dir, product_default_export_dirs,
-    product_result_library_dir, product_storage_fallback_dir, raw_response_path,
-    read_job_output_from_storage_with_options, read_keychain_secret, recovery_job_dir,
-    redact_app_config, requested_n, restore_deleted_history_job, run_json, save_app_config,
-    shared_config_dir, show_history_job, soft_delete_history_job, test_fault,
-    upload_job_outputs_to_storage, upsert_history_job, write_batch_recovery_summary,
-    write_keychain_secret,
+    LogLevel, LoggingConfig, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig,
+    StorageConfig, StorageReadback, StorageReadbackOptions, StorageTargetConfig,
+    StorageUploadOverrides, UploadFile, annotate_recovery_job_dir, append_history_job_event,
+    apply_logging_config, batch_output_path, batch_recovery_job_dir, batch_recovery_job_id,
+    build_recovery_descriptor, default_config_path, default_keychain_account, delete_history_job,
+    dispatch_task_notifications, edit_args_with_recovery, generate_args_with_recovery,
+    generation_slots_from_batch_payload, generation_slots_from_outputs, history_db_path,
+    init_logging, initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
+    list_active_history_jobs, list_expired_deleted_history_jobs, list_history_job_events,
+    list_history_jobs_page, load_app_config, log_event, logs_dir, mark_interrupted_jobs_on_startup,
+    materialize_openai_raw_response, merge_recovery_metadata, missing_generation_slot_indices,
+    notification_status_allowed, output_extension, preserve_notification_secrets,
+    preserve_storage_secrets, product_app_data_dir, product_default_export_dir,
+    product_default_export_dirs, product_result_library_dir, product_storage_fallback_dir,
+    raw_response_path, read_job_output_from_storage_with_options, read_keychain_secret,
+    read_recent_logs, recovery_job_dir, redact_app_config, requested_n,
+    restore_deleted_history_job, run_json, save_app_config, shared_config_dir, show_history_job,
+    soft_delete_history_job, test_fault, upload_job_outputs_to_storage, upsert_history_job,
+    write_batch_recovery_summary, write_keychain_secret,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -94,6 +94,13 @@ pub fn run() {
         }))
         .setup(|app| {
             allow_result_library_asset_scope(app.handle());
+            init_logging(&load_config_or_default(), ProductRuntime::Tauri);
+            log_event(
+                LogLevel::Info,
+                "local",
+                "app.started",
+                json!({ "runtime": "tauri", "version": env!("CARGO_PKG_VERSION") }),
+            );
             let _ = mark_interrupted_jobs_on_startup();
             // Off-thread so a slow filesystem walk can't delay startup, and
             // periodic so undo windows that elapse mid-session still get
@@ -108,6 +115,9 @@ pub fn run() {
             update_notifications,
             update_paths,
             update_storage,
+            update_logging,
+            get_logs,
+            open_logs_dir,
             test_notifications,
             test_storage_target,
             notification_capabilities,

--- a/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
@@ -81,10 +81,10 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
     })
 }
 
-pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value {
+pub(crate) fn failed_job_for_queue(queued: &QueuedJob, error: Value) -> Value {
     let mut metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     if let Value::Object(map) = &mut metadata {
-        map.insert("error".to_string(), json!({"message": message.clone()}));
+        map.insert("error".to_string(), error.clone());
     }
     job_snapshot(JobSnapshotInput {
         id: &queued.id,
@@ -95,7 +95,7 @@ pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value
         metadata,
         output_path: None,
         outputs: json!([]),
-        error: json!({"message": message}),
+        error,
     })
 }
 
@@ -133,7 +133,7 @@ pub(crate) fn finish_queued_job(
     app: tauri::AppHandle,
     state: JobQueueState,
     queued: QueuedJob,
-    result: Result<Value, String>,
+    result: Result<Value, Value>,
 ) {
     let (job, event_type, event_data, completed) = match result {
         Ok(response) => {
@@ -150,14 +150,14 @@ pub(crate) fn finish_queued_job(
             }
             (job, event_type, data, completed)
         }
-        Err(message) => {
-            let job = failed_job_for_queue(&queued, message.clone());
+        Err(error) => {
+            let job = failed_job_for_queue(&queued, error.clone());
             (
                 job,
                 "job.failed",
                 json!({
                     "status": "failed",
-                    "error": {"message": message},
+                    "error": error,
                 }),
                 false,
             )

--- a/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
@@ -148,9 +148,33 @@ pub(crate) fn finish_queued_job(
                 let uploading_job = uploading_job_for_queue(&queued, &response);
                 let _ = persist_job(&uploading_job);
             }
+            log_event(
+                LogLevel::Info,
+                "local",
+                "job.completed",
+                json!({
+                    "job_id": queued.id,
+                    "command": queued.command,
+                    "provider": queued.provider,
+                    "status": status.unwrap_or("completed"),
+                }),
+            );
             (job, event_type, data, completed)
         }
         Err(error) => {
+            // P0 hands us a structured JobError (code/message/detail); persist
+            // the same value so the logs panel can surface the real cause.
+            log_event(
+                LogLevel::Error,
+                "local",
+                "job.failed",
+                json!({
+                    "job_id": queued.id,
+                    "command": queued.command,
+                    "provider": queued.provider,
+                    "error": error,
+                }),
+            );
             let job = failed_job_for_queue(&queued, error.clone());
             (
                 job,
@@ -331,6 +355,16 @@ pub(crate) fn start_queued_jobs(app: tauri::AppHandle, state: JobQueueState) {
         };
         let _ = persist_job(&running_job);
         emit_queue_event(&app, &queued.id, &event);
+        log_event(
+            LogLevel::Info,
+            "local",
+            "job.started",
+            json!({
+                "job_id": queued.id,
+                "command": queued.command,
+                "provider": queued.provider,
+            }),
+        );
         let worker_app = app.clone();
         let worker_state = state.clone();
         thread::spawn(move || {

--- a/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/queue_workers.rs
@@ -148,17 +148,27 @@ pub(crate) fn finish_queued_job(
                 let uploading_job = uploading_job_for_queue(&queued, &response);
                 let _ = persist_job(&uploading_job);
             }
-            log_event(
-                LogLevel::Info,
-                "local",
-                "job.completed",
-                json!({
-                    "job_id": queued.id,
-                    "command": queued.command,
-                    "provider": queued.provider,
-                    "status": status.unwrap_or("completed"),
-                }),
-            );
+            // An Ok payload can still carry a terminal failure status (e.g.
+            // batch partial_failed), so classify the log from the terminal
+            // event type and include the cause when it failed.
+            let (log_level, log_type) = match event_type {
+                "job.failed" => (LogLevel::Error, "job.failed"),
+                "job.partial_failed" => (LogLevel::Warn, "job.partial_failed"),
+                "job.cancelled" => (LogLevel::Info, "job.cancelled"),
+                _ => (LogLevel::Info, "job.completed"),
+            };
+            let mut log_data = json!({
+                "job_id": queued.id,
+                "command": queued.command,
+                "provider": queued.provider,
+                "status": status.unwrap_or("completed"),
+            });
+            if matches!(event_type, "job.failed" | "job.partial_failed")
+                && let Some(error) = job.get("error").filter(|value| !value.is_null())
+            {
+                log_data["error"] = error.clone();
+            }
+            log_event(log_level, "local", log_type, log_data);
             (job, event_type, data, completed)
         }
         Err(error) => {

--- a/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
@@ -251,9 +251,7 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(error) => {
-                        errors.push(BatchItemError::from_error_value(*index, error))
-                    }
+                    Err(error) => errors.push(BatchItemError::from_error_value(*index, error)),
                 }
             }
         }
@@ -290,9 +288,7 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(error) => {
-                        errors.push(BatchItemError::from_error_value(*index, error))
-                    }
+                    Err(error) => errors.push(BatchItemError::from_error_value(*index, error)),
                 }
             }
         }

--- a/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/recovery_commands.rs
@@ -237,10 +237,10 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
-                        Err(message) => errors.push(BatchItemError {
-                            index: *index,
-                            message,
-                        }),
+                        Err(message) => errors.push(BatchItemError::from_error_value(
+                            *index,
+                            error_value_from_message(message),
+                        )),
                     }
                     continue;
                 }
@@ -251,10 +251,9 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(message) => errors.push(BatchItemError {
-                        index: *index,
-                        message,
-                    }),
+                    Err(error) => {
+                        errors.push(BatchItemError::from_error_value(*index, error))
+                    }
                 }
             }
         }
@@ -271,10 +270,10 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
-                        Err(message) => errors.push(BatchItemError {
-                            index: *index,
-                            message,
-                        }),
+                        Err(message) => errors.push(BatchItemError::from_error_value(
+                            *index,
+                            error_value_from_message(message),
+                        )),
                     }
                     continue;
                 }
@@ -291,10 +290,9 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(message) => errors.push(BatchItemError {
-                        index: *index,
-                        message,
-                    }),
+                    Err(error) => {
+                        errors.push(BatchItemError::from_error_value(*index, error))
+                    }
                 }
             }
         }

--- a/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
@@ -54,6 +54,9 @@ pub(crate) fn update_paths(config: PathConfig, app: tauri::AppHandle) -> Result<
     app_config.paths = next_config;
     save_config(&app_config)?;
     allow_result_library_asset_scope(&app);
+    // The app data dir may have moved; repoint the logger so get_logs and the
+    // writer stay in sync without a restart.
+    gpt_image_2_core::init_logging(&app_config, ProductRuntime::Tauri);
     Ok(config_for_ui(&app_config))
 }
 

--- a/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/settings_commands.rs
@@ -58,6 +58,32 @@ pub(crate) fn update_paths(config: PathConfig, app: tauri::AppHandle) -> Result<
 }
 
 #[tauri::command]
+pub(crate) fn update_logging(config: LoggingConfig) -> Result<Value, String> {
+    let mut app_config = load_config()?;
+    app_config.logging = config;
+    save_config(&app_config)?;
+    // Re-tune the live persistence level so the verbose toggle takes effect
+    // without restarting the app.
+    apply_logging_config(&app_config.logging);
+    Ok(config_for_ui(&app_config))
+}
+
+#[tauri::command]
+pub(crate) fn get_logs(limit: Option<usize>, level: Option<String>) -> Result<Value, String> {
+    let config = load_config_or_default();
+    let limit = limit.unwrap_or(500).clamp(1, 5000);
+    let min_level = level
+        .as_deref()
+        .and_then(LogLevel::parse)
+        .unwrap_or(LogLevel::Debug);
+    let entries = read_recent_logs(Some(&config), ProductRuntime::Tauri, limit, min_level);
+    Ok(json!({
+        "entries": entries,
+        "logs_dir": logs_dir(Some(&config), ProductRuntime::Tauri).display().to_string(),
+    }))
+}
+
+#[tauri::command]
 pub(crate) fn update_storage(mut config: StorageConfig) -> Result<Value, String> {
     let mut app_config = load_config()?;
     preserve_storage_secrets(&mut config, &app_config.storage);

--- a/apps/gpt-image-2-app/src-tauri/src/support.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/support.rs
@@ -274,7 +274,28 @@ pub(crate) fn cli_json(args: &[String]) -> Value {
     run_json(&argv).payload
 }
 
-pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, String> {
+/// Wrap a bare error string into a JobError-shaped object (`{ "message": ... }`)
+/// so internal validation/IO errors flow through the same `Value` channel as the
+/// structured payload errors produced by the core. Keeps `detail` optional.
+pub(crate) fn error_value_from_message(message: impl Into<String>) -> Value {
+    json!({ "message": message.into() })
+}
+
+/// Best-effort human-readable message from a JobError-shaped value, used where a
+/// flat string is still required (e.g. logging, summaries).
+pub(crate) fn error_message_from_value(error: &Value) -> String {
+    error
+        .get("message")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "Command failed".to_string())
+}
+
+/// Run the CLI and, on failure, preserve the entire `error` object from the
+/// payload (already redacted by core's `build_error_payload`) instead of
+/// flattening it to `error.message`. The Err value is JobError-shaped
+/// (`{ code, message, detail }`).
+pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, Value> {
     let mut argv = vec!["gpt-image-2-skill".to_string(), "--json".to_string()];
     argv.extend(args.iter().cloned());
     let outcome = run_json(&argv);
@@ -284,9 +305,7 @@ pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, String> {
         Err(outcome
             .payload
             .get("error")
-            .and_then(|error| error.get("message"))
-            .and_then(Value::as_str)
-            .unwrap_or("Command failed")
-            .to_string())
+            .cloned()
+            .unwrap_or_else(|| error_value_from_message("Command failed")))
     }
 }

--- a/apps/gpt-image-2-app/src/components/screens/history/job-drawer-sections.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-drawer-sections.tsx
@@ -163,15 +163,94 @@ export function JobDrawerStorage({
   );
 }
 
+function formatErrorDetail(detail: unknown): string {
+  if (detail == null) return "";
+  if (typeof detail === "string") return detail;
+  try {
+    return JSON.stringify(detail, null, 2);
+  } catch {
+    return String(detail);
+  }
+}
+
 export function JobDrawerError({ job }: { job: Job }) {
-  if (job.status !== "failed" || !job.error) return null;
+  if ((job.status !== "failed" && job.status !== "partial_failed") || !job.error)
+    return null;
+  const error = job.error;
+  const items = Array.isArray(error.items) ? error.items : [];
+  const detailText = formatErrorDetail(error.detail);
+  // The copy payload keeps the full structured error so users can paste the real
+  // cause (code + message + detail + per-slot items) into a bug report.
+  const copyPayload = formatErrorDetail({
+    code: error.code,
+    message: error.message,
+    detail: error.detail,
+    items: items.length > 0 ? items : undefined,
+  });
   return (
-    <div className="px-3 py-2.5 mb-3.5 bg-status-err-bg text-status-err border border-status-err rounded-md text-[12px] flex items-start gap-2">
-      <Icon name="warn" size={13} style={{ marginTop: 1 }} />
-      <div>
-        <div className="font-semibold mb-0.5">错误</div>
-        <div>{(job.error as Record<string, unknown>).message as string}</div>
+    <div className="px-3 py-2.5 mb-3.5 bg-status-err-bg text-status-err border border-status-err rounded-md text-[12px]">
+      <div className="flex items-start gap-2">
+        <Icon name="warn" size={13} style={{ marginTop: 1 }} />
+        <div className="min-w-0 flex-1">
+          <div className="mb-0.5 flex items-center gap-2">
+            <span className="font-semibold">错误</span>
+            {error.code && (
+              <span className="t-mono rounded bg-status-err/10 px-1.5 py-0.5 text-[10.5px]">
+                {error.code}
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              size="iconSm"
+              icon="copy"
+              className="ml-auto"
+              onClick={() => copyText(copyPayload, "错误详情")}
+              title="复制错误详情"
+              aria-label="复制错误详情"
+            />
+          </div>
+          <div className="break-anywhere">{error.message}</div>
+        </div>
       </div>
+      {(detailText || items.length > 0) && (
+        <details className="mt-2">
+          <summary className="cursor-pointer select-none text-[11px] font-semibold opacity-90">
+            显示详情
+          </summary>
+          {detailText && (
+            <pre className="mt-1.5 mb-0 max-h-52 overflow-auto whitespace-pre-wrap break-anywhere rounded bg-status-err/5 p-2 font-mono text-[10.5px] leading-[1.45]">
+              {detailText}
+            </pre>
+          )}
+          {items.length > 0 && (
+            <div className="mt-2 space-y-1.5">
+              {items.map((item, position) => (
+                <div
+                  key={item.index ?? position}
+                  className="rounded bg-status-err/5 px-2 py-1.5 text-[11px]"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">
+                      候选 {(item.index ?? position) + 1}
+                    </span>
+                    {item.code && (
+                      <span className="t-mono text-[10px] opacity-80">
+                        {item.code}
+                      </span>
+                    )}
+                  </div>
+                  <div className="break-anywhere">{item.message}</div>
+                  {item.detail != null && (
+                    <pre className="mt-1 mb-0 max-h-40 overflow-auto whitespace-pre-wrap break-anywhere rounded bg-status-err/5 p-1.5 font-mono text-[10px] leading-[1.4]">
+                      {formatErrorDetail(item.detail)}
+                    </pre>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </details>
+      )}
     </div>
   );
 }

--- a/apps/gpt-image-2-app/src/components/screens/history/shared.ts
+++ b/apps/gpt-image-2-app/src/components/screens/history/shared.ts
@@ -374,8 +374,7 @@ export function jobStatusLabel(job: Job): string {
 export function jobErrorMessage(job: Job): string {
   const error = job.error;
   if (!error || typeof error !== "object") return "";
-  const message = (error as Record<string, unknown>).message;
-  return typeof message === "string" ? message : "";
+  return typeof error.message === "string" ? error.message : "";
 }
 
 export function jobErrorDetailText(job: Job): string {

--- a/apps/gpt-image-2-app/src/components/screens/settings/constants.ts
+++ b/apps/gpt-image-2-app/src/components/screens/settings/constants.ts
@@ -7,6 +7,7 @@ import {
   Info,
   KeyRound,
   ListChecks,
+  ScrollText,
   Sparkles,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -45,6 +46,7 @@ export type SettingsTab =
   | "runtime"
   | "storage"
   | "prompts"
+  | "logs"
   | "about";
 
 export const NAV: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
@@ -53,10 +55,13 @@ export const NAV: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
   { id: "runtime", label: "任务", icon: ListChecks },
   { id: "storage", label: "存储", icon: HardDrive },
   { id: "prompts", label: "模板", icon: FileText },
+  { id: "logs", label: "日志", icon: ScrollText },
   { id: "about", label: "关于", icon: Info },
 ];
 
-export const BROWSER_HIDDEN_TABS: SettingsTab[] = ["storage"];
+// Static Web has no server-side file logger, so the logs tab would only ever
+// show an empty state — hide it there alongside the (server-only) storage tab.
+export const BROWSER_HIDDEN_TABS: SettingsTab[] = ["storage", "logs"];
 
 export const PARALLEL_OPTIONS = [1, 2, 3, 4, 6, 8].map((n) => ({
   value: String(n),
@@ -239,6 +244,10 @@ export const TAB_TITLES: Record<
   prompts: {
     title: "提示词模板",
     subtitle: "管理可复用的生成和编辑提示词",
+  },
+  logs: {
+    title: "日志",
+    subtitle: "查看运行诊断日志，排查生成失败的原因",
   },
   about: {
     title: "关于 / 更新",

--- a/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/index.tsx
@@ -9,6 +9,7 @@ import { AppearancePanel } from "./appearance-panel";
 import { BROWSER_HIDDEN_TABS, type SettingsTab } from "./constants";
 import { CredsPanel } from "./credentials-panel";
 import { PanelHeader, SettingsNav } from "./layout";
+import { LogsPanel } from "./logs-panel";
 import { RuntimePanel } from "./runtime-panel";
 import { StoragePanel } from "./storage-panel";
 
@@ -76,6 +77,7 @@ export function SettingsScreen({ config }: { config?: ServerConfig } = {}) {
               />
             )}
             {visibleTab === "prompts" && <PromptTemplatesPanel />}
+            {visibleTab === "logs" && <LogsPanel />}
             {visibleTab === "about" && <AboutPanel />}
           </motion.div>
         </AnimatePresence>

--- a/apps/gpt-image-2-app/src/components/screens/settings/logs-panel.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/settings/logs-panel.tsx
@@ -1,0 +1,288 @@
+import { useMemo, useState } from "react";
+import { Download, FolderOpen, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Segmented } from "@/components/ui/segmented";
+import { Toggle } from "@/components/ui/toggle";
+import {
+  useConfig,
+  useLogs,
+  useOpenLogsDir,
+  useUpdateLogging,
+} from "@/hooks/use-config";
+import { cn } from "@/lib/cn";
+import { runtimeCopy } from "@/lib/runtime-copy";
+import type { LogEntry, LogLevel } from "@/lib/types";
+import { Row, Section } from "./layout";
+
+// Segmented filter value; "all" means "no level floor" (show debug and up).
+type LevelFilter = "all" | LogLevel;
+
+const LEVEL_FILTER_OPTIONS: { value: LevelFilter; label: string }[] = [
+  { value: "all", label: "全部" },
+  { value: "error", label: "错误" },
+  { value: "warn", label: "警告" },
+  { value: "info", label: "信息" },
+  { value: "debug", label: "调试" },
+];
+
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  error: "错误",
+  warn: "警告",
+  info: "信息",
+  debug: "调试",
+};
+
+function levelClasses(level: LogLevel): string {
+  switch (level) {
+    case "error":
+      return "text-status-err border-[color:var(--status-err-25)] bg-[color:var(--status-err-08)]";
+    case "warn":
+      return "text-status-warn border-[color:var(--status-warn-25,var(--border))] bg-[color:var(--status-warn-08,var(--w-05))]";
+    case "info":
+      return "text-foreground border-border bg-[color:var(--w-05)]";
+    case "debug":
+    default:
+      return "text-muted border-border bg-[color:var(--w-03)]";
+  }
+}
+
+function formatTimestamp(ts: string): string {
+  const parsed = new Date(ts);
+  if (Number.isNaN(parsed.getTime())) return ts;
+  return parsed.toLocaleString();
+}
+
+/** Best-effort one-line message extracted from a log entry's payload. */
+function entryMessage(entry: LogEntry): string {
+  const data = entry.data ?? {};
+  const error = data.error;
+  if (error && typeof error === "object") {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === "string") return message;
+  }
+  const direct = data.message;
+  if (typeof direct === "string") return direct;
+  // Fall back to a compact rendering of the remaining payload so the row is
+  // never empty (e.g. job ids on job.started).
+  const keys = Object.keys(data);
+  if (keys.length === 0) return "";
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return "";
+  }
+}
+
+export function LogsPanel() {
+  const copy = runtimeCopy();
+  const [filter, setFilter] = useState<LevelFilter>("all");
+
+  const level = filter === "all" ? undefined : filter;
+  const isBrowser = copy.kind === "browser";
+
+  const { data: config } = useConfig();
+  const logging = config?.logging;
+  const updateLogging = useUpdateLogging();
+  const openLogsDir = useOpenLogsDir();
+
+  const logsQuery = useLogs({ level, limit: 1000, enabled: !isBrowser });
+  const entries = logsQuery.data?.entries ?? [];
+  const logsDir = logsQuery.data?.logs_dir ?? "";
+
+  // Render newest first in the UI even though the backend returns oldest-last.
+  const ordered = useMemo(() => [...entries].reverse(), [entries]);
+
+  if (isBrowser) {
+    return (
+      <div className="flex-1 min-h-0 overflow-auto p-4 sm:p-5 space-y-4">
+        <Section
+          title="日志"
+          description="运行诊断日志，便于排查生成失败的原因。"
+        >
+          <Row
+            title="此环境不支持日志"
+            description="静态 Web 版本没有本机日志文件，请使用桌面 App 或自托管的 Docker 后端查看诊断日志。"
+            control={<span className="text-[12px] text-muted">不可用</span>}
+          />
+        </Section>
+      </div>
+    );
+  }
+
+  const handleExport = () => {
+    if (ordered.length === 0) {
+      toast.warning("没有可导出的日志");
+      return;
+    }
+    // Export the currently loaded slice as JSONL (oldest-first to match the
+    // on-disk file) so it can be attached to a bug report.
+    const text = entries.map((entry) => JSON.stringify(entry)).join("\n");
+    const blob = new Blob([`${text}\n`], {
+      type: "application/x-ndjson;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    anchor.download = `gpt-image-2-logs-${stamp}.jsonl`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleOpenDir = async () => {
+    try {
+      const path = await openLogsDir.mutateAsync();
+      if (copy.kind === "http") {
+        toast.info("日志目录", {
+          description: path || "服务器日志目录路径不可用。",
+        });
+      }
+    } catch (error) {
+      toast.error("无法打开日志文件夹", {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4 sm:p-5">
+      <Section title="日志设置" description="控制诊断日志的详细程度。">
+        <Row
+          title="详细日志（调试）"
+          description="开启后会额外记录 debug 级别的事件，便于深入排查；默认仅记录信息及以上。"
+          control={
+            <Toggle
+              checked={logging?.debug ?? false}
+              disabled={updateLogging.isPending}
+              onChange={(debug) => {
+                updateLogging.mutate(
+                  { debug },
+                  {
+                    onError: (error) =>
+                      toast.error("保存日志设置失败", {
+                        description:
+                          error instanceof Error
+                            ? error.message
+                            : String(error),
+                      }),
+                  },
+                );
+              }}
+            />
+          }
+        />
+      </Section>
+
+      <div className="flex flex-col min-h-0 flex-1 rounded-xl overflow-hidden border border-border-faint">
+        <div className="flex flex-wrap items-center gap-2 border-b border-border-faint px-4 py-3 sm:px-5">
+          <Segmented
+            value={filter}
+            onChange={setFilter}
+            options={LEVEL_FILTER_OPTIONS}
+            size="sm"
+            ariaLabel="日志级别过滤"
+          />
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void logsQuery.refetch()}
+              disabled={logsQuery.isFetching}
+            >
+              <RefreshCw
+                size={13}
+                className={cn(logsQuery.isFetching && "animate-spin")}
+              />
+              刷新
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void handleOpenDir()}
+              disabled={openLogsDir.isPending}
+            >
+              <FolderOpen size={13} />
+              {copy.kind === "http" ? "日志目录" : "打开文件夹"}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleExport}
+              disabled={ordered.length === 0}
+            >
+              <Download size={13} />
+              导出
+            </Button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto">
+          {logsQuery.isLoading ? (
+            <div className="px-4 py-8 text-center text-[12.5px] text-muted">
+              正在加载日志…
+            </div>
+          ) : logsQuery.isError ? (
+            <div className="px-4 py-8 text-center text-[12.5px] text-status-err">
+              加载日志失败：
+              {logsQuery.error instanceof Error
+                ? logsQuery.error.message
+                : "未知错误"}
+            </div>
+          ) : ordered.length === 0 ? (
+            <div className="px-4 py-8 text-center text-[12.5px] text-muted">
+              暂无日志记录。
+              {logging?.debug
+                ? ""
+                : "如需更详细的事件，可开启上方的「详细日志」。"}
+            </div>
+          ) : (
+            <ul className="divide-y divide-border-faint">
+              {ordered.map((entry, index) => {
+                const message = entryMessage(entry);
+                return (
+                  <li
+                    key={`${entry.ts}-${index}`}
+                    className="flex flex-col gap-1 px-4 py-2.5 sm:px-5"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          "inline-flex shrink-0 items-center rounded border px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide",
+                          levelClasses(entry.level),
+                        )}
+                      >
+                        {LEVEL_LABEL[entry.level] ?? entry.level}
+                      </span>
+                      <span className="font-mono text-[11.5px] text-foreground">
+                        {entry.type}
+                      </span>
+                      <span className="ml-auto shrink-0 font-mono text-[11px] text-muted">
+                        {formatTimestamp(entry.ts)}
+                      </span>
+                    </div>
+                    {message && (
+                      <p className="break-words text-[12px] leading-snug text-muted">
+                        {message}
+                      </p>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {logsDir && (
+          <div className="border-t border-border-faint px-4 py-2 sm:px-5">
+            <p className="truncate font-mono text-[11px] text-muted" title={logsDir}>
+              {logsDir}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/gpt-image-2-app/src/hooks/use-config.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-config.ts
@@ -2,6 +2,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import type {
   JobStatus,
+  LoggingConfig,
+  LogLevel,
+  LogsResult,
   NotificationConfig,
   PathConfig,
   ProviderConfig,
@@ -110,6 +113,49 @@ export function useTestStorageTarget() {
         throw new Error("当前运行环境不支持测试存储目标。");
       }
       return api.testStorageTarget(name, target);
+    },
+  });
+}
+
+export function useLogs(options?: {
+  level?: LogLevel;
+  limit?: number;
+  enabled?: boolean;
+  refetchInterval?: number | false;
+}) {
+  const level = options?.level;
+  const limit = options?.limit ?? 500;
+  return useQuery<LogsResult>({
+    // level is part of the key so switching the filter re-fetches a
+    // server-side filtered slice instead of just client-filtering.
+    queryKey: ["logs", level ?? "all", limit],
+    queryFn: () => api.getLogs({ level, limit }),
+    enabled: options?.enabled ?? true,
+    refetchInterval: options?.refetchInterval ?? false,
+    staleTime: 2_000,
+  });
+}
+
+export function useUpdateLogging() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (config: LoggingConfig) => api.updateLogging(config),
+    onSuccess: (data) => {
+      qc.setQueryData(["config"], data);
+      // Verbose toggle changes which entries get persisted going forward;
+      // refresh the panel so the effect is visible.
+      void qc.invalidateQueries({ queryKey: ["logs"] });
+    },
+  });
+}
+
+export function useOpenLogsDir() {
+  return useMutation({
+    mutationFn: () => {
+      if (!api.openLogsDir) {
+        throw new Error("当前运行环境不支持打开日志文件夹。");
+      }
+      return api.openLogsDir();
     },
   });
 }

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.ts
@@ -1,6 +1,8 @@
 import type {
   GenerateRequest,
   Job,
+  LoggingConfig,
+  LogsResult,
   NotificationConfig,
   PathConfig,
   ProviderConfig,
@@ -114,6 +116,20 @@ export const browserApi: ApiClient = {
     return browser.browserConfigForUi(current);
   },
   testStorageTarget: browser.testBrowserStorageTarget,
+  async getLogs() {
+    // Static Web build has no server-side file logger to read back.
+    return { entries: [], logs_dir: "" } satisfies LogsResult;
+  },
+  async updateLogging(config: LoggingConfig) {
+    // No file logger here, but persist the preference so the toggle is sticky
+    // across reloads and stays consistent if the same config syncs elsewhere.
+    await browser.prepareBrowserRuntime();
+    const current = await browser.readConfigRecord();
+    current.logging = { debug: Boolean(config.debug) };
+    await browser.writeStoredConfig(browser.browserStoredConfig(current));
+    return browser.browserConfigForUi(current);
+  },
+  // openLogsDir intentionally omitted: the browser cannot open a folder.
   async setDefault(name: string) {
     await browser.prepareBrowserRuntime();
     const config = await browser.readConfigRecord();

--- a/apps/gpt-image-2-app/src/lib/api/browser/queue.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/queue.ts
@@ -1,4 +1,10 @@
-import type { GenerateRequest, Job, OutputRef, QueueStatus } from "../../types";
+import type {
+  GenerateRequest,
+  Job,
+  JobError,
+  OutputRef,
+  QueueStatus,
+} from "../../types";
 import { normalizeJobResponse, outputPaths } from "../shared";
 import { isActiveJobStatus } from "../types";
 import { appendEvent, nowIso } from "./events";
@@ -167,14 +173,31 @@ export async function failTask(task: BrowserQueuedTask, error: unknown) {
     : error instanceof Error
       ? error.message
       : String(error);
+  // Preserve the structured shape (code/message/detail/items) for thrown batch
+  // errors and any object that already carries a JobError-like payload, so the
+  // failed card and "复制完整错误" surface the real cause; otherwise fall back to
+  // a bare `{ message }`.
+  const structured =
+    !aborted && error && typeof error === "object"
+      ? (error as Partial<JobError>)
+      : null;
+  const jobError: JobError =
+    structured && (structured.items || structured.detail || structured.code)
+      ? {
+          code: structured.code,
+          message:
+            typeof structured.message === "string"
+              ? structured.message
+              : message,
+          detail: structured.detail,
+          items: structured.items,
+        }
+      : { message };
   const failed = {
     ...task.job,
     status: aborted ? ("cancelled" as const) : ("failed" as const),
     updated_at: nowIso(),
-    error:
-      error && typeof error === "object" && "items" in error
-        ? (error as Record<string, unknown>)
-        : { message },
+    error: jobError,
   };
   await writeJob(failed);
   appendEvent(task.job.id, aborted ? "job.cancelled" : "job.failed", {

--- a/apps/gpt-image-2-app/src/lib/api/http-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http-transport.ts
@@ -3,6 +3,9 @@ import type {
   Job,
   JobEvent,
   JobStatus,
+  LoggingConfig,
+  LogLevel,
+  LogsResult,
   NotificationCapabilities,
   NotificationConfig,
   NotificationTestResult,
@@ -126,6 +129,27 @@ export const httpApi: ApiClient = {
         body: jsonBody({ target }),
       },
     );
+  },
+  async getLogs(options?: { limit?: number; level?: LogLevel }) {
+    const params = new URLSearchParams();
+    if (options?.limit != null) params.set("limit", String(options.limit));
+    if (options?.level) params.set("level", options.level);
+    const query = params.toString();
+    return requestJson<LogsResult>(`/logs${query ? `?${query}` : ""}`);
+  },
+  async updateLogging(config: LoggingConfig) {
+    return normalizeConfig(
+      await requestJson<ServerConfig>("/logging", {
+        method: "PUT",
+        body: jsonBody(config),
+      }),
+    );
+  },
+  async openLogsDir() {
+    // No native file-manager on a remote server; surface the server-side path
+    // so the UI can show users where the logs live inside the container.
+    const result = await requestJson<LogsResult>("/logs?limit=1");
+    return result.logs_dir;
   },
   async setDefault(name: string) {
     return normalizeConfig(

--- a/apps/gpt-image-2-app/src/lib/api/http/client.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http/client.ts
@@ -29,18 +29,47 @@ export function fileApiUrl(path: string) {
   return `${base}/files?path=${encodeURIComponent(path)}`;
 }
 
-async function parseErrorResponse(response: Response) {
+/**
+ * Error thrown by {@link requestJson} for non-2xx HTTP responses. Extends
+ * `Error` so existing `error.message` consumers keep working, while carrying the
+ * structured `code`/`detail` from the server's `{ error: { message, detail,
+ * code? } }` envelope so the real, already-redacted cause survives to the UI.
+ */
+export class ApiRequestError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly detail?: unknown;
+
+  constructor(
+    message: string,
+    options: { status: number; code?: string; detail?: unknown },
+  ) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = options.status;
+    this.code = options.code;
+    this.detail = options.detail;
+  }
+}
+
+async function parseErrorResponse(
+  response: Response,
+): Promise<{ message: string; code?: string; detail?: unknown }> {
   const fallback = `${response.status} ${response.statusText}`.trim();
   const text = await response.text();
-  if (!text) return fallback;
+  if (!text) return { message: fallback };
   try {
     const payload = JSON.parse(text) as {
-      error?: { message?: string };
+      error?: { message?: string; code?: string; detail?: unknown };
       message?: string;
     };
-    return payload.error?.message || payload.message || fallback;
+    return {
+      message: payload.error?.message || payload.message || fallback,
+      code: payload.error?.code,
+      detail: payload.error?.detail,
+    };
   } catch {
-    return text || fallback;
+    return { message: text || fallback };
   }
 }
 
@@ -53,7 +82,14 @@ export async function requestJson<T>(
     headers.set("Content-Type", "application/json");
   }
   const response = await fetch(apiResourceUrl(path), { ...init, headers });
-  if (!response.ok) throw new Error(await parseErrorResponse(response));
+  if (!response.ok) {
+    const parsed = await parseErrorResponse(response);
+    throw new ApiRequestError(parsed.message, {
+      status: response.status,
+      code: parsed.code,
+      detail: parsed.detail,
+    });
+  }
   if (response.status === 204) return undefined as T;
   return (await response.json()) as T;
 }

--- a/apps/gpt-image-2-app/src/lib/api/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/index.ts
@@ -115,6 +115,19 @@ export const api: ApiClient = {
       }
       return client.testStorageTarget(name, target);
     }),
+  getLogs: (options) =>
+    invokeClient("getLogs", options) as ReturnType<ApiClient["getLogs"]>,
+  updateLogging: (config) =>
+    invokeClient("updateLogging", config) as ReturnType<
+      ApiClient["updateLogging"]
+    >,
+  openLogsDir: () =>
+    loadClient().then((client) => {
+      if (!client.openLogsDir) {
+        throw new Error("当前运行环境不支持打开日志文件夹。");
+      }
+      return client.openLogsDir();
+    }),
   setDefault: (name) =>
     invokeClient("setDefault", name) as ReturnType<ApiClient["setDefault"]>,
   upsertProvider: (name, cfg) =>

--- a/apps/gpt-image-2-app/src/lib/api/shared.ts
+++ b/apps/gpt-image-2-app/src/lib/api/shared.ts
@@ -719,6 +719,7 @@ export function normalizeConfig(config: ServerConfig): ServerConfig {
     notifications: normalizeNotificationConfig(config.notifications),
     storage: normalizeStorageConfig(config.storage),
     paths: normalizePathConfig(config.paths),
+    logging: { debug: Boolean(config.logging?.debug) },
   };
 }
 

--- a/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
+++ b/apps/gpt-image-2-app/src/lib/api/tauri-transport.ts
@@ -5,6 +5,9 @@ import type {
   Job,
   JobEvent,
   JobStatus,
+  LoggingConfig,
+  LogLevel,
+  LogsResult,
   NotificationCapabilities,
   NotificationConfig,
   NotificationTestResult,
@@ -133,6 +136,20 @@ export const tauriApi: ApiClient = {
   },
   async testStorageTarget(name: string, target?: StorageTargetConfig) {
     return invoke<StorageTestResult>("test_storage_target", { name, target });
+  },
+  async getLogs(options?: { limit?: number; level?: LogLevel }) {
+    return invoke<LogsResult>("get_logs", {
+      limit: options?.limit ?? null,
+      level: options?.level ?? null,
+    });
+  },
+  async updateLogging(config: LoggingConfig) {
+    return normalizeConfig(
+      await invoke<ServerConfig>("update_logging", { config }),
+    );
+  },
+  async openLogsDir() {
+    return invoke<string>("open_logs_dir");
   },
   async setDefault(name: string) {
     return normalizeConfig(

--- a/apps/gpt-image-2-app/src/lib/api/types.ts
+++ b/apps/gpt-image-2-app/src/lib/api/types.ts
@@ -3,6 +3,9 @@ import type {
   Job,
   JobEvent,
   JobStatus,
+  LoggingConfig,
+  LogLevel,
+  LogsResult,
   NotificationCapabilities,
   NotificationConfig,
   NotificationTestResult,
@@ -102,6 +105,19 @@ export type ApiClient = RuntimeCapabilities & {
     name: string,
     target?: StorageTargetConfig,
   ): Promise<StorageTestResult>;
+  /**
+   * Read recent persisted log entries (newest last), filtered to `>= level`.
+   * Browser runtime has no file logger and resolves to an empty result.
+   */
+  getLogs(options?: { limit?: number; level?: LogLevel }): Promise<LogsResult>;
+  /** Persist the logging config (verbose toggle) and re-tune the live level. */
+  updateLogging(config: LoggingConfig): Promise<ServerConfig>;
+  /**
+   * Tauri: reveal the logs directory in the OS file manager and return its
+   * path. HTTP: no native open, returns the server-side path string for the
+   * UI to display. Absent on the browser runtime.
+   */
+  openLogsDir?(): Promise<string>;
   setDefault(name: string): Promise<ServerConfig>;
   upsertProvider(name: string, cfg: ProviderConfig): Promise<ServerConfig>;
   revealProviderCredential(

--- a/apps/gpt-image-2-app/src/lib/types.ts
+++ b/apps/gpt-image-2-app/src/lib/types.ts
@@ -321,6 +321,23 @@ export interface OutputRef {
 }
 
 /**
+ * Structured error carried end-to-end from the core through the GUI/Web
+ * boundary. `message` is the short human summary (matches the legacy
+ * `{ message }` shape); `code` is the machine error code; `detail` is the real,
+ * already-redacted cause (an object or string) surfaced behind a "show details"
+ * affordance; `items` holds per-slot errors for batch (n>1) jobs, each itself a
+ * `JobError`.
+ */
+export interface JobError {
+  code?: string;
+  message: string;
+  detail?: unknown;
+  items?: JobError[];
+  /** Batch item index, present on `items[*]` entries. */
+  index?: number;
+}
+
+/**
  * A persisted input reference image for an `images edit` (image-to-image) job.
  * The backend fills this by scanning `ref-{index}.png` in the job directory, so
  * it works for legacy jobs too. Absent/empty for text-to-image jobs.
@@ -342,7 +359,7 @@ export interface Job {
   reference_images?: ReferenceImageRef[];
   output_path?: string;
   storage_status?: StorageStatus | string;
-  error?: Record<string, unknown> | null;
+  error?: JobError | null;
 }
 
 export interface JobEvent {

--- a/apps/gpt-image-2-app/src/lib/types.ts
+++ b/apps/gpt-image-2-app/src/lib/types.ts
@@ -287,6 +287,30 @@ export interface NotificationCapabilities {
   };
 }
 
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface LoggingConfig {
+  /** When true, debug-level events are persisted alongside info/warn/error. */
+  debug: boolean;
+}
+
+export interface LogEntry {
+  /** RFC3339 timestamp. */
+  ts: string;
+  level: LogLevel;
+  /** Event family, mirroring the JsonEventLogger vocabulary (e.g. "local"). */
+  kind: string;
+  /** Event type, e.g. "job.failed" / "app.started". */
+  type: string;
+  /** Redacted structured payload. */
+  data?: Record<string, unknown>;
+}
+
+export interface LogsResult {
+  entries: LogEntry[];
+  logs_dir: string;
+}
+
 export interface ServerConfig {
   version: 1;
   default_provider?: string;
@@ -294,6 +318,7 @@ export interface ServerConfig {
   notifications: NotificationConfig;
   storage: StorageConfig;
   paths: PathConfig;
+  logging?: LoggingConfig;
 }
 
 export type JobStatus =

--- a/crates/gpt-image-2-core/src/config_io.rs
+++ b/crates/gpt-image-2-core/src/config_io.rs
@@ -125,6 +125,7 @@ pub fn redact_app_config(config: &AppConfig) -> Value {
         "notifications": redact_notification_config(&config.notifications),
         "storage": redact_storage_config(&config.storage),
         "paths": config.paths,
+        "logging": redact_logging_config(&config.logging),
     })
 }
 

--- a/crates/gpt-image-2-core/src/config_types.rs
+++ b/crates/gpt-image-2-core/src/config_types.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::logging::LoggingConfig;
 use crate::notifications::NotificationConfig;
 use crate::provider_types::ProviderConfig;
 use crate::storage::StorageConfig;
@@ -37,6 +38,8 @@ pub struct AppConfig {
     pub storage: StorageConfig,
     #[serde(default)]
     pub paths: PathConfig,
+    #[serde(default)]
+    pub logging: LoggingConfig,
 }
 
 impl Default for AppConfig {
@@ -48,6 +51,7 @@ impl Default for AppConfig {
             notifications: NotificationConfig::default(),
             storage: StorageConfig::default(),
             paths: PathConfig::default(),
+            logging: LoggingConfig::default(),
         }
     }
 }

--- a/crates/gpt-image-2-core/src/lib.rs
+++ b/crates/gpt-image-2-core/src/lib.rs
@@ -40,6 +40,7 @@ mod history_list;
 mod image_commands;
 mod image_requests;
 mod json_events;
+mod logging;
 mod network_safety;
 mod notifications;
 mod paths;
@@ -101,6 +102,11 @@ pub use history_list::{
 pub(crate) use image_commands::*;
 pub(crate) use image_requests::*;
 pub use json_events::JsonEventLogger;
+pub(crate) use logging::*;
+pub use logging::{
+    LogLevel, LoggingConfig, apply_logging_config, init_logging, log_event, logs_dir,
+    read_recent_logs,
+};
 pub(crate) use network_safety::*;
 pub(crate) use notifications::*;
 pub use notifications::{

--- a/crates/gpt-image-2-core/src/logging.rs
+++ b/crates/gpt-image-2-core/src/logging.rs
@@ -1,0 +1,538 @@
+#![allow(unused_imports)]
+
+//! Persistent diagnostic logging for the App/Web product runtimes.
+//!
+//! Logs are written as JSONL (one JSON object per line) into a size-rolling
+//! file under `product_app_data_dir(config, runtime)/logs/`. Every payload is
+//! routed through the shared [`redact_event_payload`] sanitizer before it
+//! touches disk, so API keys / tokens / proxy passwords never get persisted.
+//!
+//! Hard guarantees enforced here:
+//! - Initialization happens at most once per process (guarded by `OnceLock`).
+//!   The CLI never calls [`init_logging`], so it keeps no file logger at all.
+//! - Nothing in this module ever writes to `stdout`. Failures degrade to a
+//!   one-line `stderr` warning and are otherwise swallowed, so the CLI's
+//!   stdout JSON protocol is never polluted even if logging is somehow active.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::*;
+
+/// Single log file size cap before it rolls over to `<name>.1`.
+const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
+/// How many rolled files to retain (`.log.1` ..= `.log.{MAX_BACKUPS}`).
+const MAX_BACKUPS: usize = 5;
+/// Base log file name inside the logs directory.
+const LOG_FILE_NAME: &str = "gpt-image-2.log";
+
+/// Persistent logging preferences. `#[serde(default)]` everywhere keeps this a
+/// zero-migration addition to `AppConfig`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct LoggingConfig {
+    /// When true, `debug`-level events are persisted in addition to
+    /// info/warn/error. Off (`false`) by default to keep logs lean.
+    #[serde(default)]
+    pub debug: bool,
+}
+
+/// No secrets live in `LoggingConfig`, so redaction is an identity transform.
+/// Kept as a named helper to mirror the `redact_*_config` pattern used by the
+/// other sub-configs in `redact_app_config`.
+pub(crate) fn redact_logging_config(config: &LoggingConfig) -> Value {
+    json!({ "debug": config.debug })
+}
+
+/// Severity levels, ordered so `>=` comparisons express "at least this severe".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+}
+
+impl LogLevel {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LogLevel::Debug => "debug",
+            LogLevel::Info => "info",
+            LogLevel::Warn => "warn",
+            LogLevel::Error => "error",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "debug" => Some(LogLevel::Debug),
+            "info" => Some(LogLevel::Info),
+            "warn" | "warning" => Some(LogLevel::Warn),
+            "error" => Some(LogLevel::Error),
+            _ => None,
+        }
+    }
+}
+
+/// Minimum level that gets persisted. `debug` is only retained when the user
+/// turns on the "verbose logging" switch (`LoggingConfig.debug`). Stored as an
+/// atomic so `update_logging` can re-tune the live level without re-init.
+static MIN_LEVEL: AtomicU8 = AtomicU8::new(LogLevel::Info as u8);
+
+fn min_level() -> u8 {
+    MIN_LEVEL.load(Ordering::Relaxed)
+}
+
+fn set_min_level_from_config(config: &LoggingConfig) {
+    let level = if config.debug {
+        LogLevel::Debug
+    } else {
+        LogLevel::Info
+    };
+    MIN_LEVEL.store(level as u8, Ordering::Relaxed);
+}
+
+/// Size-rolling JSONL writer. Holds an append handle to the active log file and
+/// rolls it over once it crosses [`MAX_FILE_BYTES`].
+struct RollingWriter {
+    path: PathBuf,
+    file: Option<File>,
+    written: u64,
+}
+
+impl RollingWriter {
+    fn open(path: PathBuf) -> Self {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let (file, written) = match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(file) => {
+                let written = file.metadata().map(|meta| meta.len()).unwrap_or(0);
+                (Some(file), written)
+            }
+            Err(_) => (None, 0),
+        };
+        Self {
+            path,
+            file,
+            written,
+        }
+    }
+
+    fn write_line(&mut self, line: &str) {
+        if self.file.is_none() {
+            // A previous open failed; try once more so a transient error
+            // (e.g. directory created later) can self-heal.
+            *self = RollingWriter::open(self.path.clone());
+        }
+        let len = line.len() as u64 + 1;
+        if self.written.saturating_add(len) > MAX_FILE_BYTES && self.written > 0 {
+            self.roll();
+        }
+        if let Some(file) = self.file.as_mut()
+            && writeln!(file, "{line}").is_ok()
+        {
+            let _ = file.flush();
+            self.written = self.written.saturating_add(len);
+        }
+    }
+
+    /// Shift `<name>.{n}` -> `<name>.{n+1}`, drop anything beyond
+    /// [`MAX_BACKUPS`], move the live file to `<name>.1`, then reopen fresh.
+    fn roll(&mut self) {
+        self.file = None;
+        let base = self.path.clone();
+        // Remove the oldest retained backup so it doesn't get bumped past the cap.
+        let oldest = backup_path(&base, MAX_BACKUPS);
+        let _ = fs::remove_file(&oldest);
+        for index in (1..MAX_BACKUPS).rev() {
+            let from = backup_path(&base, index);
+            let to = backup_path(&base, index + 1);
+            if from.exists() {
+                let _ = fs::rename(&from, &to);
+            }
+        }
+        let _ = fs::rename(&base, backup_path(&base, 1));
+        *self = RollingWriter::open(base);
+    }
+}
+
+fn backup_path(base: &Path, index: usize) -> PathBuf {
+    let mut name = base
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    name.push(format!(".{index}"));
+    base.with_file_name(name)
+}
+
+static WRITER: OnceLock<Mutex<RollingWriter>> = OnceLock::new();
+
+/// Active log directory for the given runtime/config:
+/// `product_app_data_dir(config, runtime)/logs`.
+pub fn logs_dir(config: Option<&AppConfig>, runtime: ProductRuntime) -> PathBuf {
+    product_app_data_dir(config, runtime).join("logs")
+}
+
+/// Initialize the persistent file logger. Idempotent: only the first call per
+/// process actually opens the writer; later calls just re-tune the live level.
+///
+/// CLI/Skill must NOT call this — they keep no file logger and never touch
+/// stdout from here.
+pub fn init_logging(config: &AppConfig, runtime: ProductRuntime) {
+    set_min_level_from_config(&config.logging);
+    let path = logs_dir(Some(config), runtime).join(LOG_FILE_NAME);
+    let _ = WRITER.get_or_init(|| Mutex::new(RollingWriter::open(path)));
+}
+
+/// Re-tune the live persistence level after a config change (e.g. the user
+/// toggled the verbose switch). Safe to call even if logging was never
+/// initialized.
+pub fn apply_logging_config(config: &LoggingConfig) {
+    set_min_level_from_config(config);
+}
+
+/// Persist one structured event. `data` is sanitized through the shared
+/// [`redact_event_payload`] layer before it is written, so secrets never reach
+/// disk. No-op when logging was not initialized (CLI) or when `level` is below
+/// the active threshold.
+pub fn log_event(level: LogLevel, kind: &str, type_name: &str, data: Value) {
+    if (level as u8) < min_level() {
+        return;
+    }
+    let Some(writer) = WRITER.get() else {
+        return;
+    };
+    let record = json!({
+        "ts": Utc::now().to_rfc3339(),
+        "level": level.as_str(),
+        "kind": kind,
+        "type": type_name,
+        "data": redact_event_payload(&data),
+    });
+    let line = match serde_json::to_string(&record) {
+        Ok(line) => line,
+        Err(_) => return,
+    };
+    match writer.lock() {
+        Ok(mut writer) => writer.write_line(&line),
+        Err(_) => {
+            // Poisoned lock: keep stdout clean, surface a single stderr breadcrumb.
+            eprintln!("gpt-image-2 logging: writer mutex poisoned");
+        }
+    }
+}
+
+/// Read up to `limit` of the most recent log records, newest last, filtered to
+/// `>= min_level`. Reads from the live file plus rolled backups so the panel
+/// can show history across a rollover. Lines that fail to parse are skipped.
+pub fn read_recent_logs(
+    config: Option<&AppConfig>,
+    runtime: ProductRuntime,
+    limit: usize,
+    min_level: LogLevel,
+) -> Vec<Value> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let base = logs_dir(config, runtime).join(LOG_FILE_NAME);
+    // Read newest file first; within a file we still want chronological order,
+    // so collect per-file then prepend older files.
+    let mut collected: Vec<Value> = Vec::new();
+    // Iterate live file, then .1, .2, ... until we have enough.
+    let mut sources: Vec<PathBuf> = vec![base.clone()];
+    for index in 1..=MAX_BACKUPS {
+        sources.push(backup_path(&base, index));
+    }
+    'outer: for source in sources {
+        let lines = match read_file_lines(&source) {
+            Some(lines) => lines,
+            None => continue,
+        };
+        // Walk this file newest-to-oldest so we can stop early once full.
+        let mut file_records: Vec<Value> = Vec::new();
+        for line in lines.iter().rev() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+                continue;
+            };
+            if !record_passes_level(&value, min_level) {
+                continue;
+            }
+            file_records.push(value);
+            if collected.len() + file_records.len() >= limit {
+                break;
+            }
+        }
+        // file_records is newest-first; flip to oldest-first then prepend.
+        file_records.reverse();
+        let mut merged = file_records;
+        merged.append(&mut collected);
+        collected = merged;
+        if collected.len() >= limit {
+            break 'outer;
+        }
+    }
+    if collected.len() > limit {
+        let start = collected.len() - limit;
+        collected.drain(0..start);
+    }
+    collected
+}
+
+fn read_file_lines(path: &Path) -> Option<Vec<String>> {
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+    let lines = reader.lines().map_while(Result::ok).collect::<Vec<_>>();
+    Some(lines)
+}
+
+fn record_passes_level(record: &Value, min_level: LogLevel) -> bool {
+    let level = record
+        .get("level")
+        .and_then(Value::as_str)
+        .and_then(LogLevel::parse)
+        .unwrap_or(LogLevel::Info);
+    level >= min_level
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    // Serialize tests that mutate the shared MIN_LEVEL / env so they don't
+    // race each other.
+    static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    fn unique_tmp_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("gpt-image-2-logging-{tag}-{nanos}"));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_record(writer: &Mutex<RollingWriter>, level: LogLevel, type_name: &str, data: Value) {
+        let record = json!({
+            "ts": Utc::now().to_rfc3339(),
+            "level": level.as_str(),
+            "kind": "local",
+            "type": type_name,
+            "data": redact_event_payload(&data),
+        });
+        let line = serde_json::to_string(&record).unwrap();
+        writer.lock().unwrap().write_line(&line);
+    }
+
+    #[test]
+    fn rolling_writer_caps_backups_and_drops_oldest() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let dir = unique_tmp_dir("roll");
+        let base = dir.join(LOG_FILE_NAME);
+        let writer = Mutex::new(RollingWriter::open(base.clone()));
+        // ~2KB per line; force many rollovers well past MAX_BACKUPS files.
+        let big = "x".repeat(2048);
+        for i in 0..((MAX_FILE_BYTES / 2048) as usize * (MAX_BACKUPS + 3)) {
+            write_record(
+                &writer,
+                LogLevel::Info,
+                "bulk",
+                json!({ "i": i, "pad": big }),
+            );
+        }
+        // Live file exists.
+        assert!(base.exists(), "live log file must exist");
+        // At most MAX_BACKUPS rolled files; none beyond the cap.
+        for index in 1..=MAX_BACKUPS {
+            // Existence is allowed but not required for every slot; the cap is
+            // the hard invariant.
+            let _ = backup_path(&base, index);
+        }
+        assert!(
+            !backup_path(&base, MAX_BACKUPS + 1).exists(),
+            "no backup beyond MAX_BACKUPS may exist"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn redacts_secrets_before_persisting() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let dir = unique_tmp_dir("redact");
+        let base = dir.join(LOG_FILE_NAME);
+        let writer = Mutex::new(RollingWriter::open(base.clone()));
+        write_record(
+            &writer,
+            LogLevel::Error,
+            "job.failed",
+            json!({
+                "api_key": "sk-super-secret-value",
+                "authorization": "Bearer tok_live_should_not_persist",
+                "nested": { "access_token": "refresh-me-not" },
+                "message": "boom",
+            }),
+        );
+        let contents = fs::read_to_string(&base).unwrap();
+        assert!(
+            !contents.contains("sk-super-secret-value"),
+            "api_key value must be redacted"
+        );
+        assert!(
+            !contents.contains("tok_live_should_not_persist"),
+            "authorization value must be redacted"
+        );
+        assert!(
+            !contents.contains("refresh-me-not"),
+            "nested access_token must be redacted"
+        );
+        assert!(contents.contains("\"_omitted\":\"secret\""));
+        assert!(contents.contains("boom"), "non-secret fields are preserved");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn readback_filters_by_level_and_orders_oldest_to_newest() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let dir = unique_tmp_dir("readback");
+        let base = dir.join(LOG_FILE_NAME);
+        let writer = Mutex::new(RollingWriter::open(base.clone()));
+        write_record(&writer, LogLevel::Debug, "first", json!({ "n": 1 }));
+        write_record(&writer, LogLevel::Info, "second", json!({ "n": 2 }));
+        write_record(&writer, LogLevel::Warn, "third", json!({ "n": 3 }));
+        write_record(&writer, LogLevel::Error, "fourth", json!({ "n": 4 }));
+
+        // Filter to >= warn: only third + fourth, in chronological order.
+        let records = read_recent_logs_from(&base, 100, LogLevel::Warn);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["type"], "third");
+        assert_eq!(records[1]["type"], "fourth");
+
+        // Limit keeps the newest N.
+        let latest = read_recent_logs_from(&base, 1, LogLevel::Debug);
+        assert_eq!(latest.len(), 1);
+        assert_eq!(latest[0]["type"], "fourth");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    // Test helper mirroring read_recent_logs against an explicit base path so
+    // we don't depend on product_app_data_dir in unit tests.
+    fn read_recent_logs_from(base: &Path, limit: usize, min_level: LogLevel) -> Vec<Value> {
+        let mut collected: Vec<Value> = Vec::new();
+        let mut sources: Vec<PathBuf> = vec![base.to_path_buf()];
+        for index in 1..=MAX_BACKUPS {
+            sources.push(backup_path(base, index));
+        }
+        for source in sources {
+            let Some(lines) = read_file_lines(&source) else {
+                continue;
+            };
+            let mut file_records: Vec<Value> = Vec::new();
+            for line in lines.iter().rev() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let Ok(value) = serde_json::from_str::<Value>(trimmed) else {
+                    continue;
+                };
+                if !record_passes_level(&value, min_level) {
+                    continue;
+                }
+                file_records.push(value);
+                if collected.len() + file_records.len() >= limit {
+                    break;
+                }
+            }
+            file_records.reverse();
+            let mut merged = file_records;
+            merged.append(&mut collected);
+            collected = merged;
+            if collected.len() >= limit {
+                break;
+            }
+        }
+        if collected.len() > limit {
+            let start = collected.len() - limit;
+            collected.drain(0..start);
+        }
+        collected
+    }
+
+    #[test]
+    fn public_read_recent_logs_resolves_via_product_data_dir() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let dir = unique_tmp_dir("public-readback");
+        let base = logs_dir(None, ProductRuntime::DockerWeb);
+        // Point the DockerWeb data dir at our temp dir, then write some lines
+        // straight into the resolved logs file and read them back through the
+        // public API to prove the path resolution is wired up.
+        let prev = std::env::var_os("GPT_IMAGE_2_DATA_DIR");
+        unsafe {
+            std::env::set_var("GPT_IMAGE_2_DATA_DIR", &dir);
+        }
+        let resolved = logs_dir(None, ProductRuntime::DockerWeb).join(LOG_FILE_NAME);
+        assert_ne!(resolved, base.join(LOG_FILE_NAME));
+        let writer = Mutex::new(RollingWriter::open(resolved.clone()));
+        write_record(&writer, LogLevel::Info, "alpha", json!({ "n": 1 }));
+        write_record(&writer, LogLevel::Error, "omega", json!({ "n": 2 }));
+        drop(writer);
+
+        let all = read_recent_logs(None, ProductRuntime::DockerWeb, 100, LogLevel::Debug);
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0]["type"], "alpha");
+        assert_eq!(all[1]["type"], "omega");
+        let errors_only = read_recent_logs(None, ProductRuntime::DockerWeb, 100, LogLevel::Error);
+        assert_eq!(errors_only.len(), 1);
+        assert_eq!(errors_only[0]["type"], "omega");
+
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GPT_IMAGE_2_DATA_DIR", value),
+                None => std::env::remove_var("GPT_IMAGE_2_DATA_DIR"),
+            }
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn init_logging_is_idempotent() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        // First init wins; a second init with a different dir must not panic
+        // or repoint the writer (OnceLock guarantees single init).
+        let dir = unique_tmp_dir("init-once");
+        let mut config = AppConfig::default();
+        config.logging.debug = false;
+        // Point product data dir via the DockerWeb env override so we don't
+        // touch the user's real data dir.
+        let prev = std::env::var_os("GPT_IMAGE_2_DATA_DIR");
+        unsafe {
+            std::env::set_var("GPT_IMAGE_2_DATA_DIR", &dir);
+        }
+        init_logging(&config, ProductRuntime::DockerWeb);
+        assert_eq!(min_level(), LogLevel::Info as u8);
+        // Toggling debug re-tunes the level even though the writer is fixed.
+        config.logging.debug = true;
+        init_logging(&config, ProductRuntime::DockerWeb);
+        assert_eq!(min_level(), LogLevel::Debug as u8);
+        // restore
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var("GPT_IMAGE_2_DATA_DIR", value),
+                None => std::env::remove_var("GPT_IMAGE_2_DATA_DIR"),
+            }
+        }
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/gpt-image-2-core/src/logging.rs
+++ b/crates/gpt-image-2-core/src/logging.rs
@@ -180,15 +180,23 @@ pub fn logs_dir(config: Option<&AppConfig>, runtime: ProductRuntime) -> PathBuf 
     product_app_data_dir(config, runtime).join("logs")
 }
 
-/// Initialize the persistent file logger. Idempotent: only the first call per
-/// process actually opens the writer; later calls just re-tune the live level.
+/// Initialize the persistent file logger and re-tune the live level. The writer
+/// is created once per process, but if a later call resolves to a different
+/// directory (e.g. the user changed the app data dir in Settings) the live
+/// writer is repointed there so `get_logs`/`open_logs_dir` and the writer never
+/// drift apart.
 ///
 /// CLI/Skill must NOT call this — they keep no file logger and never touch
 /// stdout from here.
 pub fn init_logging(config: &AppConfig, runtime: ProductRuntime) {
     set_min_level_from_config(&config.logging);
     let path = logs_dir(Some(config), runtime).join(LOG_FILE_NAME);
-    let _ = WRITER.get_or_init(|| Mutex::new(RollingWriter::open(path)));
+    let writer = WRITER.get_or_init(|| Mutex::new(RollingWriter::open(path.clone())));
+    if let Ok(mut writer) = writer.lock()
+        && writer.path != path
+    {
+        *writer = RollingWriter::open(path);
+    }
 }
 
 /// Re-tune the live persistence level after a config change (e.g. the user

--- a/crates/gpt-image-2-core/src/logging.rs
+++ b/crates/gpt-image-2-core/src/logging.rs
@@ -480,67 +480,64 @@ mod tests {
 
     #[test]
     fn public_read_recent_logs_resolves_via_product_data_dir() {
-        let _guard = TEST_LOCK.lock().unwrap();
         let dir = unique_tmp_dir("public-readback");
-        let base = logs_dir(None, ProductRuntime::DockerWeb);
-        // Point the DockerWeb data dir at our temp dir, then write some lines
-        // straight into the resolved logs file and read them back through the
-        // public API to prove the path resolution is wired up.
-        let prev = std::env::var_os("GPT_IMAGE_2_DATA_DIR");
-        unsafe {
-            std::env::set_var("GPT_IMAGE_2_DATA_DIR", &dir);
-        }
-        let resolved = logs_dir(None, ProductRuntime::DockerWeb).join(LOG_FILE_NAME);
-        assert_ne!(resolved, base.join(LOG_FILE_NAME));
+        // Point the app data dir at our temp dir via config (NOT the process
+        // environment, which would race parallel path tests like
+        // `product_paths_default_by_runtime`), then write lines into the
+        // resolved logs file and read them back through the public API to prove
+        // path resolution is wired up.
+        let mut config = AppConfig::default();
+        config.paths.app_data_dir = PathRef {
+            mode: PathMode::Custom,
+            path: Some(dir.clone()),
+        };
+        let resolved = logs_dir(Some(&config), ProductRuntime::DockerWeb).join(LOG_FILE_NAME);
+        assert!(resolved.starts_with(&dir));
         let writer = Mutex::new(RollingWriter::open(resolved.clone()));
         write_record(&writer, LogLevel::Info, "alpha", json!({ "n": 1 }));
         write_record(&writer, LogLevel::Error, "omega", json!({ "n": 2 }));
         drop(writer);
 
-        let all = read_recent_logs(None, ProductRuntime::DockerWeb, 100, LogLevel::Debug);
+        let all = read_recent_logs(
+            Some(&config),
+            ProductRuntime::DockerWeb,
+            100,
+            LogLevel::Debug,
+        );
         assert_eq!(all.len(), 2);
         assert_eq!(all[0]["type"], "alpha");
         assert_eq!(all[1]["type"], "omega");
-        let errors_only = read_recent_logs(None, ProductRuntime::DockerWeb, 100, LogLevel::Error);
+        let errors_only = read_recent_logs(
+            Some(&config),
+            ProductRuntime::DockerWeb,
+            100,
+            LogLevel::Error,
+        );
         assert_eq!(errors_only.len(), 1);
         assert_eq!(errors_only[0]["type"], "omega");
 
-        unsafe {
-            match prev {
-                Some(value) => std::env::set_var("GPT_IMAGE_2_DATA_DIR", value),
-                None => std::env::remove_var("GPT_IMAGE_2_DATA_DIR"),
-            }
-        }
         let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn init_logging_is_idempotent() {
         let _guard = TEST_LOCK.lock().unwrap();
-        // First init wins; a second init with a different dir must not panic
-        // or repoint the writer (OnceLock guarantees single init).
+        // Re-initializing with the same dir does not error and re-tunes the live
+        // level. Use a config-driven data dir (not the process env, which would
+        // race parallel path tests).
         let dir = unique_tmp_dir("init-once");
         let mut config = AppConfig::default();
+        config.paths.app_data_dir = PathRef {
+            mode: PathMode::Custom,
+            path: Some(dir.clone()),
+        };
         config.logging.debug = false;
-        // Point product data dir via the DockerWeb env override so we don't
-        // touch the user's real data dir.
-        let prev = std::env::var_os("GPT_IMAGE_2_DATA_DIR");
-        unsafe {
-            std::env::set_var("GPT_IMAGE_2_DATA_DIR", &dir);
-        }
         init_logging(&config, ProductRuntime::DockerWeb);
         assert_eq!(min_level(), LogLevel::Info as u8);
-        // Toggling debug re-tunes the level even though the writer is fixed.
+        // Toggling debug re-tunes the level on a subsequent init.
         config.logging.debug = true;
         init_logging(&config, ProductRuntime::DockerWeb);
         assert_eq!(min_level(), LogLevel::Debug as u8);
-        // restore
-        unsafe {
-            match prev {
-                Some(value) => std::env::set_var("GPT_IMAGE_2_DATA_DIR", value),
-                None => std::env::remove_var("GPT_IMAGE_2_DATA_DIR"),
-            }
-        }
         let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/gpt-image-2-web/src/config_api.rs
+++ b/crates/gpt-image-2-web/src/config_api.rs
@@ -81,6 +81,39 @@ pub(crate) async fn update_storage(Json(mut body): Json<StorageConfig>) -> ApiRe
     Ok(Json(config_for_ui(&config)))
 }
 
+pub(crate) async fn update_logging(Json(body): Json<LoggingConfig>) -> ApiResult {
+    let mut config = load_config().map_err(ApiError::internal)?;
+    config.logging = body;
+    save_config(&config).map_err(ApiError::internal)?;
+    // Re-tune the live persistence level so the verbose toggle takes effect
+    // without a restart.
+    apply_logging_config(&config.logging);
+    Ok(Json(config_for_ui(&config)))
+}
+
+#[derive(Deserialize)]
+pub(crate) struct LogsQuery {
+    #[serde(default)]
+    pub(crate) limit: Option<usize>,
+    #[serde(default)]
+    pub(crate) level: Option<String>,
+}
+
+pub(crate) async fn get_logs(Query(query): Query<LogsQuery>) -> ApiResult {
+    let config = load_config_or_default();
+    let limit = query.limit.unwrap_or(500).clamp(1, 5000);
+    let min_level = query
+        .level
+        .as_deref()
+        .and_then(LogLevel::parse)
+        .unwrap_or(LogLevel::Debug);
+    let entries = read_recent_logs(Some(&config), ProductRuntime::DockerWeb, limit, min_level);
+    Ok(Json(json!({
+        "entries": entries,
+        "logs_dir": logs_dir(Some(&config), ProductRuntime::DockerWeb).display().to_string(),
+    })))
+}
+
 #[derive(Deserialize)]
 pub(crate) struct StorageTestBody {
     #[serde(default)]

--- a/crates/gpt-image-2-web/src/config_api.rs
+++ b/crates/gpt-image-2-web/src/config_api.rs
@@ -64,6 +64,9 @@ pub(crate) async fn update_paths(Json(body): Json<PathConfig>) -> ApiResult {
     let mut config = load_config().map_err(ApiError::internal)?;
     config.paths = body;
     save_config(&config).map_err(ApiError::internal)?;
+    // The app data dir may have moved; repoint the logger so get_logs and the
+    // writer stay in sync without a restart.
+    gpt_image_2_core::init_logging(&config, ProductRuntime::DockerWeb);
     Ok(Json(config_for_ui(&config)))
 }
 

--- a/crates/gpt-image-2-web/src/error.rs
+++ b/crates/gpt-image-2-web/src/error.rs
@@ -7,49 +7,72 @@ pub(crate) type ApiResult<T = Value> = Result<Json<T>, ApiError>;
 #[derive(Debug)]
 pub(crate) struct ApiError {
     pub(crate) status: StatusCode,
+    pub(crate) code: Option<String>,
     pub(crate) message: String,
+    pub(crate) detail: Option<Value>,
 }
 
 impl ApiError {
     pub(crate) fn bad_request(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,
+            code: None,
             message: message.into(),
+            detail: None,
         }
     }
 
     pub(crate) fn internal(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: None,
             message: message.into(),
+            detail: None,
         }
     }
 
     pub(crate) fn not_found(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,
+            code: None,
             message: message.into(),
+            detail: None,
         }
     }
 
     pub(crate) fn forbidden(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::FORBIDDEN,
+            code: None,
             message: message.into(),
+            detail: None,
         }
+    }
+
+    /// Attach a structured `detail` (and optional `code`) lifted from a
+    /// JobError-shaped value, so the HTTP `error` envelope can carry the real
+    /// cause through to the front-end instead of just a flat message.
+    #[allow(dead_code)]
+    pub(crate) fn with_error_value(mut self, error: &Value) -> Self {
+        if let Some(code) = error.get("code").and_then(Value::as_str) {
+            self.code = Some(code.to_string());
+        }
+        if let Some(detail) = error.get("detail") {
+            self.detail = Some(detail.clone());
+        }
+        self
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (
-            self.status,
-            Json(json!({
-                "error": {
-                    "message": self.message,
-                }
-            })),
-        )
-            .into_response()
+        let mut error = json!({ "message": self.message });
+        if let (Value::Object(map), Some(code)) = (&mut error, self.code.as_ref()) {
+            map.insert("code".to_string(), json!(code));
+        }
+        if let (Value::Object(map), Some(detail)) = (&mut error, self.detail) {
+            map.insert("detail".to_string(), detail);
+        }
+        (self.status, Json(json!({ "error": error }))).into_response()
     }
 }

--- a/crates/gpt-image-2-web/src/job_execution/batch_payloads.rs
+++ b/crates/gpt-image-2-web/src/job_execution/batch_payloads.rs
@@ -80,10 +80,17 @@ pub(crate) fn batch_errors_json(errors: &[BatchItemError]) -> Value {
         errors
             .iter()
             .map(|error| {
-                json!({
+                let mut item = json!({
                     "index": error.index,
                     "message": error.message,
-                })
+                });
+                if let (Value::Object(map), Some(code)) = (&mut item, error.code.as_ref()) {
+                    map.insert("code".to_string(), json!(code));
+                }
+                if let (Value::Object(map), Some(detail)) = (&mut item, error.detail.as_ref()) {
+                    map.insert("detail".to_string(), detail.clone());
+                }
+                item
             })
             .collect(),
     )
@@ -244,7 +251,9 @@ mod tests {
             vec![(0, payload("/tmp/a.png")), (2, payload("/tmp/c.png"))],
             vec![BatchItemError {
                 index: 1,
+                code: None,
                 message: "upstream rejected candidate B".to_string(),
+                detail: None,
             }],
         );
 
@@ -273,11 +282,15 @@ mod tests {
             vec![
                 BatchItemError {
                     index: 0,
+                    code: None,
                     message: "candidate A failed".to_string(),
+                    detail: None,
                 },
                 BatchItemError {
                     index: 1,
+                    code: None,
                     message: "candidate B failed".to_string(),
+                    detail: None,
                 },
             ],
         );
@@ -295,5 +308,37 @@ mod tests {
         assert_eq!(job["status"], "failed");
         assert_eq!(terminal_event_type(job["status"].as_str()), "job.failed");
         assert!(!terminal_status_runs_storage_upload(job["status"].as_str()));
+    }
+
+    #[test]
+    fn batch_errors_json_preserves_code_and_detail_per_item() {
+        // P0 regression: per-slot batch errors must keep code/detail so
+        // `error.items[*]` carry the real cause, not just a flat message.
+        let errors = vec![
+            BatchItemError::from_error_value(
+                0,
+                json!({
+                    "code": "network_error",
+                    "message": "OpenAI request failed.",
+                    "detail": { "error": "connection refused" },
+                }),
+            ),
+            BatchItemError::from_error_value(2, json!({ "message": "plain failure" })),
+        ];
+
+        let items = batch_errors_json(&errors);
+        assert_eq!(items[0]["index"], 0);
+        assert_eq!(items[0]["code"], "network_error");
+        assert_eq!(items[0]["message"], "OpenAI request failed.");
+        assert_eq!(items[0]["detail"]["error"], "connection refused");
+        // An item without code/detail stays minimal (no null spam).
+        assert_eq!(items[1]["index"], 2);
+        assert_eq!(items[1]["message"], "plain failure");
+        assert!(items[1].get("code").is_none());
+        assert!(items[1].get("detail").is_none());
+
+        let merged = merge_batch_payloads("images generate", 3, vec![], errors);
+        assert_eq!(merged["error"]["items"][0]["detail"]["error"], "connection refused");
+        assert_eq!(merged["error"]["items"][0]["code"], "network_error");
     }
 }

--- a/crates/gpt-image-2-web/src/job_execution/batch_payloads.rs
+++ b/crates/gpt-image-2-web/src/job_execution/batch_payloads.rs
@@ -338,7 +338,10 @@ mod tests {
         assert!(items[1].get("detail").is_none());
 
         let merged = merge_batch_payloads("images generate", 3, vec![], errors);
-        assert_eq!(merged["error"]["items"][0]["detail"]["error"], "connection refused");
+        assert_eq!(
+            merged["error"]["items"][0]["detail"]["error"],
+            "connection refused"
+        );
         assert_eq!(merged["error"]["items"][0]["code"], "network_error");
     }
 }

--- a/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/edit_runner.rs
@@ -77,18 +77,21 @@ pub(crate) fn run_edit_request(
     fallback_id: String,
     dir: PathBuf,
     stream: Option<StreamContext>,
-) -> Result<Value, String> {
+) -> Result<Value, Value> {
     if request.prompt.trim().is_empty() {
-        return Err("Prompt is required.".to_string());
+        return Err(error_value_from_message("Prompt is required."));
     }
     if request.refs.is_empty() {
-        return Err("At least one reference image is required.".to_string());
+        return Err(error_value_from_message(
+            "At least one reference image is required.",
+        ));
     }
-    let output_count = requested_n(request.n)?;
+    let output_count = requested_n(request.n).map_err(error_value_from_message)?;
     if request.n.is_some() {
         request.n = Some(output_count);
     }
-    let (ref_paths, mask_path, edit_region_mode) = write_edit_inputs(&request, &dir)?;
+    let (ref_paths, mask_path, edit_region_mode) =
+        write_edit_inputs(&request, &dir).map_err(error_value_from_message)?;
     let provider_supports_n = provider_supports_n(request.provider.as_deref());
     let payload = if provider_supports_n || output_count == 1 {
         let out = dir.join(format!(
@@ -176,7 +179,7 @@ pub(crate) fn run_edit_request(
             failures,
             generation_slots,
         )
-        .map_err(app_error)?;
+        .map_err(|error| error_value_from_message(app_error(error)))?;
         merged
     };
     let request_meta = edit_request_metadata(&request);

--- a/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
+++ b/crates/gpt-image-2-web/src/job_execution/generate_runner.rs
@@ -7,11 +7,11 @@ pub(crate) fn run_generate_request(
     fallback_id: String,
     dir: PathBuf,
     stream: Option<StreamContext>,
-) -> Result<Value, String> {
+) -> Result<Value, Value> {
     if request.prompt.trim().is_empty() {
-        return Err("Prompt is required.".to_string());
+        return Err(error_value_from_message("Prompt is required."));
     }
-    let output_count = requested_n(request.n)?;
+    let output_count = requested_n(request.n).map_err(error_value_from_message)?;
     if request.n.is_some() {
         request.n = Some(output_count);
     }
@@ -90,7 +90,7 @@ pub(crate) fn run_generate_request(
             failures,
             generation_slots,
         )
-        .map_err(app_error)?;
+        .map_err(|error| error_value_from_message(app_error(error)))?;
         merged
     };
     let request_meta = serde_json::to_value(&request).unwrap_or_else(|_| json!({}));

--- a/crates/gpt-image-2-web/src/job_execution/streaming.rs
+++ b/crates/gpt-image-2-web/src/job_execution/streaming.rs
@@ -72,9 +72,7 @@ pub(crate) fn run_payloads_concurrently_streaming(
                 on_partial(index, &payload);
                 results[index] = Some(payload);
             }
-            Ok((index, Err(error))) => {
-                errors.push(BatchItemError::from_error_value(index, error))
-            }
+            Ok((index, Err(error))) => errors.push(BatchItemError::from_error_value(index, error)),
             Err(_) => break,
         }
         received += 1;

--- a/crates/gpt-image-2-web/src/job_execution/streaming.rs
+++ b/crates/gpt-image-2-web/src/job_execution/streaming.rs
@@ -15,7 +15,26 @@ pub(crate) struct StreamContext {
 #[derive(Debug, Clone)]
 pub(crate) struct BatchItemError {
     pub(crate) index: usize,
+    pub(crate) code: Option<String>,
     pub(crate) message: String,
+    pub(crate) detail: Option<Value>,
+}
+
+impl BatchItemError {
+    /// Build a structured per-slot error from a JobError-shaped `Value`
+    /// (`{ code, message, detail }`) as produced by `cli_json_result`, keeping
+    /// `code`/`detail` so the merged payload's `error.items[*]` stay rich.
+    pub(crate) fn from_error_value(index: usize, error: Value) -> Self {
+        Self {
+            index,
+            code: error
+                .get("code")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            message: error_message_from_value(&error),
+            detail: error.get("detail").cloned(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -35,7 +54,7 @@ pub(crate) fn run_payloads_concurrently_streaming(
             errors: Vec::new(),
         };
     }
-    let (tx, rx) = mpsc::channel::<(usize, Result<Value, String>)>();
+    let (tx, rx) = mpsc::channel::<(usize, Result<Value, Value>)>();
     for (index, args) in arg_sets.into_iter().enumerate() {
         let tx = tx.clone();
         thread::spawn(move || {
@@ -53,10 +72,9 @@ pub(crate) fn run_payloads_concurrently_streaming(
                 on_partial(index, &payload);
                 results[index] = Some(payload);
             }
-            Ok((index, Err(error))) => errors.push(BatchItemError {
-                index,
-                message: error,
-            }),
+            Ok((index, Err(error))) => {
+                errors.push(BatchItemError::from_error_value(index, error))
+            }
             Err(_) => break,
         }
         received += 1;

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -17,20 +17,21 @@ use axum::{
 };
 use gpt_image_2_core::{
     AppConfig, CONFIG_DIR_NAME, CredentialRef, EditRequest, GenerateRequest, HistoryListOptions,
-    KEYCHAIN_SERVICE, NotificationConfig, PathConfig, ProductRuntime, ProviderConfig,
-    StorageConfig, StorageReadbackOptions, StorageTargetConfig, StorageUploadOverrides, UploadFile,
-    annotate_recovery_job_dir, append_history_job_event, batch_output_path, batch_recovery_job_dir,
-    batch_recovery_job_id, build_recovery_descriptor, default_config_path,
-    default_keychain_account, delete_history_job, dispatch_task_notifications,
-    edit_args_with_recovery, generate_args_with_recovery, generation_slots_from_batch_payload,
-    generation_slots_from_outputs, history_db_path, initialize_product_runtime_paths,
-    legacy_jobs_dir, legacy_shared_codex_dir, list_active_history_jobs, list_history_job_events,
-    list_history_jobs_page, load_app_config, mark_interrupted_jobs_on_startup,
-    materialize_openai_raw_response, merge_recovery_metadata, missing_generation_slot_indices,
-    notification_status_allowed, output_extension, preserve_notification_secrets,
-    preserve_storage_secrets, product_app_data_dir, product_default_export_dir,
-    product_default_export_dirs, product_result_library_dir, product_storage_fallback_dir,
-    raw_response_path, read_job_output_from_storage_with_options, read_keychain_secret,
+    KEYCHAIN_SERVICE, LogLevel, LoggingConfig, NotificationConfig, PathConfig, ProductRuntime,
+    ProviderConfig, StorageConfig, StorageReadbackOptions, StorageTargetConfig,
+    StorageUploadOverrides, UploadFile, annotate_recovery_job_dir, append_history_job_event,
+    apply_logging_config, batch_output_path, batch_recovery_job_dir, batch_recovery_job_id,
+    build_recovery_descriptor, default_config_path, default_keychain_account, delete_history_job,
+    dispatch_task_notifications, edit_args_with_recovery, generate_args_with_recovery,
+    generation_slots_from_batch_payload, generation_slots_from_outputs, history_db_path,
+    init_logging, initialize_product_runtime_paths, legacy_jobs_dir, legacy_shared_codex_dir,
+    list_active_history_jobs, list_history_job_events, list_history_jobs_page, load_app_config,
+    log_event, logs_dir, mark_interrupted_jobs_on_startup, materialize_openai_raw_response,
+    merge_recovery_metadata, missing_generation_slot_indices, notification_status_allowed,
+    output_extension, preserve_notification_secrets, preserve_storage_secrets,
+    product_app_data_dir, product_default_export_dir, product_default_export_dirs,
+    product_result_library_dir, product_storage_fallback_dir, raw_response_path,
+    read_job_output_from_storage_with_options, read_keychain_secret, read_recent_logs,
     recovery_job_dir, redact_app_config, requested_n, run_json, save_app_config, shared_config_dir,
     show_history_job, test_fault, test_storage_target, upload_job_outputs_to_storage,
     upsert_history_job, write_batch_recovery_summary, write_keychain_secret,
@@ -70,6 +71,13 @@ pub(crate) use types::*;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = initialize_product_runtime_paths(ProductRuntime::DockerWeb);
+    init_logging(&load_config_or_default(), ProductRuntime::DockerWeb);
+    log_event(
+        LogLevel::Info,
+        "local",
+        "app.started",
+        json!({ "runtime": "web", "version": env!("CARGO_PKG_VERSION") }),
+    );
     let settings = parse_settings().map_err(std::io::Error::other)?;
     if !settings.static_dir.is_dir() {
         return Err(format!(

--- a/crates/gpt-image-2-web/src/queue_workers.rs
+++ b/crates/gpt-image-2-web/src/queue_workers.rs
@@ -144,17 +144,27 @@ pub(crate) fn finish_queued_job(
                 let uploading_job = uploading_job_for_queue(&queued, &response);
                 let _ = persist_job(&uploading_job);
             }
-            log_event(
-                LogLevel::Info,
-                "local",
-                "job.completed",
-                json!({
-                    "job_id": queued.id,
-                    "command": queued.command,
-                    "provider": queued.provider,
-                    "status": status.unwrap_or("completed"),
-                }),
-            );
+            // An Ok payload can still carry a terminal failure status (e.g.
+            // batch partial_failed), so classify the log from the terminal
+            // event type and include the cause when it failed.
+            let (log_level, log_type) = match event_type {
+                "job.failed" => (LogLevel::Error, "job.failed"),
+                "job.partial_failed" => (LogLevel::Warn, "job.partial_failed"),
+                "job.cancelled" => (LogLevel::Info, "job.cancelled"),
+                _ => (LogLevel::Info, "job.completed"),
+            };
+            let mut log_data = json!({
+                "job_id": queued.id,
+                "command": queued.command,
+                "provider": queued.provider,
+                "status": status.unwrap_or("completed"),
+            });
+            if matches!(event_type, "job.failed" | "job.partial_failed")
+                && let Some(error) = job.get("error").filter(|value| !value.is_null())
+            {
+                log_data["error"] = error.clone();
+            }
+            log_event(log_level, "local", log_type, log_data);
             (job, event_type, data, completed)
         }
         Err(error) => {

--- a/crates/gpt-image-2-web/src/queue_workers.rs
+++ b/crates/gpt-image-2-web/src/queue_workers.rs
@@ -144,9 +144,33 @@ pub(crate) fn finish_queued_job(
                 let uploading_job = uploading_job_for_queue(&queued, &response);
                 let _ = persist_job(&uploading_job);
             }
+            log_event(
+                LogLevel::Info,
+                "local",
+                "job.completed",
+                json!({
+                    "job_id": queued.id,
+                    "command": queued.command,
+                    "provider": queued.provider,
+                    "status": status.unwrap_or("completed"),
+                }),
+            );
             (job, event_type, data, completed)
         }
         Err(error) => {
+            // P0 hands us a structured JobError (code/message/detail); persist
+            // the same value so the logs panel can surface the real cause.
+            log_event(
+                LogLevel::Error,
+                "local",
+                "job.failed",
+                json!({
+                    "job_id": queued.id,
+                    "command": queued.command,
+                    "provider": queued.provider,
+                    "error": error,
+                }),
+            );
             let job = failed_job_for_queue(&queued, error.clone());
             (
                 job,
@@ -310,6 +334,16 @@ pub(crate) fn start_queued_jobs(state: JobQueueState) {
             (queued, running_job)
         };
         let _ = persist_job(&running_job);
+        log_event(
+            LogLevel::Info,
+            "local",
+            "job.started",
+            json!({
+                "job_id": queued.id,
+                "command": queued.command,
+                "provider": queued.provider,
+            }),
+        );
         let worker_state = state.clone();
         thread::spawn(move || {
             let stream = StreamContext {

--- a/crates/gpt-image-2-web/src/queue_workers.rs
+++ b/crates/gpt-image-2-web/src/queue_workers.rs
@@ -81,10 +81,10 @@ pub(crate) fn uploading_job_for_queue(queued: &QueuedJob, response: &Value) -> V
     })
 }
 
-pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value {
+pub(crate) fn failed_job_for_queue(queued: &QueuedJob, error: Value) -> Value {
     let mut metadata = merge_recovery_metadata(queued.metadata.clone(), &queued.dir);
     if let Value::Object(map) = &mut metadata {
-        map.insert("error".to_string(), json!({"message": message.clone()}));
+        map.insert("error".to_string(), error.clone());
     }
     job_snapshot(JobSnapshotInput {
         id: &queued.id,
@@ -95,7 +95,7 @@ pub(crate) fn failed_job_for_queue(queued: &QueuedJob, message: String) -> Value
         metadata,
         output_path: None,
         outputs: json!([]),
-        error: json!({"message": message}),
+        error,
     })
 }
 
@@ -129,7 +129,7 @@ pub(crate) fn append_terminal_queue_event(
 pub(crate) fn finish_queued_job(
     state: JobQueueState,
     queued: QueuedJob,
-    result: Result<Value, String>,
+    result: Result<Value, Value>,
 ) {
     let (job, event_type, event_data, completed) = match result {
         Ok(response) => {
@@ -146,14 +146,14 @@ pub(crate) fn finish_queued_job(
             }
             (job, event_type, data, completed)
         }
-        Err(message) => {
-            let job = failed_job_for_queue(&queued, message.clone());
+        Err(error) => {
+            let job = failed_job_for_queue(&queued, error.clone());
             (
                 job,
                 "job.failed",
                 json!({
                     "status": "failed",
-                    "error": {"message": message},
+                    "error": error,
                 }),
                 false,
             )
@@ -455,6 +455,29 @@ mod tests {
                 fallback_targets: None,
             }),
         }
+    }
+
+    #[test]
+    fn failed_job_for_queue_preserves_structured_error_with_detail() {
+        // P0 regression: a single-output provider failure must keep the full
+        // JobError (code/message/detail) on both `job.error` and
+        // `metadata.error` instead of being flattened to `{ message }`.
+        let queued = queued_job("job-network-failure");
+        let error = json!({
+            "code": "network_error",
+            "message": "OpenAI request failed.",
+            "detail": { "error": "error sending request: connection refused" },
+        });
+        let job = failed_job_for_queue(&queued, error.clone());
+
+        assert_eq!(job["status"], "failed");
+        assert_eq!(job["error"], error);
+        assert_eq!(job["error"]["code"], "network_error");
+        assert_eq!(
+            job["error"]["detail"]["error"],
+            "error sending request: connection refused"
+        );
+        assert_eq!(job["metadata"]["error"], error);
     }
 
     #[test]

--- a/crates/gpt-image-2-web/src/recovery_api.rs
+++ b/crates/gpt-image-2-web/src/recovery_api.rs
@@ -258,9 +258,7 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(error) => {
-                        errors.push(BatchItemError::from_error_value(*index, error))
-                    }
+                    Err(error) => errors.push(BatchItemError::from_error_value(*index, error)),
                 }
             }
         }
@@ -297,9 +295,7 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(error) => {
-                        errors.push(BatchItemError::from_error_value(*index, error))
-                    }
+                    Err(error) => errors.push(BatchItemError::from_error_value(*index, error)),
                 }
             }
         }

--- a/crates/gpt-image-2-web/src/recovery_api.rs
+++ b/crates/gpt-image-2-web/src/recovery_api.rs
@@ -244,10 +244,10 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
-                        Err(message) => errors.push(BatchItemError {
-                            index: *index,
-                            message,
-                        }),
+                        Err(message) => errors.push(BatchItemError::from_error_value(
+                            *index,
+                            error_value_from_message(message),
+                        )),
                     }
                     continue;
                 }
@@ -258,10 +258,9 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(message) => errors.push(BatchItemError {
-                        index: *index,
-                        message,
-                    }),
+                    Err(error) => {
+                        errors.push(BatchItemError::from_error_value(*index, error))
+                    }
                 }
             }
         }
@@ -278,10 +277,10 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                 if let Some(cached) = materialize_cached_slot_payload(&child_dir, &out) {
                     match cached {
                         Ok(payload) => payloads.push((*index, payload)),
-                        Err(message) => errors.push(BatchItemError {
-                            index: *index,
-                            message,
-                        }),
+                        Err(message) => errors.push(BatchItemError::from_error_value(
+                            *index,
+                            error_value_from_message(message),
+                        )),
                     }
                     continue;
                 }
@@ -298,10 +297,9 @@ fn fill_missing_job(job_id: &str) -> Result<Value, String> {
                     Some((child_id.as_str(), child_dir.as_path())),
                 )) {
                     Ok(payload) => payloads.push((*index, payload)),
-                    Err(message) => errors.push(BatchItemError {
-                        index: *index,
-                        message,
-                    }),
+                    Err(error) => {
+                        errors.push(BatchItemError::from_error_value(*index, error))
+                    }
                 }
             }
         }

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -79,6 +79,8 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
             get(notification_capabilities),
         )
         .route("/paths", put(update_paths))
+        .route("/logging", put(update_logging))
+        .route("/logs", get(get_logs))
         .route("/storage", put(update_storage))
         .route("/storage/{name}/test", post(test_storage))
         .route("/providers/default", post(set_default_provider))

--- a/crates/gpt-image-2-web/src/support.rs
+++ b/crates/gpt-image-2-web/src/support.rs
@@ -216,7 +216,28 @@ pub(crate) fn cli_json(args: &[String]) -> Value {
     run_json(&argv).payload
 }
 
-pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, String> {
+/// Wrap a bare error string into a JobError-shaped object (`{ "message": ... }`)
+/// so internal validation/IO errors flow through the same `Value` channel as the
+/// structured payload errors produced by the core. Keeps `detail` optional.
+pub(crate) fn error_value_from_message(message: impl Into<String>) -> Value {
+    json!({ "message": message.into() })
+}
+
+/// Best-effort human-readable message from a JobError-shaped value, used where a
+/// flat string is still required (e.g. logging, summaries).
+pub(crate) fn error_message_from_value(error: &Value) -> String {
+    error
+        .get("message")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "Command failed".to_string())
+}
+
+/// Run the CLI and, on failure, preserve the entire `error` object from the
+/// payload (already redacted by core's `build_error_payload`) instead of
+/// flattening it to `error.message`. The Err value is JobError-shaped
+/// (`{ code, message, detail }`).
+pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, Value> {
     let mut argv = vec!["gpt-image-2-skill".to_string(), "--json".to_string()];
     argv.extend(args.iter().cloned());
     let outcome = run_json(&argv);
@@ -226,10 +247,8 @@ pub(crate) fn cli_json_result(args: &[String]) -> Result<Value, String> {
         Err(outcome
             .payload
             .get("error")
-            .and_then(|error| error.get("message"))
-            .and_then(Value::as_str)
-            .unwrap_or("Command failed")
-            .to_string())
+            .cloned()
+            .unwrap_or_else(|| error_value_from_message("Command failed")))
     }
 }
 


### PR DESCRIPTION
Closes #24.

## P0 — the "everything just says 'OpenAI request failed.'" bug (real bug, not a version issue)
Core already builds **and redacts** `error.detail` with the real cause, but the GUI/Web boundary flattened it to a bare message string and dropped `detail` at every hop. This threads a structured `JobError { code?, message, detail?, items? }` end-to-end instead of a `String`:
- `cli_json_result` (Tauri + web) returns the redacted error object verbatim — no re-wrap, no double-redaction.
- `failed_job_for_queue` writes it to `job.error` **and** `metadata.error`; terminal events carry it.
- `BatchItemError` / `batch_errors_json` carry per-item `code` + `detail` (`items[*]`).
- web `ApiError` gains a `detail` field; frontend `parseErrorResponse` keeps the structured object.
- Failed-job card renders `code` + `message` with a **collapsible, copyable** detail (and per-item details for batch).
- **CLI JSON output is untouched.**

## P1 — persistent diagnostics
- Self-contained **rolling JSONL** log under app-data `logs/` (5MB × 5 files), **init-once** per process.
- **Web/Tauri only** — the CLI never initializes it, so stdout stays byte-for-byte clean.
- Every record is **redacted** via the existing `redact_event_payload` (no keys/tokens/passwords on disk).
- Instruments the queue boundary (`app.started`, `job.started/completed/failed`), with the P0 structured error+detail on `job.failed`.
- `LoggingConfig{debug}` + `update_logging`, `get_logs` (recent, level-filtered), `open_logs_dir`; a Settings 「日志」 panel (filter / refresh / open-folder / export / verbose toggle).
- **No new dependencies.**

## Verification
- `cargo test --workspace`: all pass (core incl. 5 new logging tests + P0 regressions; web queue/batch).
- `tsc --noEmit` clean; browser tests 14/14.
- CLI stdout verified clean (no log lines mixed in); redaction verified end-to-end (seeded key never hits the log file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)