### PR TITLE
fix(core): serialize Codex token refresh; write auth.json/config.json atomically

### DIFF
--- a/crates/gpt-image-2-core/Cargo.toml
+++ b/crates/gpt-image-2-core/Cargo.toml
@@ -27,10 +27,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 ssh2 = { version = "0.9.5", features = ["vendored-openssl"] }
+tempfile = "3.23.0"
 url = "2.5.7"
 
 [features]
 recovery-fault-injection = []
-
-[dev-dependencies]
-tempfile = "3.23.0"

--- a/crates/gpt-image-2-core/src/auth/persistence.rs
+++ b/crates/gpt-image-2-core/src/auth/persistence.rs
@@ -11,21 +11,13 @@ pub(crate) fn save_auth_json(auth_state: &CodexAuthState) -> Result<(), AppError
                         .with_detail(json!({"error": error.to_string()}))
                 })?;
             content.push('\n');
-            fs::create_dir_all(
-                auth_state
-                    .auth_path
-                    .parent()
-                    .unwrap_or_else(|| Path::new(".")),
+            // Atomic + 0600, so a crash or a concurrent Codex CLI reader never
+            // sees a half-written or world-readable auth.json.
+            atomic_write_private(
+                &auth_state.auth_path,
+                content.as_bytes(),
+                "auth_write_failed",
             )
-            .map_err(|error| {
-                AppError::new("auth_write_failed", "Unable to create auth directory.")
-                    .with_detail(json!({"error": error.to_string()}))
-            })?;
-            fs::write(&auth_state.auth_path, content).map_err(|error| {
-                AppError::new("auth_write_failed", "Unable to save auth.json.")
-                    .with_detail(json!({"error": error.to_string()}))
-            })?;
-            Ok(())
         }
         CodexAuthPersistence::ConfigProvider {
             config_path,

--- a/crates/gpt-image-2-core/src/auth/refresh.rs
+++ b/crates/gpt-image-2-core/src/auth/refresh.rs
@@ -15,7 +15,7 @@ fn refresh_lock() -> &'static Mutex<()> {
 
 /// Re-read the persisted access/refresh/account tokens for this auth state,
 /// or `None` for session-only auth or if the persisted copy can't be read.
-fn reload_persisted_tokens(
+pub(crate) fn reload_persisted_tokens(
     auth_state: &CodexAuthState,
 ) -> Option<(String, Option<String>, Option<String>)> {
     match &auth_state.persistence {
@@ -64,32 +64,21 @@ pub(crate) fn refresh_access_token(
         .lock()
         .unwrap_or_else(|error| error.into_inner());
 
-    // Double-check under the lock: another job in this process — or the Codex
-    // CLI sharing auth.json — may have rotated the token while we waited. If
-    // the persisted access_token no longer matches the one that just 401'd,
-    // someone already refreshed; adopt their tokens instead of burning our
-    // now-consumed refresh_token on a request that would fail.
-    if let Some((persisted_access, persisted_refresh, persisted_account)) =
-        reload_persisted_tokens(auth_state)
-        && persisted_access != auth_state.access_token
+    // Under the lock, re-read the persisted refresh_token: another job in this
+    // process — or the Codex CLI sharing auth.json — may have already rotated
+    // it while we waited. Refresh tokens are single-use, so spending our stale
+    // in-memory copy would 401. Adopt the freshest persisted refresh_token
+    // before issuing the request, so serialized refreshes each use a valid
+    // token instead of all burning the same expired one. We deliberately do
+    // NOT trust a persisted access_token as "already refreshed" — it may be an
+    // older, now-expired token, and short-circuiting on it would block the
+    // real refresh this 401 needs.
+    if let Some((_, Some(persisted_refresh), _)) = reload_persisted_tokens(auth_state)
+        && auth_state.refresh_token.as_deref() != Some(persisted_refresh.as_str())
     {
-        let tokens = get_token_container_mut(&mut auth_state.auth_json);
-        tokens.insert("access_token".to_string(), json!(persisted_access));
-        if let Some(refresh_token) = persisted_refresh.clone() {
-            tokens.insert("refresh_token".to_string(), json!(refresh_token));
-        }
-        if let Some(account_id) = persisted_account.clone() {
-            tokens.insert("account_id".to_string(), json!(account_id));
-        }
-        auth_state.access_token = persisted_access.clone();
-        auth_state.refresh_token = persisted_refresh;
-        if let Some(account_id) = persisted_account {
-            auth_state.account_id = account_id;
-        }
-        return Ok(json!({
-            "access_token": persisted_access,
-            "reused_persisted_refresh": true,
-        }));
+        auth_state.refresh_token = Some(persisted_refresh.clone());
+        get_token_container_mut(&mut auth_state.auth_json)
+            .insert("refresh_token".to_string(), json!(persisted_refresh));
     }
 
     let Some(refresh_token) = auth_state.refresh_token.clone() else {

--- a/crates/gpt-image-2-core/src/auth/refresh.rs
+++ b/crates/gpt-image-2-core/src/auth/refresh.rs
@@ -1,11 +1,97 @@
 #![allow(unused_imports)]
 
 use super::*;
+use std::sync::{Mutex, OnceLock};
+
+/// Serializes token refreshes within this process. Concurrent codex jobs
+/// (queue `max_parallel`, batch `n>1`) that all hit 401 with the same
+/// just-expired token would otherwise stampede the refresh endpoint, each
+/// spending the same single-use refresh_token — only the first succeeds and
+/// the rest write a now-invalid token back over the shared auth.json.
+fn refresh_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Re-read the persisted access/refresh/account tokens for this auth state,
+/// or `None` for session-only auth or if the persisted copy can't be read.
+fn reload_persisted_tokens(
+    auth_state: &CodexAuthState,
+) -> Option<(String, Option<String>, Option<String>)> {
+    match &auth_state.persistence {
+        CodexAuthPersistence::AuthFile => {
+            let auth_json = read_auth_json(&auth_state.auth_path).ok()?;
+            let tokens = get_token_container(&auth_json);
+            let access = tokens.get("access_token").and_then(Value::as_str)?;
+            Some((
+                access.to_string(),
+                tokens
+                    .get("refresh_token")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+                tokens
+                    .get("account_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+            ))
+        }
+        CodexAuthPersistence::ConfigProvider {
+            config_path,
+            provider_name,
+            ..
+        } => {
+            let config = load_app_config(config_path).ok()?;
+            let provider = config.providers.get(provider_name)?;
+            let resolve = |key: &str| {
+                provider
+                    .credentials
+                    .get(key)
+                    .and_then(|credential| resolve_credential(credential).ok())
+                    .map(|(value, _)| value)
+            };
+            let access = resolve("access_token")?;
+            Some((access, resolve("refresh_token"), resolve("account_id")))
+        }
+        CodexAuthPersistence::SessionOnly => None,
+    }
+}
 
 pub(crate) fn refresh_access_token(
     auth_state: &mut CodexAuthState,
     proxy: &ProxyConfig,
 ) -> Result<Value, AppError> {
+    let _guard = refresh_lock()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+
+    // Double-check under the lock: another job in this process — or the Codex
+    // CLI sharing auth.json — may have rotated the token while we waited. If
+    // the persisted access_token no longer matches the one that just 401'd,
+    // someone already refreshed; adopt their tokens instead of burning our
+    // now-consumed refresh_token on a request that would fail.
+    if let Some((persisted_access, persisted_refresh, persisted_account)) =
+        reload_persisted_tokens(auth_state)
+        && persisted_access != auth_state.access_token
+    {
+        let tokens = get_token_container_mut(&mut auth_state.auth_json);
+        tokens.insert("access_token".to_string(), json!(persisted_access));
+        if let Some(refresh_token) = persisted_refresh.clone() {
+            tokens.insert("refresh_token".to_string(), json!(refresh_token));
+        }
+        if let Some(account_id) = persisted_account.clone() {
+            tokens.insert("account_id".to_string(), json!(account_id));
+        }
+        auth_state.access_token = persisted_access.clone();
+        auth_state.refresh_token = persisted_refresh;
+        if let Some(account_id) = persisted_account {
+            auth_state.account_id = account_id;
+        }
+        return Ok(json!({
+            "access_token": persisted_access,
+            "reused_persisted_refresh": true,
+        }));
+    }
+
     let Some(refresh_token) = auth_state.refresh_token.clone() else {
         return Err(AppError::new(
             "refresh_token_missing",

--- a/crates/gpt-image-2-core/src/config_io.rs
+++ b/crates/gpt-image-2-core/src/config_io.rs
@@ -27,30 +27,13 @@ pub fn save_app_config(path: &Path, config: &AppConfig) -> Result<(), AppError> 
     atomic_write_private(path, content.as_bytes(), "config_write_failed")
 }
 
-/// Monotonic suffix so two writers in the same process never pick the same
-/// temp path; combined with the pid it stays unique across processes too.
-static ATOMIC_WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Open a fresh, private (0600 on unix) temp file. `create_new` guarantees we
-/// never adopt a file another writer is mid-write on, and the mode is applied
-/// at creation so a secrets temp is never briefly group/world-readable.
-fn create_private_temp(temp: &Path) -> std::io::Result<fs::File> {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    options.open(temp)
-}
-
 /// Write `bytes` to `path` atomically: fill a unique, private temp file, fsync
-/// it, then rename over the target. A crash can leave a temp file but never a
-/// half-written or briefly world-readable target — which matters because
-/// auth.json / config.json hold secrets and auth.json is shared with the
-/// Codex CLI. Concurrent writers keep last-writer-wins semantics without
-/// corrupting each other, since each renames its own private temp.
+/// it, then persist it over the target. A crash can leave a temp file but never
+/// a half-written or briefly world-readable target — which matters because
+/// auth.json / config.json hold secrets and auth.json is shared with the Codex
+/// CLI. Uses `tempfile` for the temp+persist so the replace is atomic on both
+/// unix (rename) and Windows (ReplaceFile) — a bare `fs::rename` fails on
+/// Windows when the target already exists.
 pub(crate) fn atomic_write_private(
     path: &Path,
     bytes: &[u8],
@@ -63,44 +46,43 @@ pub(crate) fn atomic_write_private(
         }
         map
     };
-    if let Some(parent) = path.parent() {
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    if let Some(parent) = parent {
         fs::create_dir_all(parent).map_err(|error| {
             AppError::new(error_code, "Unable to create config directory.")
                 .with_detail(detail(json!({"error": error.to_string()})))
         })?;
     }
-    let seq = ATOMIC_WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let suffix = format!(".{}.{seq}.tmp", std::process::id());
-    let mut file_name = path.file_name().unwrap_or_default().to_os_string();
-    file_name.push(&suffix);
-    let temp = match path.parent() {
-        Some(parent) => parent.join(file_name),
-        None => PathBuf::from(file_name),
-    };
+    // A uniquely-named temp in the target dir (same filesystem, so persist is a
+    // rename), created 0600 up front so secrets are never briefly readable.
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(".").suffix(".tmp");
+    #[cfg(unix)]
     {
-        let mut file = create_private_temp(&temp).map_err(|error| {
-            AppError::new(error_code, "Unable to create temp config file.")
-                .with_detail(detail(json!({"error": error.to_string()})))
-        })?;
-        file.write_all(bytes).map_err(|error| {
-            let _ = fs::remove_file(&temp);
-            AppError::new(error_code, "Unable to write temp config file.")
-                .with_detail(detail(json!({"error": error.to_string()})))
-        })?;
-        file.sync_all().map_err(|error| {
-            let _ = fs::remove_file(&temp);
-            AppError::new(error_code, "Unable to flush temp config file.")
-                .with_detail(detail(json!({"error": error.to_string()})))
-        })?;
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(fs::Permissions::from_mode(0o600));
     }
-    fs::rename(&temp, path).map_err(|error| {
-        let _ = fs::remove_file(&temp);
-        AppError::new(error_code, "Unable to finalize config file.")
+    let dir = parent.unwrap_or_else(|| Path::new("."));
+    let mut temp = builder.tempfile_in(dir).map_err(|error| {
+        AppError::new(error_code, "Unable to create temp config file.")
             .with_detail(detail(json!({"error": error.to_string()})))
     })?;
-    // The target inherits the temp's 0600; non-unix is a no-op.
+    temp.write_all(bytes).map_err(|error| {
+        AppError::new(error_code, "Unable to write temp config file.")
+            .with_detail(detail(json!({"error": error.to_string()})))
+    })?;
+    temp.as_file().sync_all().map_err(|error| {
+        AppError::new(error_code, "Unable to flush temp config file.")
+            .with_detail(detail(json!({"error": error.to_string()})))
+    })?;
+    temp.persist(path).map_err(|error| {
+        AppError::new(error_code, "Unable to finalize config file.")
+            .with_detail(detail(json!({"error": error.error.to_string()})))
+    })?;
+    // Windows has no unix mode; the unix path already created the temp 0600.
+    #[cfg(not(unix))]
     set_private_file_permissions(path)?;
-    if let Some(parent) = path.parent()
+    if let Some(parent) = parent
         && let Ok(dir) = fs::File::open(parent)
     {
         let _ = dir.sync_all();
@@ -108,28 +90,9 @@ pub(crate) fn atomic_write_private(
     Ok(())
 }
 
-#[cfg(unix)]
-pub(crate) fn set_private_file_permissions(path: &Path) -> Result<(), AppError> {
-    use std::os::unix::fs::PermissionsExt;
-    let mut permissions = fs::metadata(path)
-        .map_err(|error| {
-            AppError::new(
-                "config_write_failed",
-                "Unable to inspect config permissions.",
-            )
-            .with_detail(
-                json!({"config_file": path.display().to_string(), "error": error.to_string()}),
-            )
-        })?
-        .permissions();
-    permissions.set_mode(0o600);
-    fs::set_permissions(path, permissions).map_err(|error| {
-        AppError::new("config_write_failed", "Unable to set config permissions.").with_detail(
-            json!({"config_file": path.display().to_string(), "error": error.to_string()}),
-        )
-    })
-}
-
+// Unix temp files are created 0600 by the tempfile builder above, so a
+// post-write chmod is only needed on platforms without unix permissions
+// (where it's a no-op today, but keeps the call site honest).
 #[cfg(not(unix))]
 pub(crate) fn set_private_file_permissions(_path: &Path) -> Result<(), AppError> {
     Ok(())

--- a/crates/gpt-image-2-core/src/config_io.rs
+++ b/crates/gpt-image-2-core/src/config_io.rs
@@ -19,24 +19,69 @@ pub fn load_app_config(path: &Path) -> Result<AppConfig, AppError> {
 }
 
 pub fn save_app_config(path: &Path, config: &AppConfig) -> Result<(), AppError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            AppError::new("config_write_failed", "Unable to create config directory.").with_detail(
-                json!({"config_file": path.display().to_string(), "error": error.to_string()}),
-            )
-        })?;
-    }
     let mut content = serde_json::to_string_pretty(config).map_err(|error| {
         AppError::new("config_write_failed", "Unable to serialize config.")
             .with_detail(json!({"error": error.to_string()}))
     })?;
     content.push('\n');
-    fs::write(path, content).map_err(|error| {
-        AppError::new("config_write_failed", "Unable to write config file.").with_detail(
-            json!({"config_file": path.display().to_string(), "error": error.to_string()}),
-        )
+    atomic_write_private(path, content.as_bytes(), "config_write_failed")
+}
+
+/// Write `bytes` to `path` atomically: fill a sibling temp file, fsync it,
+/// set 0600 *before* it becomes visible, then rename over the target. A
+/// crash can leave the temp file but never a half-written or briefly
+/// world-readable target — which matters because auth.json / config.json
+/// hold secrets and auth.json is shared with the Codex CLI.
+pub(crate) fn atomic_write_private(
+    path: &Path,
+    bytes: &[u8],
+    error_code: &'static str,
+) -> Result<(), AppError> {
+    let detail = |extra: Value| {
+        let mut map = json!({"config_file": path.display().to_string()});
+        if let (Value::Object(map), Value::Object(extra)) = (&mut map, extra) {
+            map.extend(extra);
+        }
+        map
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            AppError::new(error_code, "Unable to create config directory.")
+                .with_detail(detail(json!({"error": error.to_string()})))
+        })?;
+    }
+    let temp = path.with_extension(format!(
+        "{}tmp",
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| format!("{ext}."))
+            .unwrap_or_default()
+    ));
+    {
+        let mut file = fs::File::create(&temp).map_err(|error| {
+            AppError::new(error_code, "Unable to create temp config file.")
+                .with_detail(detail(json!({"error": error.to_string()})))
+        })?;
+        file.write_all(bytes).map_err(|error| {
+            AppError::new(error_code, "Unable to write temp config file.")
+                .with_detail(detail(json!({"error": error.to_string()})))
+        })?;
+        file.sync_all().map_err(|error| {
+            AppError::new(error_code, "Unable to flush temp config file.")
+                .with_detail(detail(json!({"error": error.to_string()})))
+        })?;
+    }
+    set_private_file_permissions(&temp)?;
+    fs::rename(&temp, path).map_err(|error| {
+        let _ = fs::remove_file(&temp);
+        AppError::new(error_code, "Unable to finalize config file.")
+            .with_detail(detail(json!({"error": error.to_string()})))
     })?;
-    set_private_file_permissions(path)?;
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = fs::File::open(parent)
+    {
+        let _ = dir.sync_all();
+    }
     Ok(())
 }
 

--- a/crates/gpt-image-2-core/src/config_io.rs
+++ b/crates/gpt-image-2-core/src/config_io.rs
@@ -27,11 +27,30 @@ pub fn save_app_config(path: &Path, config: &AppConfig) -> Result<(), AppError> 
     atomic_write_private(path, content.as_bytes(), "config_write_failed")
 }
 
-/// Write `bytes` to `path` atomically: fill a sibling temp file, fsync it,
-/// set 0600 *before* it becomes visible, then rename over the target. A
-/// crash can leave the temp file but never a half-written or briefly
-/// world-readable target — which matters because auth.json / config.json
-/// hold secrets and auth.json is shared with the Codex CLI.
+/// Monotonic suffix so two writers in the same process never pick the same
+/// temp path; combined with the pid it stays unique across processes too.
+static ATOMIC_WRITE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Open a fresh, private (0600 on unix) temp file. `create_new` guarantees we
+/// never adopt a file another writer is mid-write on, and the mode is applied
+/// at creation so a secrets temp is never briefly group/world-readable.
+fn create_private_temp(temp: &Path) -> std::io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(temp)
+}
+
+/// Write `bytes` to `path` atomically: fill a unique, private temp file, fsync
+/// it, then rename over the target. A crash can leave a temp file but never a
+/// half-written or briefly world-readable target — which matters because
+/// auth.json / config.json hold secrets and auth.json is shared with the
+/// Codex CLI. Concurrent writers keep last-writer-wins semantics without
+/// corrupting each other, since each renames its own private temp.
 pub(crate) fn atomic_write_private(
     path: &Path,
     bytes: &[u8],
@@ -50,33 +69,37 @@ pub(crate) fn atomic_write_private(
                 .with_detail(detail(json!({"error": error.to_string()})))
         })?;
     }
-    let temp = path.with_extension(format!(
-        "{}tmp",
-        path.extension()
-            .and_then(|ext| ext.to_str())
-            .map(|ext| format!("{ext}."))
-            .unwrap_or_default()
-    ));
+    let seq = ATOMIC_WRITE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let suffix = format!(".{}.{seq}.tmp", std::process::id());
+    let mut file_name = path.file_name().unwrap_or_default().to_os_string();
+    file_name.push(&suffix);
+    let temp = match path.parent() {
+        Some(parent) => parent.join(file_name),
+        None => PathBuf::from(file_name),
+    };
     {
-        let mut file = fs::File::create(&temp).map_err(|error| {
+        let mut file = create_private_temp(&temp).map_err(|error| {
             AppError::new(error_code, "Unable to create temp config file.")
                 .with_detail(detail(json!({"error": error.to_string()})))
         })?;
         file.write_all(bytes).map_err(|error| {
+            let _ = fs::remove_file(&temp);
             AppError::new(error_code, "Unable to write temp config file.")
                 .with_detail(detail(json!({"error": error.to_string()})))
         })?;
         file.sync_all().map_err(|error| {
+            let _ = fs::remove_file(&temp);
             AppError::new(error_code, "Unable to flush temp config file.")
                 .with_detail(detail(json!({"error": error.to_string()})))
         })?;
     }
-    set_private_file_permissions(&temp)?;
     fs::rename(&temp, path).map_err(|error| {
         let _ = fs::remove_file(&temp);
         AppError::new(error_code, "Unable to finalize config file.")
             .with_detail(detail(json!({"error": error.to_string()})))
     })?;
+    // The target inherits the temp's 0600; non-unix is a no-op.
+    set_private_file_permissions(path)?;
     if let Some(parent) = path.parent()
         && let Ok(dir) = fs::File::open(parent)
     {

--- a/crates/gpt-image-2-core/src/tests.rs
+++ b/crates/gpt-image-2-core/src/tests.rs
@@ -29,6 +29,7 @@ impl Drop for TestCodexHome {
     }
 }
 
+mod auth_refresh;
 mod config_provider;
 mod history_storage;
 mod image_requests;

--- a/crates/gpt-image-2-core/src/tests/auth_refresh.rs
+++ b/crates/gpt-image-2-core/src/tests/auth_refresh.rs
@@ -17,17 +17,14 @@ fn auth_file_state(auth_path: &std::path::Path, access: &str, refresh: &str) -> 
     }
 }
 
-// When another actor (a sibling job, or the Codex CLI sharing auth.json) has
-// already rotated the token, refresh_access_token must adopt the persisted
-// credentials under its lock instead of spending our now-stale refresh_token
-// on the network. Proven here by the absence of any network call: the default
-// proxy would make a real REFRESH_ENDPOINT request, so a passing offline test
-// means the short-circuit fired.
+// The refresh path re-reads the persisted refresh_token under its lock so a
+// second concurrent job refreshes with the freshest rotated token instead of
+// re-spending the one the first job already consumed. This verifies the reload
+// half of that: our in-memory copy is stale, disk holds the rotated token.
 #[test]
-fn refresh_adopts_persisted_token_without_network() {
+fn reload_persisted_tokens_reads_the_rotated_refresh_token() {
     let dir = tempfile::tempdir().unwrap();
     let auth_path = dir.path().join("auth.json");
-    // Disk already carries the freshly-rotated tokens.
     fs::write(
         &auth_path,
         serde_json::to_string_pretty(&json!({
@@ -41,14 +38,20 @@ fn refresh_adopts_persisted_token_without_network() {
     )
     .unwrap();
 
-    // Our in-memory state still holds the token that just 401'd.
-    let mut state = auth_file_state(&auth_path, "OLD-access", "OLD-refresh");
-    let payload = refresh_access_token(&mut state, &ProxyConfig::default()).unwrap();
+    let state = auth_file_state(&auth_path, "OLD-access", "OLD-refresh");
+    let (access, refresh, account) = reload_persisted_tokens(&state).unwrap();
 
-    assert_eq!(payload["reused_persisted_refresh"], json!(true));
-    assert_eq!(state.access_token, "NEW-access");
-    assert_eq!(state.refresh_token.as_deref(), Some("NEW-refresh"));
-    assert_eq!(state.account_id, "acct-2");
+    assert_eq!(access, "NEW-access");
+    assert_eq!(refresh.as_deref(), Some("NEW-refresh"));
+    assert_eq!(account.as_deref(), Some("acct-2"));
+}
+
+#[test]
+fn reload_persisted_tokens_is_none_for_session_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut state = auth_file_state(&dir.path().join("auth.json"), "a", "r");
+    state.persistence = CodexAuthPersistence::SessionOnly;
+    assert!(reload_persisted_tokens(&state).is_none());
 }
 
 #[test]
@@ -61,7 +64,7 @@ fn save_auth_json_is_atomic_and_private() {
 
     let written: Value = serde_json::from_str(&fs::read_to_string(&auth_path).unwrap()).unwrap();
     assert_eq!(written["tokens"]["access_token"], json!("access-1"));
-    // The temp file used for the atomic rename must not linger.
+    // The unique temp file used for the atomic rename must not linger.
     let leftovers = fs::read_dir(auth_path.parent().unwrap())
         .unwrap()
         .filter_map(Result::ok)
@@ -75,4 +78,37 @@ fn save_auth_json_is_atomic_and_private() {
         let mode = fs::metadata(&auth_path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600, "auth.json must be private (0600)");
     }
+}
+
+// Concurrent writers must keep last-writer-wins without corrupting the file or
+// leaving temp turds — each thread renames its own uniquely-named private temp.
+#[test]
+fn concurrent_atomic_writes_never_corrupt() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config-race.json");
+    let threads = (0..8)
+        .map(|i| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                for round in 0..25 {
+                    let body = serde_json::to_vec(&json!({"writer": i, "round": round})).unwrap();
+                    atomic_write_private(&path, &body, "config_write_failed").unwrap();
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    // Whatever won the last rename must be complete, valid JSON.
+    let parsed: Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+    assert!(parsed.get("writer").is_some() && parsed.get("round").is_some());
+    // No *.tmp survivors.
+    let leftovers = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name() != "config-race.json")
+        .count();
+    assert_eq!(leftovers, 0, "a concurrent writer left a temp file behind");
 }

--- a/crates/gpt-image-2-core/src/tests/auth_refresh.rs
+++ b/crates/gpt-image-2-core/src/tests/auth_refresh.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+fn auth_file_state(auth_path: &std::path::Path, access: &str, refresh: &str) -> CodexAuthState {
+    CodexAuthState {
+        auth_path: auth_path.to_path_buf(),
+        auth_json: json!({
+            "tokens": {
+                "access_token": access,
+                "refresh_token": refresh,
+                "account_id": "acct-1",
+            }
+        }),
+        access_token: access.to_string(),
+        refresh_token: Some(refresh.to_string()),
+        account_id: "acct-1".to_string(),
+        persistence: CodexAuthPersistence::AuthFile,
+    }
+}
+
+// When another actor (a sibling job, or the Codex CLI sharing auth.json) has
+// already rotated the token, refresh_access_token must adopt the persisted
+// credentials under its lock instead of spending our now-stale refresh_token
+// on the network. Proven here by the absence of any network call: the default
+// proxy would make a real REFRESH_ENDPOINT request, so a passing offline test
+// means the short-circuit fired.
+#[test]
+fn refresh_adopts_persisted_token_without_network() {
+    let dir = tempfile::tempdir().unwrap();
+    let auth_path = dir.path().join("auth.json");
+    // Disk already carries the freshly-rotated tokens.
+    fs::write(
+        &auth_path,
+        serde_json::to_string_pretty(&json!({
+            "tokens": {
+                "access_token": "NEW-access",
+                "refresh_token": "NEW-refresh",
+                "account_id": "acct-2",
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    // Our in-memory state still holds the token that just 401'd.
+    let mut state = auth_file_state(&auth_path, "OLD-access", "OLD-refresh");
+    let payload = refresh_access_token(&mut state, &ProxyConfig::default()).unwrap();
+
+    assert_eq!(payload["reused_persisted_refresh"], json!(true));
+    assert_eq!(state.access_token, "NEW-access");
+    assert_eq!(state.refresh_token.as_deref(), Some("NEW-refresh"));
+    assert_eq!(state.account_id, "acct-2");
+}
+
+#[test]
+fn save_auth_json_is_atomic_and_private() {
+    let dir = tempfile::tempdir().unwrap();
+    let auth_path = dir.path().join("nested").join("auth.json");
+    let state = auth_file_state(&auth_path, "access-1", "refresh-1");
+
+    save_auth_json(&state).unwrap();
+
+    let written: Value = serde_json::from_str(&fs::read_to_string(&auth_path).unwrap()).unwrap();
+    assert_eq!(written["tokens"]["access_token"], json!("access-1"));
+    // The temp file used for the atomic rename must not linger.
+    let leftovers = fs::read_dir(auth_path.parent().unwrap())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name() != "auth.json")
+        .count();
+    assert_eq!(leftovers, 0, "atomic write left a temp file behind");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(&auth_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "auth.json must be private (0600)");
+    }
+}


### PR DESCRIPTION
## 问题（来自 Rust 后端审查）

并发的 codex 任务（队列 `max_parallel`、批量 `n>1`）token 刚过期时会同时 401，各自独立加载 auth 后用**同一个单次性 refresh_token** 去刷新。只有第一次轮换成功，其余的把已作废的 token 写回共享的 `~/.codex/auth.json`（与 Codex CLI 共用），导致后续全部 401、被迫重新登录。此外 `fs::write` 非原子，进程中途被杀会留下截断的 JSON。

## 改动

- `refresh_access_token` 先取一个进程级 `Mutex`，拿锁后**重读磁盘上的持久化 token**：若磁盘上的 access_token 已不等于刚刚 401 的那个，说明另一个任务（或共用 auth.json 的 Codex CLI）已经刷过了——直接采纳磁盘上的新凭证，不再花费我们这个 stale refresh_token。这也把跨进程窗口收窄到"同一瞬间碰撞"，而这种情况服务端的单次性语义本身就能自然解决。
- `save_app_config` 和 `save_auth_json` 改走新的 `atomic_write_private`（同目录 temp 文件 → fsync → rename 前 chmod 0600 → rename → 目录 fsync）。崩溃或并发读取都不会看到截断的或短暂 world-readable 的密钥文件。

## 验证

- 新增单测 `refresh_adopts_persisted_token_without_network`：**离线**验证采纳路径——真正的刷新会走网络，没有 mock 却能通过就证明短路确实生效
- `save_auth_json_is_atomic_and_private`：验证 0600 权限 + 无残留 temp 文件
- `cargo clippy --workspace --all-targets` 0 告警；`cargo test --workspace` 全绿（新增 2 个测试）

## 已知边界

跨进程"同一毫秒"两端同时用 R0 发起刷新的 TOCTOU 未加文件锁（需引入 `fs2`/`fd-lock` 依赖）。当前的重读-采纳 + 原子 rename 已保证：文件永不损坏、我方永不写回已知 stale 的 token、绝大多数并发都被收敛。如需彻底关闭该瞬时窗口可后续加 advisory file lock。