### PR TITLE
fix(ui): show error detail inline in the generation-queue card

### DIFF
--- a/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/job-row-expandable.tsx
@@ -29,6 +29,8 @@ import { JobKindIcon, JobReferenceBadge } from "./job-kind-icon";
 import { JobReferenceStrip } from "./job-reference-strip";
 import { StatusChip } from "./status-chip";
 import {
+  jobErrorCode,
+  jobErrorDetailOnly,
   jobErrorDetailText,
   jobErrorMessage,
   jobCanShowRecoveryAction,
@@ -102,6 +104,8 @@ export function JobRowExpandable({
   const metaItems = jobMetaItems(job);
   const refCount = jobReferenceCount(job);
   const errorMessage = jobErrorMessage(job);
+  const errorCode = jobErrorCode(job);
+  const errorDetailOnly = jobErrorDetailOnly(job);
   const errorDetail = jobErrorDetailText(job);
   const showPromptToggle = prompt.length > 240 || prompt.split("\n").length > 6;
   const primaryOutputIndex = outputIndexes[0] ?? 0;
@@ -348,14 +352,26 @@ export function JobRowExpandable({
                       <div className="flex items-start gap-2 text-[12.5px] text-status-err">
                         <AlertTriangle size={14} className="mt-0.5 shrink-0" />
                         <div className="min-w-0">
-                          <div className="font-medium">
-                            {status === "partial_failed"
-                              ? "部分图片生成失败"
-                              : "任务失败"}
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">
+                              {status === "partial_failed"
+                                ? "部分图片生成失败"
+                                : "任务失败"}
+                            </span>
+                            {errorCode && (
+                              <span className="t-mono rounded bg-status-err/10 px-1.5 py-0.5 text-[10px]">
+                                {errorCode}
+                              </span>
+                            )}
                           </div>
                           <div className="mt-1 whitespace-pre-wrap break-words text-[12px] text-muted">
                             {errorMessage}
                           </div>
+                          {errorDetailOnly && (
+                            <pre className="mt-1.5 mb-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-status-err/5 p-2 font-mono text-[11px] leading-[1.45] text-muted">
+                              {errorDetailOnly}
+                            </pre>
+                          )}
                         </div>
                       </div>
                       {errorDetail && (

--- a/apps/gpt-image-2-app/src/components/screens/history/shared.ts
+++ b/apps/gpt-image-2-app/src/components/screens/history/shared.ts
@@ -387,6 +387,26 @@ export function jobErrorDetailText(job: Job): string {
   }
 }
 
+export function jobErrorCode(job: Job): string {
+  const error = job.error;
+  if (!error || typeof error !== "object") return "";
+  return typeof error.code === "string" ? error.code : "";
+}
+
+/** Just the structured `detail` (the real cause), formatted for inline display.
+ * Empty when there is no detail. Separate from {@link jobErrorDetailText},
+ * which serializes the whole error object for the copy-to-clipboard payload. */
+export function jobErrorDetailOnly(job: Job): string {
+  const error = job.error;
+  if (!error || typeof error !== "object" || error.detail == null) return "";
+  if (typeof error.detail === "string") return error.detail;
+  try {
+    return JSON.stringify(error.detail, null, 2);
+  } catch {
+    return String(error.detail);
+  }
+}
+
 export function jobMetaItems(job: Job): string[] {
   const md = (job.metadata ?? {}) as Record<string, unknown>;
   const items = [job.provider || "auto"];


### PR DESCRIPTION
Follow-up to the #24 P0 fix.

P0 surfaced the structured error (`code`/`message`/`detail`) in the History job drawer (`JobDrawerError`), but the **generation-queue card** (`job-row-expandable.tsx`) still rendered only the generic `message` (e.g. "OpenAI request failed.") plus a 「复制完整错误」 button — so in the queue the real cause was only reachable via copy-to-clipboard, exactly the symptom users hit.

This renders the error **code badge + the `detail` (the real cause) inline** in the queue card, mirroring `JobDrawerError`, while keeping the copy button. Backend P0 persistence is unchanged and already correct (`failed_job_for_queue` writes `{code,message,detail}` to both `job.error` and `metadata.error`).

- New helpers `jobErrorCode` / `jobErrorDetailOnly` in `history/shared.ts`.
- `tsc --noEmit` clean; browser tests 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)