### PR TITLE
fix(ui): 修复下拉浮层选中后闪烁重现 + 隐藏浮层滚动条

### DIFF
--- a/apps/gpt-image-2-app/src/components/ui/combobox.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/combobox.tsx
@@ -81,6 +81,9 @@ export function GlassCombobox(props: GlassComboboxProps) {
   } = props;
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Guards the programmatic re-focus in handlePick: the input's onFocus
+  // must not re-open the popover we just closed.
+  const suppressFocusOpen = useRef(false);
   const isChip = props.variant === "chip";
   const chipLabel = isChip ? (props as ChipVariantProps).label : undefined;
   const trimmed = value.trim().toLowerCase();
@@ -91,8 +94,13 @@ export function GlassCombobox(props: GlassComboboxProps) {
   const handlePick = (next: string) => {
     onValueChange(next);
     setOpen(false);
-    // re-focus the input after the popover closes
-    setTimeout(() => inputRef.current?.focus(), 0);
+    // re-focus the input after the popover closes; focus() dispatches the
+    // focus event synchronously, so the guard can be reset right after
+    setTimeout(() => {
+      suppressFocusOpen.current = true;
+      inputRef.current?.focus({ preventScroll: true });
+      suppressFocusOpen.current = false;
+    }, 0);
   };
 
   const openFromSurface = (event: PointerEvent<HTMLDivElement>) => {
@@ -133,7 +141,10 @@ export function GlassCombobox(props: GlassComboboxProps) {
           id={id}
           value={value}
           onChange={(e) => onValueChange(e.target.value)}
-          onFocus={() => setOpen(true)}
+          onFocus={() => {
+            if (suppressFocusOpen.current) return;
+            setOpen(true);
+          }}
           onClick={() => {
             if (!disabled) setOpen(true);
           }}
@@ -167,8 +178,9 @@ export function GlassCombobox(props: GlassComboboxProps) {
           align="start"
           sideOffset={6}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
           className={cn(
-            "z-50 max-h-[280px] overflow-auto rounded-xl border outline-none p-1",
+            "z-50 max-h-[280px] overflow-auto scrollbar-none rounded-xl border outline-none p-1",
             "min-w-[var(--radix-popover-trigger-width)]",
             "data-[state=open]:animate-in data-[state=closed]:animate-out",
             "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",

--- a/apps/gpt-image-2-app/src/components/ui/select.tsx
+++ b/apps/gpt-image-2-app/src/components/ui/select.tsx
@@ -93,7 +93,13 @@ const SelectContent = forwardRef<
       }}
       {...rest}
     >
-      <RadixSelect.Viewport className="p-1">{children}</RadixSelect.Viewport>
+      {/* Height cap + scroll live on the Viewport: Radix gives it
+          `overflow: hidden auto`, but its `flex: 1` only resolves against a
+          flex parent — the Content wrapper isn't one, so capping Content
+          would clip the list instead of scrolling it. */}
+      <RadixSelect.Viewport className="max-h-[min(280px,var(--radix-select-content-available-height))] scrollbar-none p-1">
+        {children}
+      </RadixSelect.Viewport>
     </RadixSelect.Content>
   </RadixSelect.Portal>
 ));


### PR DESCRIPTION
## 问题

前端下拉列表（`GlassCombobox`）选中一项后，浮层没有直接消失，而是「闪烁一下又出现」。此外浮层的原生滚动条在 Liquid 背景上很显眼，观感差。

## 原因

`GlassCombobox` 在 `handlePick` 里选中后会 `setOpen(false)` 关闭浮层，紧接着用 `setTimeout` 把焦点还给输入框（方便继续编辑）。但输入框的 `onFocus` 无条件 `setOpen(true)`——于是浮层刚关掉就被这次**程序性**聚焦重新打开，形成闪烁。

## 改动

`combobox.tsx`：
- 新增 `suppressFocusOpen` ref 作守卫：`handlePick` 重新聚焦前置位、聚焦后立即复位（focus 事件同步派发，不影响用户后续正常聚焦），`onFocus` 命中守卫时不再打开浮层。
- 浮层加 `onCloseAutoFocus` 的 `preventDefault`，避免 Radix 关闭时把焦点弹到 chevron 按钮上。
- 浮层加 `scrollbar-none`，隐藏滚动条但保留滚轮/触摸/键盘滚动。

`select.tsx`：
- 顺手给 `SelectContent` 加 `max-h-[min(280px, available-height)]`，选项过多时在浮层内滚动，而不是溢出视口（Radix Select 的 Viewport 自带隐藏滚动条）。

## 验证

本地 Web 开发模式（`5173`）手测：combobox 选中后浮层正常关闭、不再闪烁；滚动条已隐藏、滚动仍可用。