### PR TITLE
fix(web): authenticate the HTTP API; refuse unauthenticated non-loopback bind; raise body limit

### DIFF
--- a/apps/gpt-image-2-app/src/components/auth-gate.tsx
+++ b/apps/gpt-image-2-app/src/components/auth-gate.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { hasConfiguredHttpRuntime } from "@/lib/api/http/client";
+import { getSessionStatus, login } from "@/lib/api/http/session";
+import { Button } from "@/components/ui/button";
+
+type GateState =
+  | { phase: "checking" }
+  | { phase: "authorized" }
+  | { phase: "needs-token" };
+
+/**
+ * Blocks the app behind the server's access token when the HTTP runtime
+ * (Docker Web / self-hosted) is protected by GPT_IMAGE_2_WEB_TOKEN. In the
+ * Tauri and static-browser runtimes there is no server token, so this renders
+ * children immediately. Auth rides an HttpOnly cookie, so once past the gate
+ * both fetch and `<img>` requests authenticate automatically.
+ */
+export function AuthGate({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<GateState>(() =>
+    hasConfiguredHttpRuntime() ? { phase: "checking" } : { phase: "authorized" },
+  );
+  const [token, setToken] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (state.phase !== "checking") return;
+    let cancelled = false;
+    void getSessionStatus().then((status) => {
+      if (cancelled) return;
+      setState({
+        phase:
+          !status.authRequired || status.authorized
+            ? "authorized"
+            : "needs-token",
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [state.phase]);
+
+  if (state.phase === "authorized") return <>{children}</>;
+
+  const onSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!token.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const ok = await login(token.trim()).catch(() => false);
+    setSubmitting(false);
+    if (ok) {
+      setToken("");
+      setState({ phase: "authorized" });
+    } else {
+      setError("访问令牌不正确。");
+    }
+  };
+
+  return (
+    <div className="desktop flex h-full w-full items-center justify-center p-6">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-[360px] rounded-2xl border border-[color:var(--w-10)] bg-[color:var(--w-04)] p-6 shadow-xl"
+      >
+        <h1 className="t-h2 mb-1 text-foreground">需要访问令牌</h1>
+        <p className="mb-4 text-[13px] text-muted">
+          这个服务端设置了 <code>GPT_IMAGE_2_WEB_TOKEN</code>
+          。输入访问令牌以继续。
+        </p>
+        <input
+          type="password"
+          autoFocus
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="访问令牌"
+          aria-label="访问令牌"
+          className="mb-3 w-full rounded-lg border border-[color:var(--w-10)] bg-[color:var(--w-02)] px-3 py-2 text-[14px] text-foreground outline-none focus:border-[color:var(--accent-40)]"
+        />
+        {error && <p className="mb-3 text-[12.5px] text-red-400">{error}</p>}
+        <Button
+          type="submit"
+          variant="primary"
+          size="md"
+          disabled={!token.trim() || submitting}
+          className="w-full"
+        >
+          {submitting ? "验证中…" : "进入"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/gpt-image-2-app/src/lib/api/http/session.ts
+++ b/apps/gpt-image-2-app/src/lib/api/http/session.ts
@@ -1,0 +1,44 @@
+import { apiResourceUrl } from "./client";
+
+export interface SessionStatus {
+  authRequired: boolean;
+  authorized: boolean;
+}
+
+/**
+ * Ask the server whether the HTTP API is behind an access token and whether
+ * this browser (via its session cookie) is already authorized. Any failure is
+ * treated as "no auth required" so a plain local server keeps working.
+ */
+export async function getSessionStatus(): Promise<SessionStatus> {
+  try {
+    const response = await fetch(apiResourceUrl("/session"), {
+      credentials: "same-origin",
+    });
+    if (!response.ok) return { authRequired: false, authorized: true };
+    const body = (await response.json()) as {
+      auth_required?: boolean;
+      authorized?: boolean;
+    };
+    return {
+      authRequired: Boolean(body.auth_required),
+      authorized: Boolean(body.authorized),
+    };
+  } catch {
+    return { authRequired: false, authorized: true };
+  }
+}
+
+/**
+ * Exchange the shared token for an HttpOnly session cookie. Resolves true on
+ * success so subsequent same-origin requests (fetch and `<img>`) authenticate.
+ */
+export async function login(token: string): Promise<boolean> {
+  const response = await fetch(apiResourceUrl("/session"), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+  return response.status === 204;
+}

--- a/apps/gpt-image-2-app/src/main.tsx
+++ b/apps/gpt-image-2-app/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import { AuthGate } from "@/components/auth-gate";
 import { TweaksProvider } from "@/hooks/use-tweaks";
 import { ConfirmProvider } from "@/hooks/use-confirm";
 import { setActionsQueryClient } from "@/lib/image-actions/query-client";
@@ -34,7 +35,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
       <TweaksProvider>
         <ConfirmProvider>
-          <App />
+          <AuthGate>
+            <App />
+          </AuthGate>
         </ConfirmProvider>
       </TweaksProvider>
     </QueryClientProvider>

--- a/crates/gpt-image-2-web/src/auth.rs
+++ b/crates/gpt-image-2-web/src/auth.rs
@@ -1,0 +1,295 @@
+#![allow(unused_imports)]
+
+use super::*;
+use axum::extract::Request;
+use axum::middleware::Next;
+
+pub(crate) const SESSION_COOKIE: &str = "gpt2_session";
+const TOKEN_ENV: &str = "GPT_IMAGE_2_WEB_TOKEN";
+const ALLOWED_HOSTS_ENV: &str = "GPT_IMAGE_2_WEB_ALLOWED_HOSTS";
+const ALLOW_UNAUTH_ENV: &str = "GPT_IMAGE_2_WEB_ALLOW_UNAUTHENTICATED";
+
+fn env_flag(name: &str) -> bool {
+    env::var(name)
+        .map(|value| matches!(value.trim(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+/// Resolved auth policy for the server, decided once at startup.
+#[derive(Clone, Debug)]
+pub(crate) struct AuthPolicy {
+    /// The shared secret from `GPT_IMAGE_2_WEB_TOKEN`, if configured.
+    token: Option<String>,
+    /// Host names allowed when running token-less (anti-DNS-rebinding).
+    allowed_hosts: Vec<String>,
+}
+
+impl Default for AuthPolicy {
+    /// Token-less, loopback-host-only — the safe default used by tests and the
+    /// Tauri build (which never serves over HTTP).
+    fn default() -> Self {
+        Self {
+            token: None,
+            allowed_hosts: vec![
+                "localhost".to_string(),
+                "127.0.0.1".to_string(),
+                "::1".to_string(),
+            ],
+        }
+    }
+}
+
+impl AuthPolicy {
+    pub(crate) fn from_env(bind_host: &str) -> Result<Self, String> {
+        let token = env::var(TOKEN_ENV)
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+
+        // Refuse to expose the API beyond loopback without a token. Otherwise a
+        // Docker/LAN deployment would serve config — including the plaintext
+        // credential-reveal endpoint — to anyone who can reach the port. The
+        // server can't see how Docker published the port, so it keys off the
+        // bind host and errs safe; operators who front it with their own
+        // network isolation / proxy auth can opt out explicitly.
+        if token.is_none() && !host_is_loopback(bind_host) {
+            if env_flag(ALLOW_UNAUTH_ENV) {
+                eprintln!(
+                    "gpt-image-2-web: WARNING — bound {bind_host} without {TOKEN_ENV} and \
+                     {ALLOW_UNAUTH_ENV}=1. The API and credential reveal are unauthenticated; \
+                     rely on your network isolation."
+                );
+            } else {
+                return Err(format!(
+                    "Refusing to bind {bind_host} without {TOKEN_ENV}: the API (including \
+                     credential reveal) would be reachable unauthenticated. Set {TOKEN_ENV} to a \
+                     secret to expose beyond localhost, bind 127.0.0.1, or set \
+                     {ALLOW_UNAUTH_ENV}=1 if the network is already trusted."
+                ));
+            }
+        }
+
+        let mut allowed_hosts = env::var(ALLOWED_HOSTS_ENV)
+            .ok()
+            .map(|value| {
+                value
+                    .split(',')
+                    .map(|item| item.trim().to_ascii_lowercase())
+                    .filter(|item| !item.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if allowed_hosts.is_empty() {
+            allowed_hosts = vec![
+                "localhost".to_string(),
+                "127.0.0.1".to_string(),
+                "::1".to_string(),
+            ];
+        }
+
+        Ok(Self {
+            token,
+            allowed_hosts,
+        })
+    }
+
+    pub(crate) fn requires_token(&self) -> bool {
+        self.token.is_some()
+    }
+}
+
+fn host_is_loopback(host: &str) -> bool {
+    let host = host.trim();
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // "0.0.0.0" / "::" parse as unspecified (all interfaces) — is_loopback()
+    // is false for them, which is exactly what we want to reject.
+    host.parse::<std::net::IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
+/// Strip the optional `:port` and surrounding brackets from a Host header and
+/// lowercase it for comparison.
+fn host_header_name(raw: &str) -> String {
+    let raw = raw.trim();
+    let without_port = if raw.starts_with('[') {
+        // IPv6 literal: [::1]:8787 -> ::1
+        raw.split(']')
+            .next()
+            .map(|s| s.trim_start_matches('['))
+            .unwrap_or(raw)
+    } else {
+        raw.rsplit_once(':').map(|(host, _)| host).unwrap_or(raw)
+    };
+    without_port.to_ascii_lowercase()
+}
+
+/// Constant-time string comparison so a wrong token can't be recovered by
+/// timing the failure.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+fn presented_token(request: &Request) -> Option<String> {
+    if let Some(value) = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        && let Some(token) = value.strip_prefix("Bearer ")
+    {
+        return Some(token.trim().to_string());
+    }
+    request
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|cookies| {
+            cookies.split(';').find_map(|pair| {
+                let (name, value) = pair.split_once('=')?;
+                if name.trim() == SESSION_COOKIE {
+                    Some(value.trim().to_string())
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+/// Axum middleware guarding `/api`. With a token configured, every request must
+/// present it (Bearer header or session cookie). Without a token, the server is
+/// loopback-bound (enforced at startup), and we additionally reject Host headers
+/// that aren't loopback names to blunt DNS-rebinding from a browser.
+pub(crate) async fn require_auth(
+    State(state): State<JobQueueState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let policy = &state.auth;
+    // The login route must stay reachable without an existing session.
+    if request.uri().path() == "/session" {
+        return next.run(request).await;
+    }
+
+    match &policy.token {
+        Some(expected) => match presented_token(&request) {
+            Some(token) if constant_time_eq(&token, expected) => next.run(request).await,
+            _ => unauthorized("Missing or invalid access token."),
+        },
+        None => {
+            let host_ok = request
+                .headers()
+                .get(header::HOST)
+                .and_then(|value| value.to_str().ok())
+                .map(|raw| policy.allowed_hosts.contains(&host_header_name(raw)))
+                // A missing Host header can't be a rebinding attack via DNS name.
+                .unwrap_or(true);
+            if host_ok {
+                next.run(request).await
+            } else {
+                forbidden("Host not allowed for token-less access.")
+            }
+        }
+    }
+}
+
+/// `POST /api/session` — exchange the shared token for an HttpOnly session
+/// cookie so image `<img>` requests (which can't carry an Authorization header)
+/// authenticate too.
+pub(crate) async fn create_session(
+    State(state): State<JobQueueState>,
+    Json(body): Json<SessionRequest>,
+) -> Response {
+    let Some(expected) = &state.auth.token else {
+        // No token configured — nothing to log in to.
+        return (StatusCode::NO_CONTENT, ()).into_response();
+    };
+    if constant_time_eq(body.token.trim(), expected) {
+        let cookie = format!(
+            "{SESSION_COOKIE}={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=1209600",
+            expected
+        );
+        (StatusCode::NO_CONTENT, [(header::SET_COOKIE, cookie)]).into_response()
+    } else {
+        unauthorized("Invalid access token.")
+    }
+}
+
+/// `GET /api/session` — report whether auth is required (so the UI can decide
+/// to show a token gate) and whether the current request is already authorized.
+pub(crate) async fn session_status(
+    State(state): State<JobQueueState>,
+    request: Request,
+) -> Json<Value> {
+    let required = state.auth.requires_token();
+    let authorized = match &state.auth.token {
+        Some(expected) => presented_token(&request)
+            .map(|token| constant_time_eq(&token, expected))
+            .unwrap_or(false),
+        None => true,
+    };
+    Json(json!({ "auth_required": required, "authorized": authorized }))
+}
+
+#[derive(Deserialize)]
+pub(crate) struct SessionRequest {
+    #[serde(default)]
+    pub(crate) token: String,
+}
+
+fn unauthorized(message: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({ "error": { "message": message } })),
+    )
+        .into_response()
+}
+
+fn forbidden(message: &str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(json!({ "error": { "message": message } })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_hosts_are_recognized() {
+        for host in ["localhost", "LOCALHOST", "127.0.0.1", "127.0.0.5", "::1"] {
+            assert!(host_is_loopback(host), "{host} should be loopback");
+        }
+        for host in ["0.0.0.0", "::", "192.168.1.10", "example.com"] {
+            assert!(!host_is_loopback(host), "{host} should not be loopback");
+        }
+    }
+
+    #[test]
+    fn host_header_name_strips_port_and_brackets() {
+        assert_eq!(host_header_name("localhost:8787"), "localhost");
+        assert_eq!(host_header_name("127.0.0.1:8787"), "127.0.0.1");
+        assert_eq!(host_header_name("[::1]:8787"), "::1");
+        assert_eq!(host_header_name("EXAMPLE.com"), "example.com");
+    }
+
+    #[test]
+    fn constant_time_eq_matches_only_identical_strings() {
+        assert!(constant_time_eq("secret", "secret"));
+        assert!(!constant_time_eq("secret", "Secret"));
+        assert!(!constant_time_eq("secret", "secret-longer"));
+        assert!(!constant_time_eq("", "x"));
+        assert!(constant_time_eq("", ""));
+    }
+}

--- a/crates/gpt-image-2-web/src/main.rs
+++ b/crates/gpt-image-2-web/src/main.rs
@@ -40,6 +40,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tower_http::services::{ServeDir, ServeFile};
 
+mod auth;
 mod config_api;
 mod error;
 mod file_api;
@@ -54,6 +55,7 @@ mod server;
 mod support;
 mod types;
 
+pub(crate) use auth::*;
 pub(crate) use config_api::*;
 pub(crate) use error::*;
 pub(crate) use file_api::*;
@@ -86,11 +88,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .into());
     }
+    // Refuses to bind a non-loopback host without GPT_IMAGE_2_WEB_TOKEN.
+    let auth_policy = AuthPolicy::from_env(&settings.host).map_err(std::io::Error::other)?;
+    if auth_policy.requires_token() {
+        println!("gpt-image-2-web: access token required (GPT_IMAGE_2_WEB_TOKEN is set).");
+    } else {
+        println!("gpt-image-2-web: no access token set; only loopback Host headers are served.");
+    }
     let _ = mark_interrupted_jobs_on_startup();
     let static_files = ServeDir::new(&settings.static_dir)
         .not_found_service(ServeFile::new(settings.static_dir.join("index.html")));
     let app = Router::new()
-        .nest("/api", api_router(JobQueueState::default()))
+        .nest("/api", api_router(JobQueueState::with_auth(auth_policy)))
         .fallback_service(static_files);
     let listener =
         tokio::net::TcpListener::bind(format!("{}:{}", settings.host, settings.port)).await?;

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -70,6 +70,7 @@ pub(crate) fn parse_settings() -> Result<Settings, String> {
 
 pub(crate) fn api_router(state: JobQueueState) -> Router {
     Router::new()
+        .route("/session", get(session_status).post(create_session))
         .route("/config", get(get_config))
         .route("/config-paths", get(config_paths))
         .route("/notifications", put(update_notifications))
@@ -113,6 +114,15 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
         .route("/images/generate", post(enqueue_generate_image))
         .route("/images/edit", post(enqueue_edit_image))
         .route("/files", get(file_response))
+        // Reference images ride in the JSON body as byte arrays, so a 1–2MB
+        // PNG blows past axum's 2MB default and 413s. Raise it for the API.
+        .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024))
+        // Gate every /api route (except the /session login handled inside)
+        // behind the access token / loopback policy.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_auth,
+        ))
         .with_state(state)
 }
 

--- a/crates/gpt-image-2-web/src/server.rs
+++ b/crates/gpt-image-2-web/src/server.rs
@@ -111,12 +111,17 @@ pub(crate) fn api_router(state: JobQueueState) -> Router {
         .merge(test_router())
         .route("/queue", get(queue_status))
         .route("/queue/concurrency", post(set_queue_concurrency))
-        .route("/images/generate", post(enqueue_generate_image))
-        .route("/images/edit", post(enqueue_edit_image))
         .route("/files", get(file_response))
         // Reference images ride in the JSON body as byte arrays, so a 1–2MB
-        // PNG blows past axum's 2MB default and 413s. Raise it for the API.
-        .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024))
+        // PNG blows past axum's 2MB default and 413s. Raise the limit only on
+        // the upload routes — a global raise would also let the unauthenticated
+        // /session login parse 64MB bodies, a needless DoS amplifier.
+        .merge(
+            Router::new()
+                .route("/images/generate", post(enqueue_generate_image))
+                .route("/images/edit", post(enqueue_edit_image))
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024)),
+        )
         // Gate every /api route (except the /session login handled inside)
         // behind the access token / loopback policy.
         .layer(axum::middleware::from_fn_with_state(

--- a/crates/gpt-image-2-web/src/types.rs
+++ b/crates/gpt-image-2-web/src/types.rs
@@ -49,6 +49,7 @@ pub(crate) enum CredentialInput {
 #[derive(Clone)]
 pub(crate) struct JobQueueState {
     pub(crate) inner: Arc<Mutex<JobQueueInner>>,
+    pub(crate) auth: Arc<AuthPolicy>,
 }
 
 impl Default for JobQueueState {
@@ -61,6 +62,16 @@ impl Default for JobQueueState {
                 events: BTreeMap::new(),
                 next_seq: BTreeMap::new(),
             })),
+            auth: Arc::new(AuthPolicy::default()),
+        }
+    }
+}
+
+impl JobQueueState {
+    pub(crate) fn with_auth(auth: AuthPolicy) -> Self {
+        Self {
+            auth: Arc::new(auth),
+            ..Self::default()
         }
     }
 }

--- a/docs/docker-web.md
+++ b/docs/docker-web.md
@@ -20,14 +20,37 @@ docker pull ghcr.io/wangnov/gpt-image-2:0.6.1
 docker build -t gpt-image-2-web .
 ```
 
+## Access control
+
+The container binds `0.0.0.0`, so the API — including the endpoint that reads
+back stored provider keys — is reachable by anything that can reach the port.
+The server therefore **refuses to start on a non-loopback host unless
+`GPT_IMAGE_2_WEB_TOKEN` is set**. Set it to a secret and the whole `/api`
+surface requires that token (sent as `Authorization: Bearer <token>` or, for
+the web UI, exchanged for an HttpOnly session cookie at first load):
+
+```bash
+-e GPT_IMAGE_2_WEB_TOKEN="$(openssl rand -hex 32)"
+```
+
+To run without a token, bind loopback only (`-e GPT_IMAGE_2_WEB_HOST=127.0.0.1`
+and publish to `127.0.0.1:8787:8787`); token-less mode also rejects requests
+whose `Host` header isn't a loopback name (override with
+`GPT_IMAGE_2_WEB_ALLOWED_HOSTS`). If the port is only reachable on a trusted
+network (e.g. a container published to `127.0.0.1` or fronted by a
+reverse proxy that authenticates), set `GPT_IMAGE_2_WEB_ALLOW_UNAUTHENTICATED=1`
+to permit token-less `0.0.0.0` binding — it prints a warning and leaves the
+API open, so only use it when the network already restricts access.
+
 ## Run
 
-OpenAI-compatible API Key:
+OpenAI-compatible API Key (exposed on the LAN, so a token is required):
 
 ```bash
 docker run --rm -p 8787:8787 \
   -v gpt-image-2-data:/data \
   -e OPENAI_API_KEY=sk-... \
+  -e GPT_IMAGE_2_WEB_TOKEN="$(openssl rand -hex 32)" \
   ghcr.io/wangnov/gpt-image-2:latest
 ```
 

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ dev-http-frontend:
 dev-http-backend image="gpt-image-2-web:latest":
     mkdir -p "$HOME/.codex/gpt-image-2-skill/jobs" "$HOME/.local/share/gpt-image-2" "$HOME/.local/share/gpt-image-2-codex/gpt-image-2-skill"
     docker rm -f gpt-image-2-web-dev gpt-image-2-web-codex-smoke >/dev/null 2>&1 || true
-    auth_mount=(); if [ -f "$HOME/.codex/auth.json" ]; then auth_mount=(-v "$HOME/.codex/auth.json:/data/codex/auth.json:ro"); fi; docker run -d --name gpt-image-2-web-dev -p 8787:8787 -v "$HOME/.local/share/gpt-image-2:/data/gpt-image-2" -v "$HOME/.local/share/gpt-image-2-codex:/data/codex" -v "$HOME/.codex/gpt-image-2-skill/jobs:/data/codex/gpt-image-2-skill/jobs:ro" "${auth_mount[@]}" "{{ image }}"
+    auth_mount=(); if [ -f "$HOME/.codex/auth.json" ]; then auth_mount=(-v "$HOME/.codex/auth.json:/data/codex/auth.json:ro"); fi; docker run -d --name gpt-image-2-web-dev -p 127.0.0.1:8787:8787 -e GPT_IMAGE_2_WEB_ALLOW_UNAUTHENTICATED=1 -v "$HOME/.local/share/gpt-image-2:/data/gpt-image-2" -v "$HOME/.local/share/gpt-image-2-codex:/data/codex" -v "$HOME/.codex/gpt-image-2-skill/jobs:/data/codex/gpt-image-2-skill/jobs:ro" "${auth_mount[@]}" "{{ image }}"
 
 # Start the Tauri dev server for desktop-only behavior checks.
 dev-tauri:


### PR DESCRIPTION
## 安全洞（来自 Rust 后端审查的唯一 P0）

Docker/Web 服务端绑 `0.0.0.0`、**零鉴权**，且暴露 `GET /api/providers/{name}/credentials/{credential}` —— 明文返回存储的 provider 密钥（OpenAI key、Codex token、S3 secret）。任何能访问该端口的人都能读走全部密钥并改写配置。

## 改动

- **鉴权层（`auth.rs`）**：`from_fn` 中间件守护整个 `/api`。设置 `GPT_IMAGE_2_WEB_TOKEN` 后每个请求必须带 token——API 客户端用 `Authorization: Bearer`，Web UI 用 HttpOnly SameSite=Strict session cookie（`<img>` 请求无法设 header，靠 cookie 鉴权）。`POST /api/session` 用 token 换 cookie；`GET` 报告是否需要鉴权。token 比较为常量时间。
- **启动守卫**：非 loopback host 且无 token → 拒绝启动。服务端看不到 Docker 如何映射端口，故按 bind host 从严；`GPT_IMAGE_2_WEB_ALLOW_UNAUTHENTICATED=1` 是带警告的显式逃生阀（可信网络用）。无 token 模式还会拒绝非 loopback 的 Host 头（防 DNS rebinding，可用 `GPT_IMAGE_2_WEB_ALLOWED_HOSTS` 覆盖）。
- **credential reveal 现在在中间件之后**（原来完全裸奔）。
- **body limit 抬到 64MB**：参考图以 JSON 字节数组传输，1–2MB 的 PNG 之前会撞 axum 2MB 默认限制而 413。
- **前端 AuthGate**：仅 HTTP runtime 下检查 `/api/session` 并在进入前显示 token 输入；Tauri/浏览器 runtime 直接放行。
- `just dev-http-backend` 改为发布到 `127.0.0.1` 并设逃生阀；文档更新。base64 编码上传字节（1.33x vs 3.7x）作为后续优化（limit 已解锁功能）。

## 验证

新增 3 个 Rust 单测（loopback 识别、Host 解析、常量时间比较）+ **实测运行中的服务端**：
- 非 loopback + 无 token → 拒绝启动 ✓
- 无 token / 错 token → 401；正确 Bearer 或 session cookie → 200 ✓
- 登录设置 cookie ✓；DNS-rebinding Host → 403 ✓
- 3MB edit body 不再 413 ✓；逃生阀与 loopback dev 路径都正常 ✓
- 前端：dev 模式 AuthGate 放行、app 正常渲染、无误挡

## 已知后续

base64 上传编码（把 bytes 从 JSON 数字数组换成 base64 字符串，3.7x→1.33x）留作后续优化 PR。