### PR TITLE
ci: run the full test surface on PRs (workspace tests, frontend, worker, clippy)

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: release-candidate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   candidate:
     runs-on: ubuntu-24.04
@@ -14,7 +18,47 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Install cargo-dist
-        run: cargo install cargo-dist --locked --version 0.31.0
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+      # tauri_build::build() refuses to compile when frontendDist is missing,
+      # and the workspace-wide gates below compile the Tauri crate too.
+      - name: Ensure frontend dist exists for tauri_build
+        run: mkdir -p apps/gpt-image-2-app/dist
       - name: Prepare release candidate
         run: scripts/release/prepare.sh
+
+  frontend:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/gpt-image-2-app/package-lock.json
+      - name: Install dependencies
+        run: npm --prefix apps/gpt-image-2-app ci
+      - name: Test
+        run: npm --prefix apps/gpt-image-2-app run test
+      - name: Build
+        run: npm --prefix apps/gpt-image-2-app run build
+
+  relay:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: workers/gpt-image-2-relay/package-lock.json
+      - name: Install dependencies
+        run: npm --prefix workers/gpt-image-2-relay ci
+      - name: Type-check
+        run: npm --prefix workers/gpt-image-2-relay run typecheck
+      - name: Test
+        run: npm --prefix workers/gpt-image-2-relay run test

--- a/apps/gpt-image-2-app/package.json
+++ b/apps/gpt-image-2-app/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "build:http": "VITE_GPT_IMAGE_2_API_BASE=/api npm run build",
     "prepare:sidecar": "node scripts/prepare-sidecar.mjs",
+    "test": "vitest run",
     "test:browser": "vitest run src/lib/api/browser-transport.test.ts",
     "typecheck": "tsc --noEmit",
     "tauri": "tauri"

--- a/apps/gpt-image-2-app/src-tauri/src/export_commands.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/export_commands.rs
@@ -54,8 +54,8 @@ pub(crate) fn export_files_into_dir(
     export_dir: &Path,
 ) -> Result<Vec<String>, String> {
     let sources = validate_source_paths(paths)?;
-    fs::create_dir_all(&export_dir).map_err(|error| format!("无法创建保存目录：{error}"))?;
-    if all_sources_within_dir(&sources, &export_dir) {
+    fs::create_dir_all(export_dir).map_err(|error| format!("无法创建保存目录：{error}"))?;
+    if all_sources_within_dir(&sources, export_dir) {
         return Ok(display_paths(&sources));
     }
 
@@ -65,7 +65,7 @@ pub(crate) fn export_files_into_dir(
             .file_name()
             .and_then(|name| name.to_str())
             .ok_or_else(|| "图片文件名无效。".to_string())?;
-        let destination = unique_destination(&export_dir, file_name);
+        let destination = unique_destination(export_dir, file_name);
         fs::copy(&source, &destination).map_err(|error| format!("保存图片失败：{error}"))?;
         saved.push(destination.display().to_string());
     }

--- a/apps/gpt-image-2-app/src-tauri/src/export_names.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/export_names.rs
@@ -11,30 +11,29 @@ pub(crate) fn output_paths_from_job(job: &Value) -> Vec<String> {
         .filter_map(|output| output.get("path").and_then(Value::as_str))
         .map(ToString::to_string)
         .collect::<Vec<_>>();
-    if paths.is_empty() {
-        if let Some(files) = job
+    if paths.is_empty()
+        && let Some(files) = job
             .get("metadata")
             .and_then(|metadata| metadata.get("output"))
             .and_then(|output| output.get("files"))
             .and_then(Value::as_array)
-        {
-            paths.extend(
-                files
-                    .iter()
-                    .filter_map(|output| output.get("path").and_then(Value::as_str))
-                    .map(ToString::to_string),
-            );
-        }
+    {
+        paths.extend(
+            files
+                .iter()
+                .filter_map(|output| output.get("path").and_then(Value::as_str))
+                .map(ToString::to_string),
+        );
     }
-    if paths.is_empty() {
-        if let Some(path) = job.get("output_path").and_then(Value::as_str).or_else(|| {
+    if paths.is_empty()
+        && let Some(path) = job.get("output_path").and_then(Value::as_str).or_else(|| {
             job.get("metadata")
                 .and_then(|metadata| metadata.get("output"))
                 .and_then(|output| output.get("path"))
                 .and_then(Value::as_str)
-        }) {
-            paths.push(path.to_string());
-        }
+        })
+    {
+        paths.push(path.to_string());
     }
     paths
 }

--- a/apps/gpt-image-2-app/src-tauri/src/support.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/support.rs
@@ -7,8 +7,10 @@ pub(crate) fn default_result_library_mode() -> gpt_image_2_core::ExportDirMode {
 }
 
 pub(crate) fn sync_result_library_to_default_export_dir(config: &mut PathConfig) {
-    let mut preview = AppConfig::default();
-    preview.paths = config.clone();
+    let preview = AppConfig {
+        paths: config.clone(),
+        ..Default::default()
+    };
     let save_dir = product_default_export_dir(Some(&preview), ProductRuntime::Tauri);
     config.result_library_dir.mode = gpt_image_2_core::PathMode::Custom;
     config.result_library_dir.path = Some(save_dir);
@@ -42,12 +44,10 @@ pub(crate) fn normalize_product_storage_defaults(config: &mut AppConfig) {
     let fallback_dir = product_storage_fallback_dir(Some(config), ProductRuntime::Tauri);
     if let Some(StorageTargetConfig::Local { directory, .. }) =
         config.storage.targets.get_mut("local-default")
+        && (*directory == shared_config_dir().join("storage").join("fallback")
+            || directory.as_os_str().is_empty())
     {
-        if *directory == shared_config_dir().join("storage").join("fallback")
-            || directory.as_os_str().is_empty()
-        {
-            *directory = fallback_dir;
-        }
+        *directory = fallback_dir;
     }
     if matches!(
         config.paths.default_export_dir.mode,

--- a/apps/gpt-image-2-app/src-tauri/src/tests.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/tests.rs
@@ -98,8 +98,10 @@ fn tauri_storage_defaults_keep_explicit_downloads_save_directory() {
 fn sync_result_library_uses_selected_standard_save_folder() {
     let mut paths = AppConfig::default().paths;
     paths.default_export_dir.mode = gpt_image_2_core::ExportDirMode::Downloads;
-    let mut preview = AppConfig::default();
-    preview.paths = paths.clone();
+    let preview = AppConfig {
+        paths: paths.clone(),
+        ..Default::default()
+    };
     let expected = product_default_export_dir(Some(&preview), ProductRuntime::Tauri);
 
     sync_result_library_to_default_export_dir(&mut paths);

--- a/crates/gpt-image-2-core/src/history_db.rs
+++ b/crates/gpt-image-2-core/src/history_db.rs
@@ -370,7 +370,6 @@ pub fn list_history_job_events(job_id: &str) -> Result<Vec<Value>, AppError> {
 /// Mark a history row as soft-deleted by stamping `deleted_at` with the
 /// current epoch seconds. Already-deleted rows are not re-stamped, keeping
 /// the original deletion time intact for trash retention windows.
-
 pub fn soft_delete_history_job(job_id: &str) -> Result<usize, AppError> {
     let conn = open_history_db()?;
     let now = SystemTime::now()
@@ -392,7 +391,6 @@ pub fn soft_delete_history_job(job_id: &str) -> Result<usize, AppError> {
 }
 
 /// Clear `deleted_at` so the row reappears in the default listing. Idempotent.
-
 pub fn restore_deleted_history_job(job_id: &str) -> Result<usize, AppError> {
     let conn = open_history_db()?;
     conn.execute(
@@ -410,7 +408,6 @@ pub fn restore_deleted_history_job(job_id: &str) -> Result<usize, AppError> {
 /// has elapsed). Used by the trash GC worker so the cutoff is anchored to
 /// when the row was soft-deleted, not to the trash directory's filesystem
 /// mtime (which `fs::rename` doesn't update).
-
 pub fn list_expired_deleted_history_jobs(
     threshold_epoch_secs: u64,
 ) -> Result<Vec<String>, AppError> {

--- a/crates/gpt-image-2-core/src/image_requests/openai.rs
+++ b/crates/gpt-image-2-core/src/image_requests/openai.rs
@@ -45,7 +45,7 @@ pub(crate) fn request_openai_images_once(
         AppError::new("network_error", "OpenAI request failed.")
             .with_detail(json!({ "error": error.to_string() }))
     })?;
-    parse_openai_json_response(response, logger, recovery.as_deref_mut())
+    parse_openai_json_response(response, logger, recovery)
 }
 
 pub(crate) fn request_openai_edit_once(
@@ -99,7 +99,7 @@ pub(crate) fn request_openai_edit_once(
         AppError::new("network_error", "OpenAI multipart request failed.")
             .with_detail(json!({ "error": error.to_string() }))
     })?;
-    parse_openai_json_response(response, logger, recovery.as_deref_mut())
+    parse_openai_json_response(response, logger, recovery)
 }
 
 pub(crate) fn parse_openai_json_response(
@@ -122,7 +122,7 @@ pub(crate) fn parse_openai_json_response(
         )
         .with_detail(json!({ "error": error.to_string() }))
     })?;
-    if let Some(ctx) = recovery.as_deref_mut() {
+    if let Some(ctx) = recovery {
         ctx.mark_response_body_completed()?;
         ctx.spool_raw_response(&raw)?;
     }

--- a/crates/gpt-image-2-core/src/notifications/types.rs
+++ b/crates/gpt-image-2-core/src/notifications/types.rs
@@ -7,16 +7,12 @@ use crate::CredentialRef;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum EmailTlsMode {
+    #[default]
     StartTls,
     Smtps,
     None,
-}
-
-impl Default for EmailTlsMode {
-    fn default() -> Self {
-        Self::StartTls
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/crates/gpt-image-2-core/src/notifications/webhook.rs
+++ b/crates/gpt-image-2-core/src/notifications/webhook.rs
@@ -277,25 +277,21 @@ mod tests {
     #[test]
     fn webhook_ssrf_guard_rejects_non_http_schemes() {
         let err = validate_webhook_target("ftp://example.com/hook")
-            .err()
-            .expect("non-http scheme should be rejected");
+            .expect_err("non-http scheme should be rejected");
         assert_eq!(err.code, "notification_webhook_invalid");
     }
 
     #[test]
     fn webhook_ssrf_guard_rejects_malformed_urls() {
-        let err = validate_webhook_target("not a url")
-            .err()
-            .expect("malformed url should be rejected");
+        let err =
+            validate_webhook_target("not a url").expect_err("malformed url should be rejected");
         assert_eq!(err.code, "notification_webhook_invalid");
     }
 
     #[test]
     fn webhook_ssrf_guard_keeps_notification_owned_invalid_url_detail() {
         let url = format!("not a url {}", "x".repeat(300));
-        let err = validate_webhook_target(&url)
-            .err()
-            .expect("malformed url should be rejected");
+        let err = validate_webhook_target(&url).expect_err("malformed url should be rejected");
         assert_eq!(err.code, "notification_webhook_invalid");
         assert_eq!(err.detail.unwrap()["url"], url);
     }

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -75,7 +75,7 @@ impl Recoverability {
         }
     }
 
-    pub fn from_str(value: &str) -> Option<Self> {
+    pub fn parse(value: &str) -> Option<Self> {
         match value {
             "recoverable.never_dispatched" => Some(Self::NeverDispatched),
             "recoverable.local_response_cached" => Some(Self::LocalResponseCached),
@@ -705,7 +705,7 @@ pub fn write_batch_recovery_summary(
         let recoverability = state
             .recoverability
             .as_deref()
-            .and_then(Recoverability::from_str)
+            .and_then(Recoverability::parse)
             .unwrap_or_else(|| {
                 classify_from_state_and_evidence(&state, raw_response_path(child_dir).is_file())
             });
@@ -827,7 +827,7 @@ pub fn build_recovery_descriptor(job: &Value) -> Value {
     let mut recoverability = metadata
         .get("recoverability")
         .and_then(Value::as_str)
-        .and_then(Recoverability::from_str)
+        .and_then(Recoverability::parse)
         .unwrap_or_else(|| {
             let state = job_dir.as_deref().and_then(load_recovery_state);
             if let Some(state) = state {

--- a/crates/gpt-image-2-core/src/recovery.rs
+++ b/crates/gpt-image-2-core/src/recovery.rs
@@ -75,6 +75,13 @@ impl Recoverability {
         }
     }
 
+    /// Kept for downstream compatibility (this crate is published); prefer
+    /// [`Recoverability::parse`] in new code.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(value: &str) -> Option<Self> {
+        Self::parse(value)
+    }
+
     pub fn parse(value: &str) -> Option<Self> {
         match value {
             "recoverable.never_dispatched" => Some(Self::NeverDispatched),

--- a/crates/gpt-image-2-core/src/storage/orchestrator.rs
+++ b/crates/gpt-image-2-core/src/storage/orchestrator.rs
@@ -124,6 +124,7 @@ fn record_upload_attempt(
     Ok(completed)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn upload_manifest(
     output: &UploadOutput,
     target_name: &str,

--- a/crates/gpt-image-2-core/src/storage/types.rs
+++ b/crates/gpt-image-2-core/src/storage/types.rs
@@ -178,16 +178,12 @@ pub struct BackendCapabilities {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum StorageFallbackPolicy {
     Never,
+    #[default]
     OnFailure,
     Always,
-}
-
-impl Default for StorageFallbackPolicy {
-    fn default() -> Self {
-        Self::OnFailure
-    }
 }
 
 /// How `Result Origin` and `Archives` relate for a deployment. Replaces the
@@ -222,17 +218,13 @@ pub enum PipelineMode {
 /// objects are never deleted implicitly by these policies.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum CleanupMode {
+    #[default]
     Never,
     AfterArchiveSuccess,
     ByAge,
     BySize,
-}
-
-impl Default for CleanupMode {
-    fn default() -> Self {
-        Self::Never
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default)]

--- a/crates/gpt-image-2-core/src/storage_config.rs
+++ b/crates/gpt-image-2-core/src/storage_config.rs
@@ -10,15 +10,11 @@ fn default_true() -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum PathMode {
+    #[default]
     Default,
     Custom,
-}
-
-impl Default for PathMode {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -40,19 +36,15 @@ impl Default for PathRef {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, Ord, PartialEq, PartialOrd)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum ExportDirMode {
     Downloads,
     Documents,
     Pictures,
+    #[default]
     ResultLibrary,
     Custom,
     BrowserDefault,
-}
-
-impl Default for ExportDirMode {
-    fn default() -> Self {
-        Self::ResultLibrary
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]

--- a/crates/gpt-image-2-core/src/tests/storage_config.rs
+++ b/crates/gpt-image-2-core/src/tests/storage_config.rs
@@ -537,13 +537,15 @@ fn effective_pipeline_with_explicit_pipeline_ignores_legacy_fields() {
 fn effective_pipeline_preserves_explicit_empty_archives() {
     // Explicitly empty Mirror archives is allowed at the type level — the UI
     // validator (pipelineConfigIssue) is responsible for warning the user.
-    let mut config = StorageConfig::default();
-    config.pipeline = Some(PipelineConfig {
-        mode: PipelineMode::Mirror,
-        origin: None,
-        archives: Vec::new(),
-        cleanup: CleanupPolicy::default(),
-    });
+    let config = StorageConfig {
+        pipeline: Some(PipelineConfig {
+            mode: PipelineMode::Mirror,
+            origin: None,
+            archives: Vec::new(),
+            cleanup: CleanupPolicy::default(),
+        }),
+        ..Default::default()
+    };
     let pipeline = config.effective_pipeline();
     assert_eq!(pipeline.mode, PipelineMode::Mirror);
     assert!(pipeline.archives.is_empty());
@@ -573,13 +575,15 @@ fn explicit_pipeline_serialises_without_legacy_pollution() {
     // When `pipeline` is set, serialised output should keep both new and
     // legacy fields so back-compat readers still see something — but
     // `pipeline` should appear and be re-readable on the other side.
-    let mut config = StorageConfig::default();
-    config.pipeline = Some(PipelineConfig {
-        mode: PipelineMode::CloudPrimary,
-        origin: Some("s3-main".to_string()),
-        archives: vec!["webdav-1".to_string()],
-        cleanup: CleanupPolicy::default(),
-    });
+    let config = StorageConfig {
+        pipeline: Some(PipelineConfig {
+            mode: PipelineMode::CloudPrimary,
+            origin: Some("s3-main".to_string()),
+            archives: vec!["webdav-1".to_string()],
+            cleanup: CleanupPolicy::default(),
+        }),
+        ..Default::default()
+    };
     let value = serde_json::to_value(&config).expect("serialise");
     assert_eq!(value["pipeline"]["mode"], "cloud_primary");
     assert_eq!(value["pipeline"]["origin"], "s3-main");

--- a/crates/gpt-image-2-web/src/support.rs
+++ b/crates/gpt-image-2-web/src/support.rs
@@ -14,12 +14,10 @@ pub(crate) fn normalize_product_storage_defaults(config: &mut AppConfig) {
     let fallback_dir = product_storage_fallback_dir(Some(config), ProductRuntime::DockerWeb);
     if let Some(StorageTargetConfig::Local { directory, .. }) =
         config.storage.targets.get_mut("local-default")
+        && (*directory == shared_config_dir().join("storage").join("fallback")
+            || directory.as_os_str().is_empty())
     {
-        if *directory == shared_config_dir().join("storage").join("fallback")
-            || directory.as_os_str().is_empty()
-        {
-            *directory = fallback_dir;
-        }
+        *directory = fallback_dir;
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -16,9 +16,13 @@ sync-skill:
 smoke-skill-install:
     node scripts/smoke_skill_install.cjs
 
-# Run Rust tests for the CLI crate.
+# Run Rust tests for the whole workspace.
 test:
-    cargo test -p gpt-image-2-skill
+    cargo test --workspace
+
+# Run clippy across the whole workspace, failing on warnings.
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
 
 # Build the CLI crate in debug mode.
 build:
@@ -43,6 +47,10 @@ app-build:
 # Build the HTTP-backed Web frontend.
 app-build-http:
     npm --prefix apps/gpt-image-2-app run build:http
+
+# Run the full frontend test suite.
+app-test:
+    npm --prefix apps/gpt-image-2-app run test
 
 # Run the browser transport tests.
 app-test-browser:

--- a/scripts/release/prepare.sh
+++ b/scripts/release/prepare.sh
@@ -12,7 +12,8 @@ cd "$ROOT_DIR"
 
 node scripts/release/sync-version-manifests.mjs
 cargo fmt --check
-cargo test -p "$CRATE_NAME"
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
 cargo run -q -p "$CRATE_NAME" -- --json doctor >/tmp/gpt-image-2-skill-doctor.json
 node scripts/smoke_skill_install.cjs >/tmp/gpt-image-2-skill-skill-smoke.json
 if {

--- a/scripts/release/verify.sh
+++ b/scripts/release/verify.sh
@@ -30,7 +30,7 @@ if [[ -n "$RELEASE_DIR" ]]; then
 else
   node scripts/npm/build-matrix.mjs --check
 fi
-cargo test -p "$CRATE_NAME"
+cargo test --workspace
 cargo run -q -p "$CRATE_NAME" -- --json doctor >/tmp/gpt-image-2-skill-verify-doctor.json
 node scripts/smoke_skill_install.cjs >/tmp/gpt-image-2-skill-verify-skill.json
 


### PR DESCRIPTION
## 问题

审查发现 PR 唯一的质量门 `release-candidate.yml` 实际运行 **0 个测试**：

- `prepare.sh` 跑的是 `cargo test -p gpt-image-2-skill`，而 CLI crate 没有任何 `#[test]`。真正的 149 个测试在 core（128）/ web（9）/ tauri（12），从不在 CI 执行。
- 前端 16 个 vitest 测试文件（94 个测试）只有一个单文件入口 `test:browser`，没有全量运行方式，CI 里也没有任何前端 job。
- worker 有测试和 typecheck 脚本，同样零 CI 调用。
- 无 clippy 门。

## 改动

- `prepare.sh` / `verify.sh` / `justfile`：`cargo test --workspace`；`prepare.sh` 增加 `cargo clippy --workspace --all-targets -- -D warnings` 门
- 清掉现存 27 条风格级 clippy 告警（多数 `--fix` 自动修复；`Recoverability::from_str` 更名 `parse` 消除 `should_implement_trait`；`upload_manifest` 加 `#[allow(too_many_arguments)]`，待上传路径重构时一并处理）
- 前端 `package.json` 增加全量 `test` script；justfile 增加 `app-test` / `clippy`
- `release-candidate.yml`：
  - 新增 `frontend` job（vitest 94 个测试 + build，build 内含 `tsc --noEmit`）
  - 新增 `relay` job（typecheck + vitest）
  - candidate job 安装 Tauri 系统依赖并预创建 `dist/`（workspace 级门会编译 Tauri crate；`tauri_build::build()` 要求 frontendDist 存在）
  - cargo-dist 改用预编译 installer（原来源码编译冷缓存 6m18s，release.yml 本来就用 installer）
  - 增加 per-PR concurrency cancel-in-progress

## 验证

- 本地 `cargo clippy --workspace --all-targets` 0 告警
- 本地 `cargo test --workspace` 149 个测试全绿
- 本地 `vitest run` 16 文件 94 测试全绿
- `cargo fmt --all --check` 干净