### PR TITLE
fix(web,app,core): move blocking core calls off the tokio runtime; add SFTP timeouts

### DIFF
--- a/apps/gpt-image-2-app/src-tauri/src/file_access.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/file_access.rs
@@ -66,24 +66,34 @@ pub(crate) async fn copy_image_to_clipboard(
     output_index: Option<usize>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    let raw = PathBuf::from(&path);
-    let bytes = if raw.is_file() {
-        let resolved = resolve_within_allowed_scope(&raw)?;
-        fs::read(&resolved).map_err(|error| format!("读取失败：{error}"))?
-    } else if let (Some(job_id), Some(output_index)) = (job_id.as_deref(), output_index) {
-        read_job_output_for_product(job_id, output_index, true)?.bytes
-    } else {
-        return Err("图片文件不存在，可能已被移动或删除。".to_string());
-    };
-    // Decode via the `image` crate so JPEG / WEBP / GIF outputs round-trip
-    // — `tauri::image::Image::from_bytes` only supports PNG/ICO with the
-    // currently enabled feature set, which would otherwise hard-regress
-    // Copy Image on any non-PNG job.
-    let decoded =
-        image::load_from_memory(&bytes).map_err(|error| format!("解析图片失败：{error}"))?;
-    let rgba = decoded.to_rgba8();
-    let (width, height) = rgba.dimensions();
-    let image = tauri::image::Image::new_owned(rgba.into_raw(), width, height);
+    // Reading a job output can pull it back from remote storage over core's
+    // blocking HTTP client, which panics if dropped on the tokio runtime this
+    // async command runs on; the `image` decode is blocking CPU work too. Do
+    // both on the blocking pool and hand back only the raw RGBA buffer.
+    let (raw, width, height) =
+        tauri::async_runtime::spawn_blocking(move || -> Result<(Vec<u8>, u32, u32), String> {
+            let raw_path = PathBuf::from(&path);
+            let bytes = if raw_path.is_file() {
+                let resolved = resolve_within_allowed_scope(&raw_path)?;
+                fs::read(&resolved).map_err(|error| format!("读取失败：{error}"))?
+            } else if let (Some(job_id), Some(output_index)) = (job_id.as_deref(), output_index) {
+                read_job_output_for_product(job_id, output_index, true)?.bytes
+            } else {
+                return Err("图片文件不存在，可能已被移动或删除。".to_string());
+            };
+            // Decode via the `image` crate so JPEG / WEBP / GIF outputs
+            // round-trip — `tauri::image::Image::from_bytes` only supports
+            // PNG/ICO with the currently enabled feature set, which would
+            // otherwise hard-regress Copy Image on any non-PNG job.
+            let decoded = image::load_from_memory(&bytes)
+                .map_err(|error| format!("解析图片失败：{error}"))?;
+            let rgba = decoded.to_rgba8();
+            let (width, height) = rgba.dimensions();
+            Ok((rgba.into_raw(), width, height))
+        })
+        .await
+        .map_err(|error| format!("图片处理任务失败：{error}"))??;
+    let image = tauri::image::Image::new_owned(raw, width, height);
     app.clipboard()
         .write_image(&image)
         .map_err(|error| format!("写入剪贴板失败：{error}"))?;

--- a/crates/gpt-image-2-core/src/storage/backends/sftp.rs
+++ b/crates/gpt-image-2-core/src/storage/backends/sftp.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
@@ -14,6 +15,10 @@ use crate::{resolve_credential, validate_remote_tcp_target};
 use super::super::types::StorageTargetConfig;
 use super::super::util::*;
 use crate::{AppError, CredentialRef};
+
+const SFTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+// Matches the 120s cap used by the HTTP-family storage backends.
+const SFTP_IO_TIMEOUT_MS: u32 = 120_000;
 
 fn ensure_remote_dir(sftp: &ssh2::Sftp, remote_dir: &Path) {
     let mut current = PathBuf::new();
@@ -85,12 +90,35 @@ pub(crate) fn connect_sftp_session(
 ) -> Result<(Session, String), AppError> {
     sftp_expected_host_key(host_key_sha256)?;
     let addrs = validate_remote_tcp_target(host, port, "SFTP storage")?;
-    let tcp = TcpStream::connect(addrs.as_slice()).map_err(|error| {
+    // Bounded connect + session timeouts: every HTTP-family backend caps
+    // I/O at 120s, while an SFTP server that blackholes TCP would pin an
+    // upload worker forever ("uploading" jobs that never settle).
+    // connect_timeout takes a single address, so walk the pinned list the
+    // way `connect(&[..])` would.
+    let mut last_error: Option<std::io::Error> = None;
+    let mut connected = None;
+    for addr in &addrs {
+        match TcpStream::connect_timeout(addr, SFTP_CONNECT_TIMEOUT) {
+            Ok(stream) => {
+                connected = Some(stream);
+                break;
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    let tcp = connected.ok_or_else(|| {
         AppError::new(
             "storage_sftp_connect_failed",
             "Unable to connect to SFTP server.",
         )
-        .with_detail(json!({"host": host, "port": port, "error": error.to_string()}))
+        .with_detail(json!({
+            "host": host,
+            "port": port,
+            "timeout_secs": SFTP_CONNECT_TIMEOUT.as_secs(),
+            "error": last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "no resolved address".to_string()),
+        }))
     })?;
     let mut session = Session::new().map_err(|error| {
         AppError::new(
@@ -100,6 +128,7 @@ pub(crate) fn connect_sftp_session(
         .with_detail(json!({"error": error.to_string()}))
     })?;
     session.set_tcp_stream(tcp);
+    session.set_timeout(SFTP_IO_TIMEOUT_MS);
     session.handshake().map_err(|error| {
         AppError::new("storage_sftp_handshake_failed", "SFTP handshake failed.")
             .with_detail(json!({"host": host, "error": error.to_string()}))

--- a/crates/gpt-image-2-web/src/config_api.rs
+++ b/crates/gpt-image-2-web/src/config_api.rs
@@ -188,7 +188,6 @@ pub(crate) async fn test_notifications(Json(body): Json<NotificationTestBody>) -
         "output_path": Value::Null,
         "error": if status == "failed" { json!({"message": "Notification test failure"}) } else { Value::Null },
     });
-    let deliveries = dispatch_task_notifications(&config.notifications, &job);
     // dispatch_task_notifications only fires server channels (email/webhook).
     // Toast and system notifications are delivered client-side, so a wholly
     // empty deliveries vec is OK as long as the config still has a local
@@ -197,6 +196,11 @@ pub(crate) async fn test_notifications(Json(body): Json<NotificationTestBody>) -
     let local_eligible = config.notifications.enabled
         && notification_status_allowed(&config.notifications, status)
         && (config.notifications.toast.enabled || config.notifications.system.enabled);
+    // The webhook channel uses core's blocking HTTP client; dispatch on the
+    // blocking pool so dropping it can't panic the tokio worker.
+    let notifications = config.notifications.clone();
+    let deliveries =
+        run_core_blocking(move || dispatch_task_notifications(&notifications, &job)).await?;
     let (ok, reason) = if !deliveries.is_empty() {
         (deliveries.iter().all(|delivery| delivery.ok), None)
     } else if local_eligible {
@@ -326,7 +330,14 @@ pub(crate) async fn delete_provider(Path(name): Path<String>) -> ApiResult {
 
 pub(crate) async fn provider_test(Path(name): Path<String>) -> Json<Value> {
     let started = SystemTime::now();
-    let payload = cli_json(&["--provider".to_string(), name.clone(), "doctor".to_string()]);
+    // doctor reaches the provider over core's blocking HTTP client, which
+    // panics if dropped on a tokio worker — run it on the blocking pool.
+    let doctor_name = name.clone();
+    let payload = run_core_blocking(move || {
+        cli_json(&["--provider".to_string(), doctor_name, "doctor".to_string()])
+    })
+    .await
+    .unwrap_or_else(|error| json!({"ok": false, "error": {"message": error.message}}));
     let latency_ms = started.elapsed().unwrap_or_default().as_millis();
     let ok = payload.get("ok").and_then(Value::as_bool).unwrap_or(false);
     let message = if ok {

--- a/crates/gpt-image-2-web/src/file_api.rs
+++ b/crates/gpt-image-2-web/src/file_api.rs
@@ -73,16 +73,23 @@ pub(crate) async fn job_output_response(
     let job = show_history_job(&job_id)
         .map_err(app_error)
         .map_err(ApiError::not_found)?;
-    let readback = read_job_output_from_storage_with_options(
-        &config.storage,
-        &job,
-        output_index,
-        StorageReadbackOptions {
-            allow_archive_fallback: true,
-            rehydrate_local_cache: true,
-            local_cache_roots: local_cache_roots_for_product(&config),
-        },
-    )
+    // Storage readback can pull the image back from a remote target
+    // (S3/WebDAV/…) over core's blocking HTTP client, so it must run on the
+    // blocking pool rather than inline on the tokio worker.
+    let readback_job = job.clone();
+    let readback = run_core_blocking(move || {
+        read_job_output_from_storage_with_options(
+            &config.storage,
+            &readback_job,
+            output_index,
+            StorageReadbackOptions {
+                allow_archive_fallback: true,
+                rehydrate_local_cache: true,
+                local_cache_roots: local_cache_roots_for_product(&config),
+            },
+        )
+    })
+    .await?
     .map_err(app_error)
     .map_err(ApiError::not_found)?;
     let file_name = output_file_name_from_job(&job, output_index);

--- a/crates/gpt-image-2-web/src/queue_api.rs
+++ b/crates/gpt-image-2-web/src/queue_api.rs
@@ -66,7 +66,12 @@ pub(crate) async fn cancel_job(
         error: Value::Null,
     });
     persist_job(&job).map_err(ApiError::internal)?;
-    let notification_deliveries = dispatch_notifications_for_job(&job);
+    // Firing webhook notifications goes through core's blocking HTTP client;
+    // run it on the blocking pool so a configured webhook can't panic the
+    // tokio worker on cancel.
+    let notify_job = job.clone();
+    let notification_deliveries =
+        run_core_blocking(move || dispatch_notifications_for_job(&notify_job)).await?;
     Ok(Json(json!({
         "job_id": job_id,
         "job": job,

--- a/crates/gpt-image-2-web/src/recovery_api.rs
+++ b/crates/gpt-image-2-web/src/recovery_api.rs
@@ -39,16 +39,28 @@ pub(crate) async fn resume_job(
     State(state): State<JobQueueState>,
     Json(body): Json<ResumeRequest>,
 ) -> ApiResult {
+    // continue_save / fill_missing / reupload / discard all re-run recovery
+    // through core's blocking provider + storage clients, so they run on the
+    // blocking pool. resubmit only re-enqueues (retry_job is genuinely async)
+    // and stays on the tokio worker.
     match body.action.as_str() {
-        "continue_save" => continue_save_job(&job_id)
+        "continue_save" => run_core_blocking(move || continue_save_job(&job_id))
+            .await?
             .map(Json)
             .map_err(ApiError::internal),
-        "fill_missing" => fill_missing_job(&job_id)
+        "fill_missing" => run_core_blocking(move || fill_missing_job(&job_id))
+            .await?
             .map(Json)
             .map_err(ApiError::internal),
-        "reupload" => reupload_job(&job_id).map(Json).map_err(ApiError::internal),
+        "reupload" => run_core_blocking(move || reupload_job(&job_id))
+            .await?
+            .map(Json)
+            .map_err(ApiError::internal),
         "resubmit" => retry_job(Path(job_id), State(state)).await,
-        "discard" => discard_job(&job_id).map(Json).map_err(ApiError::internal),
+        "discard" => run_core_blocking(move || discard_job(&job_id))
+            .await?
+            .map(Json)
+            .map_err(ApiError::internal),
         _ => Err(ApiError::bad_request("Unsupported recovery action.")),
     }
 }

--- a/crates/gpt-image-2-web/src/support.rs
+++ b/crates/gpt-image-2-web/src/support.rs
@@ -6,6 +6,24 @@ pub(crate) fn app_error(error: gpt_image_2_core::AppError) -> String {
     format!("{}: {}", error.code, error.message)
 }
 
+/// Run a synchronous core operation on the blocking pool.
+///
+/// core's network and keyring I/O is built on blocking clients (reqwest
+/// blocking, ssh2, keyring). Calling those inline from a tokio worker
+/// doesn't just stall the runtime — dropping a blocking reqwest client in
+/// async context panics with "Cannot drop a runtime in a context where
+/// blocking is not allowed". Every handler that can reach core network or
+/// keyring paths must go through here (`test_storage` already did).
+pub(crate) async fn run_core_blocking<T, F>(task: F) -> Result<T, ApiError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(task)
+        .await
+        .map_err(|error| ApiError::internal(format!("Blocking task failed: {error}")))
+}
+
 pub(crate) fn load_config_or_default() -> AppConfig {
     load_config().unwrap_or_default()
 }

--- a/crates/gpt-image-2-web/src/support.rs
+++ b/crates/gpt-image-2-web/src/support.rs
@@ -8,12 +8,17 @@ pub(crate) fn app_error(error: gpt_image_2_core::AppError) -> String {
 
 /// Run a synchronous core operation on the blocking pool.
 ///
-/// core's network and keyring I/O is built on blocking clients (reqwest
-/// blocking, ssh2, keyring). Calling those inline from a tokio worker
-/// doesn't just stall the runtime — dropping a blocking reqwest client in
-/// async context panics with "Cannot drop a runtime in a context where
-/// blocking is not allowed". Every handler that can reach core network or
-/// keyring paths must go through here (`test_storage` already did).
+/// core's network I/O is built on blocking reqwest (and ssh2). Calling it
+/// inline from a tokio worker doesn't just stall the runtime — dropping a
+/// blocking reqwest client in async context panics with "Cannot drop a
+/// runtime in a context where blocking is not allowed". Every async handler
+/// that can reach a core network path must go through here (`test_storage`
+/// already did).
+///
+/// Scope: this addresses the reqwest-drop panic only. Keyring reads (config
+/// redaction's `present` probe, credential reveal) also block, but on
+/// dbus/libsecret rather than reqwest, so they stall a worker without
+/// panicking; moving those off-thread is a separate, lower-severity change.
 pub(crate) async fn run_core_blocking<T, F>(task: F) -> Result<T, ApiError>
 where
     F: FnOnce() -> T + Send + 'static,


### PR DESCRIPTION
## 问题（来自 Rust 后端审查，已实测复现）

core 的网络/keyring I/O 全部基于阻塞客户端（reqwest blocking、ssh2）。在 tokio worker 上内联调用它们不只是卡住 runtime——**在 async 上下文里 drop 一个 blocking reqwest client 会 panic**：`Cannot drop a runtime in a context where blocking is not allowed`。多个 web/tauri handler 一旦触及网络就会崩。

## 改动

**Web（新增 `run_core_blocking` helper 包 `spawn_blocking`）**：
- `provider_test`（doctor → 阻塞可达性探测）
- `test_notifications` + `cancel_job`（webhook 派发 → 阻塞 POST）
- `job_output_response`（storage readback → 阻塞 GET）
- `resume_job` 的 continue_save / fill_missing / reupload / discard（provider + storage 阻塞）
- `resubmit` 保持 async（retry_job 只入队，非阻塞）
- `test_storage` 本来就用了 spawn_blocking，这次把它推广成统一 helper

**Tauri**：
- `copy_image_to_clipboard`（async command）的 readback + image 解码改到 `async_runtime::spawn_blocking`
- 其余同步 command（`ensure_job_output_cached`、`provider_test`、`test_notifications`、`resume_job`）本就安全——Tauri 在 blocking 线程池跑同步 command

**core SFTP**：`connect_timeout`(30s) + `session.set_timeout`(120s，对齐 HTTP 系后端)。此前 blackhole 的 SFTP 服务器会永久挂住上传 worker，任务卡在 "uploading"。

## 验证

- `cargo clippy --workspace --all-targets` 0 告警；`cargo test --workspace` 149 全绿
- **本地运行 web server 实测**：`POST /api/providers/openai/test` 返回 HTTP 200，响应里 `reachable:true / status:405,404 / latency_ms:685`——阻塞式 HTTPS 可达性探测真实执行（对 chatgpt.com、api.openai.com 发了真请求）并正常返回，服务日志无 panic。这正是审查指出会 panic 的"测试凭证"路径。