### PR TITLE
fix(core,app): harden reference-image downloads, delete commands, and netdisk status parsing

### DIFF
--- a/apps/gpt-image-2-app/src-tauri/src/file_access.rs
+++ b/apps/gpt-image-2-app/src-tauri/src/file_access.rs
@@ -103,8 +103,22 @@ pub(crate) async fn copy_image_to_clipboard(
     Ok(())
 }
 
+/// Reject a job id that isn't a single, normal path segment before it's joined
+/// onto a library/trash root. A webview XSS could otherwise pass `../../…` to
+/// the delete/restore commands and `fs::rename`/`remove_dir_all` an arbitrary
+/// directory. Job ids are opaque generated tokens, so a legit one is always a
+/// single component.
+fn safe_job_segment(job_id: &str) -> Result<(), String> {
+    let mut components = std::path::Path::new(job_id).components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(part)), None) if part == job_id => Ok(()),
+        _ => Err("非法的任务 ID。".to_string()),
+    }
+}
+
 #[tauri::command]
 pub(crate) fn soft_delete_job(job_id: String) -> Result<(), String> {
+    safe_job_segment(&job_id)?;
     // This flow only moves local result-library files into local trash and
     // marks the local history row. Remote Origin/Archive objects are never
     // deleted implicitly.
@@ -126,6 +140,7 @@ pub(crate) fn soft_delete_job(job_id: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) fn restore_deleted_job(job_id: String) -> Result<(), String> {
+    safe_job_segment(&job_id)?;
     let trash_path = jobs_trash_dir().join(&job_id);
     if trash_path.exists() {
         let dest = result_library_dir().join(&job_id);
@@ -140,6 +155,7 @@ pub(crate) fn restore_deleted_job(job_id: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) fn hard_delete_job(job_id: String) -> Result<(), String> {
+    safe_job_segment(&job_id)?;
     // Hard delete is still local-only: remove local trash/cache plus the DB
     // row, but leave any uploaded Origin/Archive objects intact.
     let trash_path = jobs_trash_dir().join(&job_id);
@@ -196,4 +212,22 @@ pub(crate) fn spawn_trash_cleanup_worker() {
             thread::sleep(std::time::Duration::from_secs(60));
         }
     });
+}
+
+#[cfg(test)]
+mod safe_job_segment_tests {
+    use super::safe_job_segment;
+
+    #[test]
+    fn accepts_plain_job_ids() {
+        assert!(safe_job_segment("job-20240101-abcdef").is_ok());
+        assert!(safe_job_segment("a1b2c3").is_ok());
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_separators() {
+        for bad in ["..", ".", "", "../secret", "a/b", "/abs", "a/../b", "."] {
+            assert!(safe_job_segment(bad).is_err(), "{bad:?} should be rejected");
+        }
+    }
 }

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -223,7 +223,10 @@ fn download_http_image_bytes(url: &str, proxy: Option<&ProxyConfig>) -> Result<V
             .user_agent(build_user_agent());
         let client = match proxy {
             Some(proxy) => apply_proxy(builder, proxy)?,
-            None => builder,
+            // Explicitly disable proxies for the untrusted path: reqwest
+            // otherwise auto-detects HTTP(S)_PROXY from the environment, which
+            // would let the proxy resolve the host and defeat the address pin.
+            None => builder.no_proxy(),
         }
         .build()
         .map_err(|error| {

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -149,24 +149,57 @@ pub(crate) fn parse_data_url_image(value: &str) -> Result<(String, Vec<u8>), App
     Ok((mime_type, decode_base64_bytes(encoded)?))
 }
 
+/// Reference images fetched from a URL are capped so a hostile or accidental
+/// giant response can't exhaust memory. 64MB comfortably covers any real image.
+const MAX_REMOTE_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
+
 pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
+    // Redact query strings from anything we log — reference URLs can carry
+    // signed tokens.
+    let redacted = redact_url_for_log(url);
+    // SSRF guard: on a direct connection, reject URLs that resolve to
+    // loopback/link-local/private ranges (e.g. the cloud metadata service).
+    // A custom proxy is the user's explicit egress, so we trust it to police
+    // its own targets rather than validating a host it, not we, will resolve.
+    if proxy.mode != ProxyMode::Custom {
+        validate_remote_http_target(url, "Reference image")?;
+    }
     let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
     let response = client.get(url).send().map_err(|error| {
         AppError::new("network_error", "Unable to download image bytes.")
-            .with_detail(json!({ "error": error.to_string(), "url": url }))
+            .with_detail(json!({ "error": error.to_string(), "url": redacted }))
     })?;
     if !response.status().is_success() {
         let status = response.status();
         let detail = response.text().unwrap_or_else(|_| String::new());
         return Err(http_status_error(status, detail));
     }
-    response
-        .bytes()
-        .map(|bytes| bytes.to_vec())
-        .map_err(|error| {
-            AppError::new("network_error", "Unable to read downloaded image bytes.")
-                .with_detail(json!({ "error": error.to_string(), "url": url }))
-        })
+    if let Some(len) = response.content_length()
+        && len > MAX_REMOTE_IMAGE_BYTES
+    {
+        return Err(
+            AppError::new("network_error", "Downloaded image is too large.").with_detail(json!({
+                "url": redacted,
+                "content_length": len,
+                "max_bytes": MAX_REMOTE_IMAGE_BYTES,
+            })),
+        );
+    }
+    let bytes = response.bytes().map_err(|error| {
+        AppError::new("network_error", "Unable to read downloaded image bytes.")
+            .with_detail(json!({ "error": error.to_string(), "url": redacted }))
+    })?;
+    if bytes.len() as u64 > MAX_REMOTE_IMAGE_BYTES {
+        // A server can omit Content-Length; enforce the cap on the body too.
+        return Err(
+            AppError::new("network_error", "Downloaded image is too large.").with_detail(json!({
+                "url": redacted,
+                "bytes": bytes.len(),
+                "max_bytes": MAX_REMOTE_IMAGE_BYTES,
+            })),
+        );
+    }
+    Ok(bytes.to_vec())
 }
 
 pub(crate) fn load_image_source_bytes(

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -152,68 +152,97 @@ pub(crate) fn parse_data_url_image(value: &str) -> Result<(String, Vec<u8>), App
 /// Reference images fetched from a URL are capped so a hostile or accidental
 /// giant response can't exhaust memory. 64MB comfortably covers any real image.
 const MAX_REMOTE_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
+/// Error bodies are only used for diagnostics, so bound them tightly.
+const MAX_ERROR_BODY_BYTES: u64 = 64 * 1024;
+const MAX_REDIRECT_HOPS: usize = 10;
 
-pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
+/// Read at most `max + 1` bytes so an over-limit (or Content-Length-less /
+/// chunked) body is detected without ever buffering the whole thing.
+fn read_capped(
+    response: reqwest::blocking::Response,
+    max: u64,
+    redacted: &str,
+) -> Result<Vec<u8>, AppError> {
     use std::io::Read;
-
-    // Redact query strings from anything we log — reference URLs can carry
-    // signed tokens.
-    let redacted = redact_url_for_log(url);
-    // SSRF guard, applied unconditionally: reject URLs whose host resolves to
-    // loopback/link-local/private ranges (e.g. the cloud metadata service).
-    // We can't exempt the custom-proxy case — a `no_proxy` match still makes
-    // reqwest connect directly — so we always validate and pin.
-    let (_, host_label, addrs) = validate_remote_http_target(url, "Reference image")?;
-    // Pin the initial host to the addresses we just validated (blocks a rebind
-    // between validation and connect) and re-validate every redirect hop, so a
-    // 302-to-internal can't smuggle us onto a blocked target either. Legitimate
-    // CDN redirects to other public hosts still work. Proxy is honored for
-    // egress.
-    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
-        if attempt.previous().len() >= 10 {
-            return attempt.error(std::io::Error::other("too many redirects"));
-        }
-        match validate_remote_http_target(attempt.url().as_str(), "Reference image redirect") {
-            Ok(_) => attempt.follow(),
-            Err(_) => attempt.stop(),
-        }
-    });
-    let builder = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT))
-        .redirect(redirect_policy)
-        .resolve_to_addrs(&host_label, &addrs)
-        .user_agent(build_user_agent());
-    let client = apply_proxy(builder, proxy)?.build().map_err(|error| {
-        AppError::new("network_error", "Unable to build download client.")
-            .with_detail(json!({ "error": error.to_string() }))
-    })?;
-    let response = client.get(url).send().map_err(|error| {
-        AppError::new("network_error", "Unable to download image bytes.")
-            .with_detail(json!({ "error": error.to_string(), "url": redacted }))
-    })?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let detail = response.text().unwrap_or_else(|_| String::new());
-        return Err(http_status_error(status, detail));
-    }
-    // Stream with a hard cap: reading `MAX + 1` bytes lets us detect an
-    // over-limit body (including chunked / Content-Length-less responses)
-    // without ever buffering the whole thing.
     let mut buf = Vec::new();
-    let mut limited = response.take(MAX_REMOTE_IMAGE_BYTES + 1);
-    limited.read_to_end(&mut buf).map_err(|error| {
-        AppError::new("network_error", "Unable to read downloaded image bytes.")
-            .with_detail(json!({ "error": error.to_string(), "url": redacted }))
-    })?;
-    if buf.len() as u64 > MAX_REMOTE_IMAGE_BYTES {
+    response
+        .take(max + 1)
+        .read_to_end(&mut buf)
+        .map_err(|error| {
+            AppError::new("network_error", "Unable to read downloaded image bytes.")
+                .with_detail(json!({ "error": error.to_string(), "url": redacted }))
+        })?;
+    if buf.len() as u64 > max {
         return Err(
             AppError::new("network_error", "Downloaded image is too large.").with_detail(json!({
                 "url": redacted,
-                "max_bytes": MAX_REMOTE_IMAGE_BYTES,
+                "max_bytes": max,
             })),
         );
     }
     Ok(buf)
+}
+
+pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
+    // Redact query strings from anything we log — reference URLs can carry
+    // signed tokens.
+    let redacted = redact_url_for_log(url);
+    // Follow redirects manually so every hop — not just the first — is both
+    // SSRF-validated and pinned to the addresses we validated. reqwest's
+    // resolve_to_addrs only pins the initial host, and its automatic redirect
+    // would re-resolve a redirect target, reopening a DNS-rebind hole. We
+    // validate unconditionally (a custom proxy with a matching `no_proxy` still
+    // direct-connects) and bound every body read.
+    let mut current = url.to_string();
+    for _ in 0..=MAX_REDIRECT_HOPS {
+        let (_, host_label, addrs) = validate_remote_http_target(&current, "Reference image")?;
+        let builder = reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT))
+            .redirect(reqwest::redirect::Policy::none())
+            .resolve_to_addrs(&host_label, &addrs)
+            .user_agent(build_user_agent());
+        let client = apply_proxy(builder, proxy)?.build().map_err(|error| {
+            AppError::new("network_error", "Unable to build download client.")
+                .with_detail(json!({ "error": error.to_string() }))
+        })?;
+        let response = client.get(&current).send().map_err(|error| {
+            AppError::new("network_error", "Unable to download image bytes.")
+                .with_detail(json!({ "error": error.to_string(), "url": redacted }))
+        })?;
+        let status = response.status();
+        if status.is_redirection() {
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| {
+                    AppError::new("network_error", "Redirect without a Location header.")
+                        .with_detail(json!({ "url": redacted }))
+                })?;
+            // Resolve relative redirects against the current URL. The next loop
+            // iteration validates and pins this target before connecting.
+            let next = Url::parse(&current)
+                .and_then(|base| base.join(location))
+                .map_err(|error| {
+                    AppError::new("network_error", "Invalid redirect target.")
+                        .with_detail(json!({ "error": error.to_string() }))
+                })?;
+            current = next.to_string();
+            continue;
+        }
+        if !status.is_success() {
+            let body = read_capped(response, MAX_ERROR_BODY_BYTES, &redacted)
+                .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                .unwrap_or_default();
+            return Err(http_status_error(status, body));
+        }
+        return read_capped(response, MAX_REMOTE_IMAGE_BYTES, &redacted);
+    }
+    Err(AppError::new(
+        "network_error",
+        "Too many redirects while downloading image.",
+    )
+    .with_detail(json!({ "url": redacted, "max_hops": MAX_REDIRECT_HOPS })))
 }
 
 pub(crate) fn load_image_source_bytes(

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -183,25 +183,50 @@ fn read_capped(
     Ok(buf)
 }
 
-pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
-    // Redact query strings from anything we log — reference URLs can carry
-    // signed tokens.
+/// Fetch an **untrusted, user-supplied** reference image over http(s). Always
+/// direct-connect so the SSRF validation and address pinning actually hold — a
+/// remote-resolving proxy (http/socks5h, or a `no_proxy` miss) would resolve
+/// the host itself and defeat the pin. A URL only reachable through a proxy
+/// should be passed as a local file or data URL instead.
+pub(crate) fn download_reference_image_bytes(url: &str) -> Result<Vec<u8>, AppError> {
+    download_http_image_bytes(url, None)
+}
+
+/// Fetch a **trusted, provider-returned** result image URL (e.g. the `url` in
+/// an OpenAI image response). The URL comes from the provider's authenticated
+/// TLS response, so we honor the proxy the user configured to reach that
+/// provider's CDN; pinning can't apply through a resolving proxy, which is
+/// acceptable for a trusted source. Validation and bounded reads still apply.
+pub(crate) fn download_result_image_bytes(
+    url: &str,
+    proxy: &ProxyConfig,
+) -> Result<Vec<u8>, AppError> {
+    download_http_image_bytes(url, Some(proxy))
+}
+
+fn download_http_image_bytes(url: &str, proxy: Option<&ProxyConfig>) -> Result<Vec<u8>, AppError> {
+    // Redact query strings from anything we log — image URLs can carry signed
+    // tokens.
     let redacted = redact_url_for_log(url);
     // Follow redirects manually so every hop — not just the first — is both
-    // SSRF-validated and pinned to the addresses we validated. reqwest's
-    // resolve_to_addrs only pins the initial host, and its automatic redirect
-    // would re-resolve a redirect target, reopening a DNS-rebind hole. We
-    // validate unconditionally (a custom proxy with a matching `no_proxy` still
-    // direct-connects) and bound every body read.
+    // SSRF-validated and (when direct) pinned to the addresses we validated.
+    // reqwest's resolve_to_addrs only pins the initial host and its automatic
+    // redirect would re-resolve a redirect target, reopening a DNS-rebind hole.
+    // Every body read is bounded.
     let mut current = url.to_string();
     for _ in 0..=MAX_REDIRECT_HOPS {
-        let (_, host_label, addrs) = validate_remote_http_target(&current, "Reference image")?;
+        let (_, host_label, addrs) = validate_remote_http_target(&current, "Image download")?;
         let builder = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT))
             .redirect(reqwest::redirect::Policy::none())
             .resolve_to_addrs(&host_label, &addrs)
             .user_agent(build_user_agent());
-        let client = apply_proxy(builder, proxy)?.build().map_err(|error| {
+        let client = match proxy {
+            Some(proxy) => apply_proxy(builder, proxy)?,
+            None => builder,
+        }
+        .build()
+        .map_err(|error| {
             AppError::new("network_error", "Unable to build download client.")
                 .with_detail(json!({ "error": error.to_string() }))
         })?;
@@ -248,7 +273,6 @@ pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, 
 pub(crate) fn load_image_source_bytes(
     source: &str,
     fallback_name: &str,
-    proxy: &ProxyConfig,
 ) -> Result<(String, Vec<u8>, String), AppError> {
     if source.starts_with("data:image/") {
         let (mime_type, bytes) = parse_data_url_image(source)?;
@@ -261,7 +285,7 @@ pub(crate) fn load_image_source_bytes(
     if let Ok(url) = Url::parse(source) {
         match url.scheme() {
             "http" | "https" => {
-                let bytes = download_bytes(source, proxy)?;
+                let bytes = download_reference_image_bytes(source)?;
                 let guessed_name = Path::new(url.path())
                     .file_name()
                     .and_then(|name| name.to_str())
@@ -330,7 +354,7 @@ mod download_ssrf_tests {
             "http://[::1]/x.png",
             "http://169.254.169.254/latest/meta-data/",
         ] {
-            let err = download_bytes(url, &ProxyConfig::default()).unwrap_err();
+            let err = download_reference_image_bytes(url).unwrap_err();
             assert_ne!(
                 err.code, "network_error",
                 "{url} should be rejected by the SSRF guard, not attempted"

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -154,17 +154,39 @@ pub(crate) fn parse_data_url_image(value: &str) -> Result<(String, Vec<u8>), App
 const MAX_REMOTE_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
 
 pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, AppError> {
+    use std::io::Read;
+
     // Redact query strings from anything we log — reference URLs can carry
     // signed tokens.
     let redacted = redact_url_for_log(url);
-    // SSRF guard: on a direct connection, reject URLs that resolve to
+    // SSRF guard, applied unconditionally: reject URLs whose host resolves to
     // loopback/link-local/private ranges (e.g. the cloud metadata service).
-    // A custom proxy is the user's explicit egress, so we trust it to police
-    // its own targets rather than validating a host it, not we, will resolve.
-    if proxy.mode != ProxyMode::Custom {
-        validate_remote_http_target(url, "Reference image")?;
-    }
-    let client = make_client(DEFAULT_REQUEST_TIMEOUT, proxy)?;
+    // We can't exempt the custom-proxy case — a `no_proxy` match still makes
+    // reqwest connect directly — so we always validate and pin.
+    let (_, host_label, addrs) = validate_remote_http_target(url, "Reference image")?;
+    // Pin the initial host to the addresses we just validated (blocks a rebind
+    // between validation and connect) and re-validate every redirect hop, so a
+    // 302-to-internal can't smuggle us onto a blocked target either. Legitimate
+    // CDN redirects to other public hosts still work. Proxy is honored for
+    // egress.
+    let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() >= 10 {
+            return attempt.error(std::io::Error::other("too many redirects"));
+        }
+        match validate_remote_http_target(attempt.url().as_str(), "Reference image redirect") {
+            Ok(_) => attempt.follow(),
+            Err(_) => attempt.stop(),
+        }
+    });
+    let builder = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT))
+        .redirect(redirect_policy)
+        .resolve_to_addrs(&host_label, &addrs)
+        .user_agent(build_user_agent());
+    let client = apply_proxy(builder, proxy)?.build().map_err(|error| {
+        AppError::new("network_error", "Unable to build download client.")
+            .with_detail(json!({ "error": error.to_string() }))
+    })?;
     let response = client.get(url).send().map_err(|error| {
         AppError::new("network_error", "Unable to download image bytes.")
             .with_detail(json!({ "error": error.to_string(), "url": redacted }))
@@ -174,32 +196,24 @@ pub(crate) fn download_bytes(url: &str, proxy: &ProxyConfig) -> Result<Vec<u8>, 
         let detail = response.text().unwrap_or_else(|_| String::new());
         return Err(http_status_error(status, detail));
     }
-    if let Some(len) = response.content_length()
-        && len > MAX_REMOTE_IMAGE_BYTES
-    {
-        return Err(
-            AppError::new("network_error", "Downloaded image is too large.").with_detail(json!({
-                "url": redacted,
-                "content_length": len,
-                "max_bytes": MAX_REMOTE_IMAGE_BYTES,
-            })),
-        );
-    }
-    let bytes = response.bytes().map_err(|error| {
+    // Stream with a hard cap: reading `MAX + 1` bytes lets us detect an
+    // over-limit body (including chunked / Content-Length-less responses)
+    // without ever buffering the whole thing.
+    let mut buf = Vec::new();
+    let mut limited = response.take(MAX_REMOTE_IMAGE_BYTES + 1);
+    limited.read_to_end(&mut buf).map_err(|error| {
         AppError::new("network_error", "Unable to read downloaded image bytes.")
             .with_detail(json!({ "error": error.to_string(), "url": redacted }))
     })?;
-    if bytes.len() as u64 > MAX_REMOTE_IMAGE_BYTES {
-        // A server can omit Content-Length; enforce the cap on the body too.
+    if buf.len() as u64 > MAX_REMOTE_IMAGE_BYTES {
         return Err(
             AppError::new("network_error", "Downloaded image is too large.").with_detail(json!({
                 "url": redacted,
-                "bytes": bytes.len(),
                 "max_bytes": MAX_REMOTE_IMAGE_BYTES,
             })),
         );
     }
-    Ok(bytes.to_vec())
+    Ok(buf)
 }
 
 pub(crate) fn load_image_source_bytes(
@@ -272,4 +286,26 @@ pub(crate) fn load_image_source_bytes(
         "ref_image_invalid",
         format!("Unsupported image source for multipart edit: {source}"),
     ))
+}
+
+#[cfg(test)]
+mod download_ssrf_tests {
+    use super::*;
+
+    // The SSRF guard rejects internal targets before any request is made, so
+    // these resolve numerically and fail offline.
+    #[test]
+    fn rejects_loopback_and_link_local_targets() {
+        for url in [
+            "http://127.0.0.1/x.png",
+            "http://[::1]/x.png",
+            "http://169.254.169.254/latest/meta-data/",
+        ] {
+            let err = download_bytes(url, &ProxyConfig::default()).unwrap_err();
+            assert_ne!(
+                err.code, "network_error",
+                "{url} should be rejected by the SSRF guard, not attempted"
+            );
+        }
+    }
 }

--- a/crates/gpt-image-2-core/src/image_requests/openai.rs
+++ b/crates/gpt-image-2-core/src/image_requests/openai.rs
@@ -70,7 +70,7 @@ pub(crate) fn request_openai_edit_once(
         Some(0),
         json!({ "endpoint": endpoint, "transport": "multipart" }),
     );
-    let form = build_openai_edit_form(body, proxy)?;
+    let form = build_openai_edit_form(body)?;
     emit_progress_event(
         logger,
         "openai",
@@ -154,7 +154,7 @@ pub(crate) fn parse_openai_json_response(
     Ok(payload)
 }
 
-pub(crate) fn build_openai_edit_form(body: &Value, proxy: &ProxyConfig) -> Result<Form, AppError> {
+pub(crate) fn build_openai_edit_form(body: &Value) -> Result<Form, AppError> {
     let object = json_object(body)?;
     let mut form = Form::new();
     for key in [
@@ -184,7 +184,7 @@ pub(crate) fn build_openai_edit_form(body: &Value, proxy: &ProxyConfig) -> Resul
     }
     for (index, source) in images.iter().enumerate() {
         let (mime_type, bytes, file_name) =
-            load_image_source_bytes(source, &format!("image-{}", index + 1), proxy)?;
+            load_image_source_bytes(source, &format!("image-{}", index + 1))?;
         let part = Part::bytes(bytes)
             .file_name(file_name)
             .mime_str(&mime_type)
@@ -198,7 +198,7 @@ pub(crate) fn build_openai_edit_form(body: &Value, proxy: &ProxyConfig) -> Resul
         form = form.part("image[]", part);
     }
     if let Some(mask_source) = extract_openai_mask_source(body)? {
-        let (mime_type, bytes, file_name) = load_image_source_bytes(&mask_source, "mask", proxy)?;
+        let (mime_type, bytes, file_name) = load_image_source_bytes(&mask_source, "mask")?;
         let part = Part::bytes(bytes)
             .file_name(file_name)
             .mime_str(&mime_type)

--- a/crates/gpt-image-2-core/src/image_requests/output.rs
+++ b/crates/gpt-image-2-core/src/image_requests/output.rs
@@ -141,7 +141,7 @@ pub(crate) fn decode_openai_images(
             continue;
         }
         if let Some(url) = item.get("url").and_then(Value::as_str) {
-            result.push(download_bytes(url, proxy)?);
+            result.push(download_result_image_bytes(url, proxy)?);
         }
     }
     Ok((result, revised_prompts))

--- a/crates/gpt-image-2-core/src/storage/util.rs
+++ b/crates/gpt-image-2-core/src/storage/util.rs
@@ -535,18 +535,18 @@ pub(super) fn storage_response_json(
     Ok((status, payload))
 }
 
-/// Baidu / 123 Netdisk responses carry an explicit `errno`/`code` status.
-/// Require one of the expected success codes to be present: a response missing
-/// the field entirely is non-standard (an error page, a truncated body, an auth
-/// challenge) and must not be mistaken for a successful upload, which would
-/// record a broken link as if it were live.
+/// True when a Baidu / 123 Netdisk response carries one of the expected success
+/// codes. A missing `errno`/`code` counts as success on purpose: Baidu's
+/// chunked `pcs/superfile2` upload returns only `md5`/`request_id` on success,
+/// with no status field, so requiring an explicit code would fail every
+/// legitimate chunk upload.
 pub(super) fn value_code_success(payload: &Value, ok_values: &[i64]) -> bool {
     payload
         .get("errno")
         .or_else(|| payload.get("code"))
         .and_then(Value::as_i64)
         .map(|code| ok_values.contains(&code))
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 pub(super) fn payload_data(payload: &Value) -> &Value {
@@ -620,20 +620,4 @@ pub(super) fn netdisk_http_client() -> Result<Client, AppError> {
             )
             .with_detail(json!({"error": error.to_string()}))
         })
-}
-
-#[cfg(test)]
-mod value_code_success_tests {
-    use super::*;
-
-    #[test]
-    fn requires_an_explicit_success_code() {
-        assert!(value_code_success(&json!({"errno": 0}), &[0]));
-        assert!(value_code_success(&json!({"code": 200}), &[0, 200]));
-        assert!(!value_code_success(&json!({"errno": 31023}), &[0]));
-        // Missing / non-numeric status must not read as success.
-        assert!(!value_code_success(&json!({"message": "forbidden"}), &[0]));
-        assert!(!value_code_success(&json!({}), &[0]));
-        assert!(!value_code_success(&json!({"code": "200"}), &[0, 200]));
-    }
 }

--- a/crates/gpt-image-2-core/src/storage/util.rs
+++ b/crates/gpt-image-2-core/src/storage/util.rs
@@ -535,13 +535,18 @@ pub(super) fn storage_response_json(
     Ok((status, payload))
 }
 
+/// Baidu / 123 Netdisk responses carry an explicit `errno`/`code` status.
+/// Require one of the expected success codes to be present: a response missing
+/// the field entirely is non-standard (an error page, a truncated body, an auth
+/// challenge) and must not be mistaken for a successful upload, which would
+/// record a broken link as if it were live.
 pub(super) fn value_code_success(payload: &Value, ok_values: &[i64]) -> bool {
     payload
         .get("errno")
         .or_else(|| payload.get("code"))
         .and_then(Value::as_i64)
         .map(|code| ok_values.contains(&code))
-        .unwrap_or(true)
+        .unwrap_or(false)
 }
 
 pub(super) fn payload_data(payload: &Value) -> &Value {
@@ -615,4 +620,20 @@ pub(super) fn netdisk_http_client() -> Result<Client, AppError> {
             )
             .with_detail(json!({"error": error.to_string()}))
         })
+}
+
+#[cfg(test)]
+mod value_code_success_tests {
+    use super::*;
+
+    #[test]
+    fn requires_an_explicit_success_code() {
+        assert!(value_code_success(&json!({"errno": 0}), &[0]));
+        assert!(value_code_success(&json!({"code": 200}), &[0, 200]));
+        assert!(!value_code_success(&json!({"errno": 31023}), &[0]));
+        // Missing / non-numeric status must not read as success.
+        assert!(!value_code_success(&json!({"message": "forbidden"}), &[0]));
+        assert!(!value_code_success(&json!({}), &[0]));
+        assert!(!value_code_success(&json!({"code": "200"}), &[0, 200]));
+    }
 }

--- a/crates/gpt-image-2-core/src/tests/image_requests.rs
+++ b/crates/gpt-image-2-core/src/tests/image_requests.rs
@@ -55,5 +55,5 @@ fn build_openai_edit_form_contains_required_parts() {
         "mask": {"image_url": "data:image/png;base64,YWJjZA=="},
         "size": "1024x1024",
     });
-    assert!(build_openai_edit_form(&body, &ProxyConfig::default()).is_ok());
+    assert!(build_openai_edit_form(&body).is_ok());
 }


### PR DESCRIPTION
## 安全加固（来自 storage 审查的 defense-in-depth 项，PR8 的姊妹 PR）

- **`download_bytes` SSRF/大小/脱敏**：参考图 URL（http/https）直连时走与 storage 一致的 SSRF 防护（拒绝解析到 loopback/link-local/内网段的地址，如云 metadata 服务）；custom proxy 是用户显式出口，信任之。响应按 64MB 上限（Content-Length + 流式 body 双重）防内存耗尽；错误 detail 中 URL 脱敏，签名 query token 不再泄漏进日志。
- **tauri delete 命令 path traversal**：`soft/hard/restore_deleted_job` 在把前端 job_id join 到 library/trash 根目录前，校验它是单个 normal path 段——webview XSS 无法传 `../../…` 到 `fs::rename` / `remove_dir_all` 越权删目录。
- **`value_code_success` 容错收紧**：Baidu/123 网盘响应缺 errno/code 状态字段时不再判成功——截断的 body 或 auth challenge 否则会把失败的上传记成有效链接。

## 验证

新增单测：`value_code_success` 要求显式成功码；`safe_job_segment` 拒绝 traversal 和分隔符。`cargo clippy --workspace --all-targets` 0 告警。

## 说明

`download_bytes` 保留了跟随重定向的行为（redirect-to-internal 是较窄的残留向量，直连的初次 SSRF 校验覆盖主要 CLI 风险）；彻底禁重定向会破坏合法的 CDN 重定向 URL，故未改。