### PR TITLE
refactor(core): unify S3 SigV4 signing, migrate history schema once, drop upload clones

### DIFF
--- a/crates/gpt-image-2-core/src/history_db.rs
+++ b/crates/gpt-image-2-core/src/history_db.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, params};
@@ -46,6 +48,28 @@ pub(crate) fn open_history_db() -> Result<Connection, AppError> {
             )
             .with_detail(json!({"error": error.to_string()}))
         })?;
+    ensure_history_schema(&conn, &path)?;
+    Ok(conn)
+}
+
+/// Run the CREATE TABLE / INDEX / ALTER migrations once per database path for
+/// the life of the process. They're all idempotent, but running the full set
+/// on every `open_history_db()` — i.e. every queue write — is wasted work. The
+/// path key keeps tests that point at different databases correct; the lock is
+/// held across the first migration so only the first opener of each path pays.
+fn ensure_history_schema(conn: &Connection, path: &Path) -> Result<(), AppError> {
+    static MIGRATED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    let migrated = MIGRATED.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut guard = migrated.lock().unwrap_or_else(|error| error.into_inner());
+    if guard.contains(path) {
+        return Ok(());
+    }
+    run_history_migrations(conn)?;
+    guard.insert(path.to_path_buf());
+    Ok(())
+}
+
+fn run_history_migrations(conn: &Connection) -> Result<(), AppError> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS jobs (
             id TEXT PRIMARY KEY,
@@ -180,7 +204,7 @@ pub(crate) fn open_history_db() -> Result<Connection, AppError> {
         )
         .with_detail(json!({"error": error.to_string()}))
     })?;
-    Ok(conn)
+    Ok(())
 }
 
 pub(crate) fn record_history_job(
@@ -250,32 +274,36 @@ pub fn upsert_history_job(
 
 pub fn delete_history_job(job_id: &str) -> Result<usize, AppError> {
     // This only deletes local SQLite history. Remote Origin/Archive objects
-    // referenced by output_uploads stay untouched by design.
-    let conn = open_history_db()?;
-    conn.execute("DELETE FROM job_events WHERE job_id = ?1", params![job_id])
-        .map_err(|error| {
-            AppError::new(
-                "history_delete_failed",
-                "Unable to delete job event history.",
-            )
+    // referenced by output_uploads stay untouched by design. All three table
+    // deletes run in one transaction so a crash can't leave a job row without
+    // its events/uploads or vice versa.
+    let mut conn = open_history_db()?;
+    let tx = conn.transaction().map_err(|error| {
+        AppError::new("history_delete_failed", "Unable to delete history job.")
             .with_detail(json!({"error": error.to_string()}))
-        })?;
-    conn.execute(
+    })?;
+    let delete_err = |error: rusqlite::Error, message: &str| {
+        AppError::new("history_delete_failed", message.to_string())
+            .with_detail(json!({"error": error.to_string()}))
+    };
+    tx.execute("DELETE FROM job_events WHERE job_id = ?1", params![job_id])
+        .map_err(|error| delete_err(error, "Unable to delete job event history."))?;
+    tx.execute(
         "DELETE FROM output_uploads WHERE job_id = ?1",
         params![job_id],
     )
-    .map_err(|error| {
+    .map_err(|error| delete_err(error, "Unable to delete output upload history."))?;
+    let removed = tx
+        .execute("DELETE FROM jobs WHERE id = ?1", params![job_id])
+        .map_err(|error| delete_err(error, "Unable to delete history job."))?;
+    tx.commit().map_err(|error| {
         AppError::new(
             "history_delete_failed",
-            "Unable to delete output upload history.",
+            "Unable to commit history deletion.",
         )
         .with_detail(json!({"error": error.to_string()}))
     })?;
-    conn.execute("DELETE FROM jobs WHERE id = ?1", params![job_id])
-        .map_err(|error| {
-            AppError::new("history_delete_failed", "Unable to delete history job.")
-                .with_detail(json!({"error": error.to_string()}))
-        })
+    Ok(removed)
 }
 
 pub fn append_history_job_event(job_id: &str, event: &Value) -> Result<u64, AppError> {

--- a/crates/gpt-image-2-core/src/storage/backends/http.rs
+++ b/crates/gpt-image-2-core/src/storage/backends/http.rs
@@ -31,7 +31,10 @@ pub(super) fn upload_to_http(
     })?;
     let mime = mime_guess::from_path(&output.path).first_or_octet_stream();
     let file_name = output_file_name(output);
-    let part = Part::bytes(bytes.clone())
+    // Length before the buffer moves into the multipart part — avoids cloning
+    // the whole file just to report its size later.
+    let bytes_len = bytes.len() as u64;
+    let part = Part::bytes(bytes)
         .file_name(file_name.clone())
         .mime_str(mime.as_ref())
         .map_err(|error| {
@@ -91,7 +94,7 @@ pub(super) fn upload_to_http(
         http_url_if_safe(json_pointer_string(&response_json, public_url_json_pointer));
     Ok(StorageUploadOutcome {
         url: extracted_url,
-        bytes: Some(bytes.len() as u64),
+        bytes: Some(bytes_len),
         metadata: json!({
             "http_status": status.as_u16(),
             "url_from_response": public_url_json_pointer

--- a/crates/gpt-image-2-core/src/storage/backends/s3.rs
+++ b/crates/gpt-image-2-core/src/storage/backends/s3.rs
@@ -53,6 +53,54 @@ fn s3_signing_key(secret_access_key: &str, date: &str, region: &str) -> Result<V
     hmac_sha256(&service_key, "aws4_request")
 }
 
+/// Build the SigV4 `Authorization` header for an S3 request. Shared by
+/// upload/download/head, which previously each open-coded the identical
+/// canonical-request → string-to-sign → signature chain. `content_type` is
+/// `Some` only for uploads (it joins the signed headers); the caller still
+/// sets the matching request headers.
+#[allow(clippy::too_many_arguments)]
+fn sign_s3_request(
+    method: &str,
+    canonical_uri: &str,
+    host: &str,
+    content_type: Option<&str>,
+    payload_hash: &str,
+    session_token: Option<&str>,
+    amz_date: &str,
+    short_date: &str,
+    region: &str,
+    access_key_id: &str,
+    secret_access_key: &str,
+) -> Result<String, AppError> {
+    let mut canonical_headers = String::new();
+    let mut signed_headers = String::new();
+    if let Some(content_type) = content_type {
+        canonical_headers.push_str(&format!("content-type:{content_type}\n"));
+        signed_headers.push_str("content-type;");
+    }
+    canonical_headers.push_str(&format!(
+        "host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
+    ));
+    signed_headers.push_str("host;x-amz-content-sha256;x-amz-date");
+    if let Some(token) = session_token {
+        canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
+        signed_headers.push_str(";x-amz-security-token");
+    }
+    let canonical_request = format!(
+        "{method}\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+    let credential_scope = format!("{short_date}/{region}/s3/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+    let signing_key = s3_signing_key(secret_access_key, short_date, region)?;
+    let signature = hex_lower(&hmac_sha256(&signing_key, &string_to_sign)?);
+    Ok(format!(
+        "AWS4-HMAC-SHA256 Credential={access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    ))
+}
+
 pub(super) fn upload_to_s3(
     target: &StorageTargetConfig,
     job_id: &str,
@@ -130,26 +178,19 @@ pub(super) fn upload_to_s3(
     let content_type = mime_guess::from_path(&output.path)
         .first_or_octet_stream()
         .to_string();
-    let mut canonical_headers = format!(
-        "content-type:{content_type}\nhost:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n"
-    );
-    let mut signed_headers = "content-type;host;x-amz-content-sha256;x-amz-date".to_string();
-    if let Some(token) = &session_token {
-        canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
-        signed_headers.push_str(";x-amz-security-token");
-    }
-    let canonical_request =
-        format!("PUT\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
-    let credential_scope = format!("{short_date}/{signing_region}/s3/aws4_request");
-    let string_to_sign = format!(
-        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
-        sha256_hex(canonical_request.as_bytes())
-    );
-    let signing_key = s3_signing_key(&secret_access_key, &short_date, signing_region)?;
-    let signature = hex_lower(&hmac_sha256(&signing_key, &string_to_sign)?);
-    let authorization = format!(
-        "AWS4-HMAC-SHA256 Credential={access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
-    );
+    let authorization = sign_s3_request(
+        "PUT",
+        &canonical_uri,
+        &host,
+        Some(&content_type),
+        &payload_hash,
+        session_token.as_deref(),
+        &amz_date,
+        &short_date,
+        signing_region,
+        &access_key_id,
+        &secret_access_key,
+    )?;
     let client = pinned_http_client(
         &host_label,
         &addrs,
@@ -157,6 +198,9 @@ pub(super) fn upload_to_s3(
         "storage_s3_client_failed",
         "Unable to build S3 storage client.",
     )?;
+    // Capture the length before moving the buffer into the request body, so a
+    // 4K PNG isn't cloned in full just to report its size afterwards.
+    let bytes_len = bytes.len() as u64;
     let mut request = client
         .put(&url)
         .header("Host", host.clone())
@@ -164,7 +208,7 @@ pub(super) fn upload_to_s3(
         .header("x-amz-content-sha256", payload_hash)
         .header("x-amz-date", amz_date)
         .header(AUTHORIZATION, authorization)
-        .body(bytes.clone());
+        .body(bytes);
     if let Some(token) = session_token {
         request = request.header("x-amz-security-token", token);
     }
@@ -197,7 +241,7 @@ pub(super) fn upload_to_s3(
                 .as_deref()
                 .map(|base| join_storage_url(base, &key)),
         ),
-        bytes: Some(bytes.len() as u64),
+        bytes: Some(bytes_len),
         metadata: json!({
             "bucket": bucket,
             "key": key,
@@ -272,25 +316,19 @@ pub(super) fn download_from_s3(
     let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
     let short_date = now.format("%Y%m%d").to_string();
     let payload_hash = sha256_hex(b"");
-    let mut canonical_headers =
-        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
-    let mut signed_headers = "host;x-amz-content-sha256;x-amz-date".to_string();
-    if let Some(token) = &session_token {
-        canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
-        signed_headers.push_str(";x-amz-security-token");
-    }
-    let canonical_request =
-        format!("GET\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
-    let credential_scope = format!("{short_date}/{signing_region}/s3/aws4_request");
-    let string_to_sign = format!(
-        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
-        sha256_hex(canonical_request.as_bytes())
-    );
-    let signing_key = s3_signing_key(&secret_access_key, &short_date, signing_region)?;
-    let signature = hex_lower(&hmac_sha256(&signing_key, &string_to_sign)?);
-    let authorization = format!(
-        "AWS4-HMAC-SHA256 Credential={access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
-    );
+    let authorization = sign_s3_request(
+        "GET",
+        &canonical_uri,
+        &host,
+        None,
+        &payload_hash,
+        session_token.as_deref(),
+        &amz_date,
+        &short_date,
+        signing_region,
+        &access_key_id,
+        &secret_access_key,
+    )?;
     let client = pinned_http_client(
         &host_label,
         &addrs,
@@ -407,25 +445,19 @@ pub(super) fn head_s3(
     let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
     let short_date = now.format("%Y%m%d").to_string();
     let payload_hash = sha256_hex(b"");
-    let mut canonical_headers =
-        format!("host:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n");
-    let mut signed_headers = "host;x-amz-content-sha256;x-amz-date".to_string();
-    if let Some(token) = &session_token {
-        canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
-        signed_headers.push_str(";x-amz-security-token");
-    }
-    let canonical_request =
-        format!("HEAD\n{canonical_uri}\n\n{canonical_headers}\n{signed_headers}\n{payload_hash}");
-    let credential_scope = format!("{short_date}/{signing_region}/s3/aws4_request");
-    let string_to_sign = format!(
-        "AWS4-HMAC-SHA256\n{amz_date}\n{credential_scope}\n{}",
-        sha256_hex(canonical_request.as_bytes())
-    );
-    let signing_key = s3_signing_key(&secret_access_key, &short_date, signing_region)?;
-    let signature = hex_lower(&hmac_sha256(&signing_key, &string_to_sign)?);
-    let authorization = format!(
-        "AWS4-HMAC-SHA256 Credential={access_key_id}/{credential_scope}, SignedHeaders={signed_headers}, Signature={signature}"
-    );
+    let authorization = sign_s3_request(
+        "HEAD",
+        &canonical_uri,
+        &host,
+        None,
+        &payload_hash,
+        session_token.as_deref(),
+        &amz_date,
+        &short_date,
+        signing_region,
+        &access_key_id,
+        &secret_access_key,
+    )?;
     let client = pinned_http_client(
         &host_label,
         &addrs,
@@ -476,4 +508,61 @@ pub(super) fn head_s3(
             "http_status": status.as_u16(),
         }),
     })
+}
+
+#[cfg(test)]
+mod sigv4_tests {
+    use super::*;
+
+    // Golden SigV4 signatures for fixed inputs, so the shared signer can't
+    // drift the canonical request out from under upload/download/head. The
+    // upload variant includes content-type in the signed headers; the read
+    // variants don't.
+    #[test]
+    fn upload_signature_is_stable() {
+        let auth = sign_s3_request(
+            "PUT",
+            "/bucket/key.png",
+            "bucket.s3.amazonaws.com",
+            Some("image/png"),
+            "abc123",
+            None,
+            "20240101T000000Z",
+            "20240101",
+            "us-east-1",
+            "AKIDEXAMPLE",
+            "SECRET",
+        )
+        .unwrap();
+        assert_eq!(
+            auth,
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, \
+             Signature=de01a32b1bf10b70013a186737622e6553a35552437b45e0499c402923c5b5a3"
+        );
+    }
+
+    #[test]
+    fn download_signature_is_stable() {
+        let auth = sign_s3_request(
+            "GET",
+            "/bucket/key.png",
+            "bucket.s3.amazonaws.com",
+            None,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            Some("session-tok"),
+            "20240101T000000Z",
+            "20240101",
+            "us-east-1",
+            "AKIDEXAMPLE",
+            "SECRET",
+        )
+        .unwrap();
+        assert_eq!(
+            auth,
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20240101/us-east-1/s3/aws4_request, \
+             SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, \
+             Signature=fcd31ac6b956c8359694375a374ca6a28535954d5e053c0ce3a209e97999b8cf"
+        );
+    }
 }


### PR DESCRIPTION
## 改动（来自 Rust 后端审查的中优先级项）

- **S3 SigV4 去重**：`upload_to_s3`、`download_from_s3`、`head_s3` 各自 open-code 了同一段约 20 行的 canonical-request → string-to-sign → signature 链。提炼单个 `sign_s3_request()`。**Golden 测试锁定** upload（含 content-type）和 download（含 session-token）两个变体的精确 Authorization 输出，防止共享签名器漂移导致 S3 请求签名失败。
- **history_db migration 一次化**：`open_history_db()` 之前每次调用（即每次队列写入）都重跑全套 CREATE TABLE/INDEX + ALTER。改为按 db path 用 `OnceLock<Mutex<HashSet>>` 守卫只跑一次（per-path 以保测试正确），仍每次开新连接带 pragmas。
- **delete_history_job 事务**：三张表的 DELETE 包进一个事务，崩溃不会留下没有 events/uploads 的孤儿 job 行。
- **上传路径去 clone**：s3/http 后端在把 buffer move 进请求体前先取 `bytes.len()`，不再为事后报告大小整份 clone 文件（4K PNG 可 20MB+）。

## 验证

- `cargo clippy --workspace --all-targets` 0 告警；`cargo test --workspace` 154 全绿（新增 2 个 SigV4 golden 测试 + 既有 22 个 history 测试保护 migration/delete 改动）
- S3 签名重构逐字节保持不变（golden 测试用固定输入断言完整 Authorization 字符串）

## 说明

`orchestrator.rs` 的 manifest sha256 会再读一次文件——消除它需要跨各 backend 回传 hash（S3 算了 sha256 但 http/local/webdav/sftp 没有），较侵入，留作后续。SSRF 对齐、tauri path token、value_code 容错等安全加固项将在单独的 PR8b 提交。