### PR TITLE
fix(ui): frontend bug batch — shortcut hijack, WebGL/timer/RAF leaks, a11y

### DIFF
--- a/apps/gpt-image-2-app/src/components/reactbits/backgrounds/Grainient.tsx
+++ b/apps/gpt-image-2-app/src/components/reactbits/backgrounds/Grainient.tsx
@@ -317,6 +317,7 @@ const Grainient: React.FC<GrainientProps> = ({
       } catch {
         /* ignore */
       }
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
     };
   }, [
     timeSpeed,

--- a/apps/gpt-image-2-app/src/components/reactbits/backgrounds/LetterGlitch.tsx
+++ b/apps/gpt-image-2-app/src/components/reactbits/backgrounds/LetterGlitch.tsx
@@ -214,6 +214,7 @@ const LetterGlitch = ({
 
     return () => {
       cancelAnimationFrame(animationRef.current!);
+      clearTimeout(resizeTimeout);
       window.removeEventListener('resize', handleResize);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/gpt-image-2-app/src/components/reactbits/backgrounds/Plasma.tsx
+++ b/apps/gpt-image-2-app/src/components/reactbits/backgrounds/Plasma.tsx
@@ -249,6 +249,7 @@ export const Plasma: React.FC<PlasmaProps> = ({
       } catch {
         /* ignore */
       }
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
     };
   }, [color, speed, direction, scale, opacity, mouseInteractive]);
 

--- a/apps/gpt-image-2-app/src/components/reactbits/components/ClickSpark.tsx
+++ b/apps/gpt-image-2-app/src/components/reactbits/components/ClickSpark.tsx
@@ -35,7 +35,8 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const sparksRef = useRef<Spark[]>([]);
-  const startTimeRef = useRef<number | null>(null);
+  const animationIdRef = useRef<number | null>(null);
+  const drawRef = useRef<(timestamp: number) => void>(() => {});
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -92,13 +93,11 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    let animationId: number;
-
+    // The loop only runs while sparks are in flight: handleClick starts it,
+    // and it parks itself after the last spark finishes instead of spinning
+    // at 60fps for the lifetime of the (always-mounted) host screen.
     const draw = (timestamp: number) => {
-      if (!startTimeRef.current) {
-        startTimeRef.current = timestamp;
-      }
-      ctx?.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
 
       sparksRef.current = sparksRef.current.filter((spark: Spark) => {
         const elapsed = timestamp - spark.startTime;
@@ -127,13 +126,23 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
         return true;
       });
 
-      animationId = requestAnimationFrame(draw);
+      if (sparksRef.current.length > 0) {
+        animationIdRef.current = requestAnimationFrame(draw);
+      } else {
+        animationIdRef.current = null;
+      }
     };
 
-    animationId = requestAnimationFrame(draw);
+    drawRef.current = draw;
+    if (sparksRef.current.length > 0 && animationIdRef.current === null) {
+      animationIdRef.current = requestAnimationFrame(draw);
+    }
 
     return () => {
-      cancelAnimationFrame(animationId);
+      if (animationIdRef.current !== null) {
+        cancelAnimationFrame(animationIdRef.current);
+        animationIdRef.current = null;
+      }
     };
   }, [sparkColor, sparkSize, sparkRadius, sparkCount, duration, easeFunc, extraScale]);
 
@@ -153,6 +162,9 @@ const ClickSpark: React.FC<ClickSparkProps> = ({
     }));
 
     sparksRef.current.push(...newSparks);
+    if (animationIdRef.current === null) {
+      animationIdRef.current = requestAnimationFrame(drawRef.current);
+    }
   };
 
   return (

--- a/apps/gpt-image-2-app/src/components/screens/edit/use-mask-workspace.ts
+++ b/apps/gpt-image-2-app/src/components/screens/edit/use-mask-workspace.ts
@@ -116,7 +116,7 @@ export function useMaskWorkspace({
   }, [active, targetRefId, updateMaskToolbarScale, usesRegion, zoom]);
 
   useEffect(() => {
-    if (!usesRegion) return;
+    if (!active || !usesRegion) return;
     const isEditableTarget = (target: EventTarget | null) => {
       if (!(target instanceof HTMLElement)) return false;
       return Boolean(

--- a/apps/gpt-image-2-app/src/components/screens/history/index.tsx
+++ b/apps/gpt-image-2-app/src/components/screens/history/index.tsx
@@ -225,6 +225,7 @@ export function HistoryScreen({
               <button
                 key={f.value}
                 type="button"
+                aria-pressed={isActive}
                 onClick={() => setFilter(f.value)}
                 className={cn(
                   "relative shrink-0 whitespace-nowrap px-3.5 h-8 rounded-full text-[12.5px] font-medium transition-colors",

--- a/apps/gpt-image-2-app/src/components/shell/window-chrome.tsx
+++ b/apps/gpt-image-2-app/src/components/shell/window-chrome.tsx
@@ -19,6 +19,11 @@ const Grainient = lazy(
   () => import("@/components/reactbits/backgrounds/Grainient"),
 );
 
+// Module-level so the fallback keeps a stable identity: an inline array
+// literal would be a new reference every render, and LiquidChrome rebuilds
+// its whole WebGL context when baseColor changes.
+const LIQUID_DEFAULT_BASE_COLOR: [number, number, number] = [0.18, 0.16, 0.32];
+
 /**
  * Render the active theme preset's background. Each kind reads only
  * the params it cares about from preset.background; everything else
@@ -60,7 +65,7 @@ function ThemeBackground({ presetId }: { presetId: ThemePresetId }) {
     case "liquid":
       return (
         <LiquidChrome
-          baseColor={bg.baseColor ?? [0.18, 0.16, 0.32]}
+          baseColor={bg.baseColor ?? LIQUID_DEFAULT_BASE_COLOR}
           speed={bg.speed}
           amplitude={bg.amplitude}
           frequencyX={bg.frequencyX}

--- a/apps/gpt-image-2-app/src/hooks/use-shortcuts.ts
+++ b/apps/gpt-image-2-app/src/hooks/use-shortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 type Handler = (e: KeyboardEvent) => void;
 
@@ -24,6 +24,10 @@ export function useShortcut(
 export function useGlobalShortcuts(callbacks: {
   onScreen?: (screen: string) => void;
 }) {
+  // Read through a ref so callers can pass an inline object literal without
+  // re-binding the window listener on every render.
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -35,10 +39,10 @@ export function useGlobalShortcuts(callbacks: {
           "3": "history",
           "4": "settings",
         };
-        callbacks.onScreen?.(map[e.key]);
+        callbacksRef.current.onScreen?.(map[e.key]);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [callbacks]);
+  }, []);
 }


### PR DESCRIPTION
## 修复清单（均来自前端审查）

1. **跨屏幕快捷键劫持（用户可感知 bug）**：`use-mask-workspace.ts` 的全局键盘 effect 守卫漏了 `active`（同文件另两个 effect 都有，`active` 在 deps 里却没参与判断）。四个屏幕 `hidden` 常驻挂载 + editMode 持久化 → 编辑屏停在"局部编辑"时，生成/任务/设置屏上的 Space 被吞、⌘Z 无声撤销看不见的遮罩。一行修复：`if (!active || !usesRegion) return;`
2. **WebGL context 泄漏**：Plasma/Grainient 卸载不调 `WEBGL_lose_context`（LiquidChrome 是正确示范）。主题 450ms 交叉淡出每次切换新建 context，连续点外观预设会触发浏览器 context 上限、活跃背景黑屏。
3. **LetterGlitch resize 防抖定时器未清理**：卸载后可重启 RAF 并对已置空的 canvas ref 抛 TypeError（拖窗口大小时切主题可触发）。
4. **ClickSpark 空转 RAF**：包着常驻生成 CTA，火花为空也 60fps clearRect。改为点击启动、画完自停。
5. **useGlobalShortcuts 每次渲染重绑**：App 传内联对象字面量 + `[callbacks]` deps。callbacks 收进 ref，监听只挂一次。
6. **liquid baseColor 回退数组字面量**：提为模块常量，防止未来某预设缺 baseColor 时每帧重建 WebGL context。
7. **a11y**：任务筛选 chips 补 `aria-pressed`。

## 验证

- typecheck ✓、vitest 94/94 ✓、production build ✓
- **浏览器实测对照实验**（vite dev + 合成 KeyboardEvent）：
  - 编辑屏激活 + 局部编辑：Space/⌘Z `defaultPrevented=true`（功能保持）
  - 切到生成屏：`defaultPrevented=false`（劫持消除）
- console 无告警