### PR TITLE
fix(release): guard release-tauri against racing the cargo-dist release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ Rust workspace（`crates/*`）+ Tauri / Web 前端（`apps/gpt-image-2-app`）+ 
 1. `just release patch`（或 `minor` / `major`）—— cargo-dist 流程：bump 版本、发布 crates.io、创建 GitHub Release、上传 CLI 安装包。tag push 后自动触发 "Release" workflow。
 2. `just release-tauri v<新版本>` —— 手动触发 "Tauri App Release"（`workflow_dispatch`）：构建桌面 app 安装包，并**生成、上传 `latest.json`**（tauri updater manifest）。**不会随 tag 自动触发，必须手动跑。**
 
+   ⚠️ **顺序铁律**：第二步必须等第一步的 "Release" workflow 把 GitHub Release 建好之后再跑。两个流程都会创建同一个 `v<版本>` Release，但 cargo-dist 的 `gh release create` **不幂等**、Tauri 的 `create-release` **幂等**——若第二步抢跑，Tauri 会先把 Release 建出来，导致 cargo-dist 在 "Create GitHub Release" 撞 `already exists`，整个 "Release" workflow 失败（CLI 安装包、npm 触发一并丢失）。`just release-tauri` 已内置 `scripts/release/wait-for-release.sh`，会阻塞到 Release 存在再 dispatch；若手动 `gh workflow run`，务必自行确认 Release 已建好。
+
 Tauri updater 的端点是 `releases/latest/download/latest.json`（见 `apps/gpt-image-2-app/src-tauri/tauri.conf.json`）。漏掉第 2 步，最新 Release 里就没有 `latest.json`，已安装的 app 检查更新会报：
 
 > Could not fetch a valid release JSON from the remote

--- a/justfile
+++ b/justfile
@@ -96,7 +96,10 @@ release level="patch":
     scripts/release/publish.sh "{{ level }}" --execute
 
 # Build and publish desktop app installers for an existing release tag.
+# Waits until the cargo-dist Release exists first, so Tauri's idempotent
+# create-release never races cargo-dist's non-idempotent `gh release create`.
 release-tauri tag:
+    scripts/release/wait-for-release.sh "{{ tag }}"
     gh workflow run "Tauri App Release" -f release_tag="{{ tag }}" -f release_draft=false -f prerelease=false
 
 # Build and publish the Docker Web image to GHCR for an existing release tag.

--- a/scripts/release/wait-for-release.sh
+++ b/scripts/release/wait-for-release.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+require_cmd gh
+
+TAG="${1:-}"
+TIMEOUT="${2:-1200}"
+INTERVAL="${WAIT_RELEASE_INTERVAL:-15}"
+
+if [[ -z "$TAG" ]]; then
+  echo "usage: wait-for-release.sh <tag> [timeout_seconds]" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+# The cargo-dist "Release" workflow and the "Tauri App Release" workflow both
+# create the same GitHub Release. cargo-dist's `gh release create` is NOT
+# idempotent (it fails on an existing tag), while Tauri's create-release IS
+# (it exits 0 when the release already exists). So the only safe ordering is
+# cargo-dist first, Tauri second. This guard blocks until cargo-dist has
+# created the Release, so dispatching Tauri can never win the race.
+echo "waiting for GitHub Release $TAG to exist (timeout ${TIMEOUT}s, poll ${INTERVAL}s)…"
+
+elapsed=0
+while ! gh release view "$TAG" >/dev/null 2>&1; do
+  if (( elapsed >= TIMEOUT )); then
+    echo "timed out after ${TIMEOUT}s waiting for release $TAG to appear." >&2
+    echo "the cargo-dist 'Release' workflow must create the Release before Tauri runs." >&2
+    echo "check it: gh run list --workflow=release.yml --limit 5" >&2
+    exit 1
+  fi
+  sleep "$INTERVAL"
+  elapsed=$(( elapsed + INTERVAL ))
+done
+
+echo "release $TAG exists; cargo-dist created it — safe to dispatch Tauri App Release."


### PR DESCRIPTION
## 背景

0.6.9 发版时踩到的真实事故：两步发版（`just release patch` → `just release-tauri`）几乎同时触发，两个 workflow 争抢创建同一个 GitHub Release。

## 根因

- **Tauri 的 `create-release` job 幂等**（release 已存在就 `exit 0`）
- **cargo-dist 的 `gh release create` 不幂等**（撞 tag 直接失败）

唯一安全的顺序是 **cargo-dist 先建 Release，Tauri 后跑**。若 Tauri 抢先（它的 create-release 仅 ~3 秒），cargo-dist 十几分钟后跑到 "Create GitHub Release" 撞 `already exists`，整个 "Release" workflow 失败 —— CLI 安装包没上传、npm publish 不触发。

## 改动

- 新增 `scripts/release/wait-for-release.sh`：轮询 `gh release view <tag>` 直到 Release 存在（默认 20min 超时，超时给出排查指引）。
- `justfile` 的 `release-tauri` 在 dispatch 前先跑该等待脚本，从机制上杜绝抢跑。
- `CLAUDE.md` 写明「顺序铁律」与根因。

## 验证

- `bash -n` 语法通过；脚本 mode `100755`
- `just --dry-run release-tauri v9.9.9` 展开正确（先等待脚本，再 `gh workflow run`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
