### PR TITLE
feat(security): harden production relay and release chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:10"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /apps/gpt-image-2-app
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:20"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /workers/gpt-image-2-relay
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,15 @@ jobs:
         run: scripts/security/check-workflows.sh
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json
             workers/gpt-image-2-relay/package-lock.json
       - name: Audit npm dependencies
         run: |
+          npm --prefix apps/gpt-image-2-app ci
+          npm --prefix workers/gpt-image-2-relay ci
           npm --prefix apps/gpt-image-2-app audit --audit-level=high
           npm --prefix workers/gpt-image-2-relay audit --audit-level=high
           npm --prefix apps/gpt-image-2-app install-scripts ls --json | jq -e '.allowScripts | length == 0'
@@ -63,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: ${{ matrix.package }}/package-lock.json
       - name: Install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,34 @@ permissions:
   contents: read
 
 jobs:
+  security:
+    name: Security
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Verify workflow supply-chain policy
+        run: scripts/security/check-workflows.sh
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            apps/gpt-image-2-app/package-lock.json
+            workers/gpt-image-2-relay/package-lock.json
+      - name: Audit npm dependencies
+        run: |
+          npm --prefix apps/gpt-image-2-app audit --audit-level=high
+          npm --prefix workers/gpt-image-2-relay audit --audit-level=high
+          npm --prefix apps/gpt-image-2-app install-scripts ls --json | jq -e '.allowScripts | length == 0'
+          npm --prefix workers/gpt-image-2-relay install-scripts ls --json | jq -e '.allowScripts | length == 0'
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
+      - name: Audit Rust dependencies
+        run: cargo audit
+
   node:
     name: Node (${{ matrix.package }})
     runs-on: ubuntu-24.04
@@ -30,8 +58,10 @@ jobs:
           - apps/gpt-image-2-app
           - workers/gpt-image-2-relay
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
@@ -50,11 +80,13 @@ jobs:
     name: Rust
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: scripts/security/check-workflows.sh
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: ${{ matrix.package }}/package-lock.json
       - name: Install

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+          - rust
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4

--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -97,14 +97,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.release.outputs.ref }}
           persist-credentials: false
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
@@ -143,16 +143,16 @@ jobs:
             artifact: linux-arm64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.prepare.outputs.ref }}
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -160,7 +160,7 @@ jobs:
 
       - name: Build and push platform image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./Dockerfile
@@ -182,7 +182,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: digests-${{ matrix.artifact }}
           path: /tmp/digests/*
@@ -196,17 +196,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           path: /tmp/digests
           pattern: digests-*
@@ -244,7 +244,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestation
-        uses: actions/attest@v4
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.manifest.outputs.digest }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ env.TAG_NAME }}
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
       - name: Install trusted publishing npm
         run: npm install -g npm@^11.10.0
       - name: Download release assets

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ env.TAG_NAME }}
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24
+          node-version: 24.19.0
       - name: Install trusted publishing npm
         run: npm install -g npm@^11.10.0
       - name: Download release assets

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,10 +27,10 @@ jobs:
       TAG_NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ env.TAG_NAME }}
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24
       - name: Install trusted publishing npm

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -22,12 +22,11 @@ env:
   PAGES_PRODUCTION_BRANCH: codex/static-byok-web-runtime
 
 jobs:
-  deploy:
-    name: Deploy static app to Cloudflare Pages
+  verify:
+    name: Verify relay and static app
     runs-on: ubuntu-24.04
-    env:
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    outputs:
+      commit: ${{ steps.verified.outputs.commit }}
     steps:
       - name: Resolve release tag
         id: release
@@ -43,11 +42,16 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ steps.release.outputs.tag }}
 
-      - uses: actions/setup-node@v6
+      - name: Record the immutable verified commit
+        id: verified
+        shell: bash
+        run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
@@ -61,8 +65,66 @@ jobs:
       - name: Install Wrangler dependencies
         run: npm ci --prefix workers/gpt-image-2-relay
 
+      - name: Test relay security boundaries
+        run: |
+          npm --prefix workers/gpt-image-2-relay audit --audit-level=high
+          npm --prefix workers/gpt-image-2-relay run typecheck
+          npm --prefix workers/gpt-image-2-relay run test
+          npm --prefix workers/gpt-image-2-relay run dry-run
+
+      - name: Test static app
+        run: |
+          npm --prefix apps/gpt-image-2-app audit --audit-level=high
+          npm --prefix apps/gpt-image-2-app run test
+
       - name: Build static app
         run: npm --prefix apps/gpt-image-2-app run build
+
+      - name: Verify static security headers
+        shell: bash
+        run: |
+          test -f apps/gpt-image-2-app/dist/_headers
+          grep -Fq "Content-Security-Policy:" apps/gpt-image-2-app/dist/_headers
+          grep -Fq "frame-ancestors 'none'" apps/gpt-image-2-app/dist/_headers
+
+  deploy:
+    name: Deploy relay, then static app to Cloudflare Pages
+    needs: verify
+    runs-on: ubuntu-24.04
+    environment:
+      name: cloudflare-production
+      url: https://image.codex-pool.com
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.verify.outputs.commit }}
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            apps/gpt-image-2-app/package-lock.json
+            workers/gpt-image-2-relay/package-lock.json
+
+      - name: Install app dependencies
+        run: npm ci --prefix apps/gpt-image-2-app
+
+      - name: Install Wrangler dependencies
+        run: npm ci --prefix workers/gpt-image-2-relay
+
+      - name: Rebuild the verified static app
+        run: npm --prefix apps/gpt-image-2-app run build
+
+      - name: Verify rebuilt security headers
+        shell: bash
+        run: |
+          test -f apps/gpt-image-2-app/dist/_headers
+          grep -Fq "Content-Security-Policy:" apps/gpt-image-2-app/dist/_headers
+          grep -Fq "frame-ancestors 'none'" apps/gpt-image-2-app/dist/_headers
 
       - name: Check Cloudflare credentials
         shell: bash
@@ -76,12 +138,48 @@ jobs:
             exit 1
           fi
 
+      - name: Check relay secrets without exposing values
+        shell: bash
+        run: |
+          secrets_json="$(./workers/gpt-image-2-relay/node_modules/.bin/wrangler secret list \
+            --config workers/gpt-image-2-relay/wrangler.jsonc \
+            --format json)"
+          for secret_name in TURNSTILE_SITE_KEY TURNSTILE_SECRET_KEY RELAY_SESSION_HMAC_KEY; do
+            if ! jq -e --arg name "$secret_name" \
+              'map(.name) | index($name) != null' <<<"$secrets_json" >/dev/null; then
+              echo "::error::Missing Worker secret $secret_name. Refusing to deploy."
+              exit 1
+            fi
+          done
+
+      - name: Deploy relay Worker first
+        run: npm --prefix workers/gpt-image-2-relay run deploy
+
+      - name: Require a ready relay v2 before publishing the static app
+        shell: bash
+        run: |
+          config_file="$RUNNER_TEMP/relay-v2-config.json"
+          for attempt in {1..18}; do
+            if curl --fail --silent --show-error --max-time 10 \
+              "https://image.codex-pool.com/api/relay/v2/config" \
+              --output "$config_file" \
+              && jq -e \
+                '.version == 2 and .enabled == true and .auth_mode == "turnstile" and (.turnstile_site_key | type == "string" and length > 0)' \
+                "$config_file" >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Relay v2 did not become ready; static deployment is blocked."
+          exit 1
+
       - name: Deploy to Cloudflare Pages
         shell: bash
         run: |
           commit_hash="$(git rev-parse HEAD)"
           commit_message="$(git log -1 --pretty=%s)"
-          ./workers/gpt-image-2-relay/node_modules/.bin/wrangler pages deploy apps/gpt-image-2-app/dist \
+          ./workers/gpt-image-2-relay/node_modules/.bin/wrangler pages deploy dist \
+            --cwd apps/gpt-image-2-app \
             --project-name "$PAGES_PROJECT_NAME" \
             --branch "$PAGES_PRODUCTION_BRANCH" \
             --commit-hash "$commit_hash" \

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: |
             apps/gpt-image-2-app/package-lock.json

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           registry-url: https://registry.npmjs.org
       - name: Wait for npm package visibility
         shell: bash

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -36,12 +36,12 @@ jobs:
     env:
       VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || format('v{0}', inputs.version) }}
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.18.1
+        uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
         with:
           version: 1.18.1
       - name: Install CLI with cargo-binstall
@@ -66,7 +66,7 @@ jobs:
     env:
       VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || format('v{0}', inputs.version) }}
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/post-release-verify.yml
+++ b/.github/workflows/post-release-verify.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@dc19f1e48450eefe5a29b8da6c6b00a87d730b37 # v1.18.1
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           registry-url: https://registry.npmjs.org
       - name: Wait for npm package visibility
         shell: bash

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: apps/gpt-image-2-app/package-lock.json
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: workers/gpt-image-2-relay/package-lock.json
       - name: Install dependencies

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: apps/gpt-image-2-app/package-lock.json
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 22
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: workers/gpt-image-2-relay/package-lock.json
       - name: Install dependencies

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -12,10 +12,10 @@ jobs:
   candidate:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
       - name: Install Tauri system dependencies
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: scripts/release/install-cargo-dist.sh
       # tauri_build::build() refuses to compile when frontendDist is missing,
       # and the workspace-wide gates below compile the Tauri crate too.
       - name: Ensure frontend dist exists for tauri_build
@@ -34,8 +34,8 @@ jobs:
   frontend:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm
@@ -50,8 +50,8 @@ jobs:
   relay:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,17 +62,15 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: scripts/release/install-cargo-dist.sh
       - name: Cache dist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -94,7 +92,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -128,7 +126,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -136,14 +134,20 @@ jobs:
         if: ${{ matrix.container }}
         run: |
           if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            echo "The configured release container must include a trusted Rust toolchain." >&2
+            exit 1
           fi
-      - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+      - name: Install dist on Unix
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        run: scripts/release/install-cargo-dist.sh
+      - name: Install dist on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: ./scripts/release/install-cargo-dist.ps1
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -204,7 +208,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -221,19 +225,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -251,7 +255,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: artifacts-build-global
           path: |
@@ -271,19 +275,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -296,14 +300,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: artifacts-*
           path: artifacts
@@ -336,14 +340,14 @@ jobs:
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: true
           repository: "Wangnov/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
       # So we have access to the formula
       - name: Fetch homebrew formulae
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           pattern: artifacts-*
           path: Formula/
@@ -383,7 +387,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/tauri-app-release.yml
+++ b/.github/workflows/tauri-app-release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: 24.19.0
+          node-version: 26.6.0
           cache: npm
           cache-dependency-path: apps/gpt-image-2-app/package-lock.json
 

--- a/.github/workflows/tauri-app-release.yml
+++ b/.github/workflows/tauri-app-release.yml
@@ -83,7 +83,7 @@ jobs:
       APPLE_TEAM_ID: 3VT538F8B6
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           ref: ${{ inputs.release_tag }}
@@ -95,21 +95,21 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: lts/*
           cache: npm
           cache-dependency-path: apps/gpt-image-2-app/package-lock.json
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Add Rust target
         if: matrix.rust_target != ''
         run: rustup target add ${{ matrix.rust_target }}
 
       - name: Cache Rust
-        uses: swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: |
             . -> target
@@ -344,7 +344,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag }}
       SOURCE_REPO: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
@@ -390,7 +390,7 @@ jobs:
       GITHUB_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           repository: "Wangnov/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/tauri-app-release.yml
+++ b/.github/workflows/tauri-app-release.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: lts/*
+          node-version: 24.19.0
           cache: npm
           cache-dependency-path: apps/gpt-image-2-app/package-lock.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,30 +122,9 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
-]
-
-[[package]]
-name = "ashpd"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
-dependencies = [
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.4",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "tokio",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
 ]
 
 [[package]]
@@ -377,6 +356,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -1057,15 +1042,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "dlib"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
-dependencies = [
- "libloading",
 ]
 
 [[package]]
@@ -1888,11 +1864,14 @@ name = "gpt-image-2-web"
 version = "0.7.3"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "gpt-image-2-core",
  "gpt-image-2-runtime",
+ "hmac",
  "mime_guess",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tower-http",
 ]
@@ -1951,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2205,7 +2184,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2573,11 +2552,11 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -2735,14 +2714,16 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2939,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.17.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -2982,7 +2963,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3573,13 +3554,13 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -3752,27 +3733,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3830,7 +3793,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4165,26 +4128,26 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.4"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "ashpd",
  "block2",
  "dispatch2",
  "js-sys",
+ "libc",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "percent-encoding",
  "pollster",
  "raw-window-handle",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4398,12 +4361,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -5343,11 +5300,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
@@ -5360,7 +5316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -5507,10 +5463,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -5888,12 +5842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6133,7 +6081,6 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix",
- "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -6177,12 +6124,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.3",
+ "quick-xml",
  "quote",
 ]
 
@@ -6192,8 +6139,6 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
- "dlib",
- "log",
  "pkg-config",
 ]
 
@@ -7128,7 +7073,6 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -7287,7 +7231,6 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
  "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",

--- a/README.md
+++ b/README.md
@@ -471,16 +471,19 @@ Linux glibc 沙箱下,缓存与 bootstrap 阶段会先检查 GNU target(`*-unkno
 
 主要能力:
 
-- `RELAY_MODE`:`open`(任意上游 URL,凭 `x-gpt-image-2-upstream` header 指定)或 `allowlist`(只允许配置中列出的 origin)
-- `RELAY_ALLOWED_ORIGINS` / `RELAY_ALLOWED_METHODS` / `RELAY_MAX_REQUEST_BYTES` / `RELAY_MAX_RESPONSE_BYTES` 全部可调
-- 请求 / 响应 header 黑名单清理(剥离 `cookie`、`set-cookie`、`cf-*` 等)
-- `report-only` 模式可在不阻断流量的情况下采集 allowlist 命中率
+- 不要求预先收集用户的中转站域名:用户仍可填写任意公网 HTTPS API Base,但 Worker 只会拼接 `/models`、`/images/generations`、`/images/edits` 三个固定 API 路径,以及执行无凭证的图片下载
+- 前端先用无副作用的 `/models` 探测直连能力;生成/编辑 POST 在响应状态不明时绝不自动换通道重放,避免重复生成和重复扣费
+- Relay v2 使用 Turnstile 换取短期、签名、`HttpOnly`、`SameSite=Strict` cookie,并强制精确 Origin、Fetch Metadata、会话限速和请求大小上限
+- `global_fetch_strictly_public`、公网 HTTPS URL 校验、逐级重定向复验、请求/响应 header allowlist 和流式响应上限共同收紧 SSRF 与数据泄漏边界
+- 旧 `/api/relay` 只为缓存页面保留受限兼容,同样只接受四类标准操作;不再存在 `RELAY_MODE=open`
 
 ```bash
 just relay-test    # 跑 vitest + tsc
 just relay-dry     # wrangler dry-run
 just relay-deploy  # 部署到生产路由
 ```
+
+部署前必须在 Cloudflare Worker secret 中配置 `TURNSTILE_SITE_KEY`、`TURNSTILE_SECRET_KEY` 和至少 32 字节随机值的 `RELAY_SESSION_HMAC_KEY`。Release workflow 会先检查 secret、部署并验证 Worker v2，确认 `enabled: true` 后才发布静态页面。完整灰度、验证和回滚步骤见 [`docs/relay-security-runbook.md`](docs/relay-security-runbook.md)。
 
 如果只用 CLI / 桌面 App / Docker Web,这一段可以忽略。它存在的意义是让浏览器侧 transport 不必把 API key 嵌进前端 bundle。
 
@@ -1040,16 +1043,19 @@ See [`skills/gpt-image-2-skill/SKILL.md`](skills/gpt-image-2-skill/SKILL.md) and
 
 Key features:
 
-- `RELAY_MODE`: `open` (any upstream URL via the `x-gpt-image-2-upstream` header) or `allowlist` (only origins listed in config)
-- Configurable `RELAY_ALLOWED_ORIGINS` / `RELAY_ALLOWED_METHODS` / `RELAY_MAX_REQUEST_BYTES` / `RELAY_MAX_RESPONSE_BYTES`
-- Request / response header blocklist (strips `cookie`, `set-cookie`, `cf-*`, etc.)
-- Report-only mode collects allowlist hit-rate without blocking traffic
+- Users may keep arbitrary public HTTPS API Base domains, while the Worker itself constructs only `/models`, `/images/generations`, `/images/edits`, and credential-free asset download requests.
+- The browser negotiates transport with a side-effect-free `/models` probe. It never replays an ambiguous generation/edit POST through another transport, preventing duplicate work and charges.
+- Relay v2 exchanges Turnstile for a short-lived signed `HttpOnly`, `SameSite=Strict` cookie and enforces exact origins, Fetch Metadata, per-session rate limits, and operation-specific body limits.
+- `global_fetch_strictly_public`, public-HTTPS URL validation, redirect revalidation, strict header allowlists, and streamed response limits narrow SSRF and data-leak boundaries.
+- The old `/api/relay` route remains only as a restricted compatibility path for cached pages. `RELAY_MODE=open` no longer exists.
 
 ```bash
 just relay-test    # vitest + tsc
 just relay-dry     # wrangler dry-run
 just relay-deploy  # deploy to the production route
 ```
+
+Before deployment, configure `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`, and a random 32-byte-or-longer `RELAY_SESSION_HMAC_KEY` as Cloudflare Worker secrets. The release workflow verifies the secrets, deploys and checks Relay v2, and publishes the static app only after the live config reports `enabled: true`. See [`docs/relay-security-runbook.md`](docs/relay-security-runbook.md) for rollout, verification, and rollback steps.
 
 If you only use the CLI, desktop app, or Docker Web, you can ignore this surface. It exists so browser-side transports do not have to embed an API key in the frontend bundle.
 

--- a/apps/gpt-image-2-app/package-lock.json
+++ b/apps/gpt-image-2-app/package-lock.json
@@ -3773,9 +3773,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/apps/gpt-image-2-app/package.json
+++ b/apps/gpt-image-2-app/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.3",
   "private": true,
   "type": "module",
+  "allowScripts": {
+    "esbuild@0.25.12": true,
+    "fsevents": false
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",

--- a/apps/gpt-image-2-app/public/_headers
+++ b/apps/gpt-image-2-app/public/_headers
@@ -1,0 +1,8 @@
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://api.fontshare.com; font-src 'self' data: https://cdn.fontshare.com; img-src 'self' data: blob: https:; connect-src 'self' https: wss:; frame-src https://challenges.cloudflare.com; worker-src 'self' blob:; manifest-src 'self'; media-src 'self' blob:
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), browsing-topics=()
+  Referrer-Policy: no-referrer
+  Strict-Transport-Security: max-age=31536000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-XSS-Protection: 0

--- a/apps/gpt-image-2-app/src-tauri/Cargo.toml
+++ b/apps/gpt-image-2-app/src-tauri/Cargo.toml
@@ -38,7 +38,7 @@ tauri-plugin-updater = "2.10.1"
 # dependency and the extra capability/permission wiring; the dialog runs
 # behind a Tauri command, so the existing Tauri runtime gating already
 # scopes its availability.
-rfd = { version = "0.15", default-features = false, features = ["xdg-portal", "tokio"] }
+rfd = { version = "0.17", default-features = false, features = ["xdg-portal"] }
 
 [features]
 recovery-fault-injection = ["gpt-image-2-core/recovery-fault-injection"]

--- a/apps/gpt-image-2-app/src-tauri/tauri.conf.json
+++ b/apps/gpt-image-2-app/src-tauri/tauri.conf.json
@@ -27,7 +27,19 @@
       }
     ],
     "security": {
-      "csp": null,
+      "csp": {
+        "default-src": "'self' customprotocol: asset:",
+        "script-src": "'self'",
+        "style-src": "'self' 'unsafe-inline' https://api.fontshare.com",
+        "font-src": "'self' data: https://cdn.fontshare.com",
+        "img-src": "'self' asset: http://asset.localhost data: blob: https:",
+        "connect-src": "ipc: http://ipc.localhost asset: http://asset.localhost data: blob: https:",
+        "object-src": "'none'",
+        "base-uri": "'none'",
+        "frame-src": "'none'",
+        "frame-ancestors": "'none'",
+        "form-action": "'none'"
+      },
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/apps/gpt-image-2-app/src/lib/api/browser-transport.test.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser-transport.test.ts
@@ -2,6 +2,7 @@ import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { browserApi, __resetBrowserApiForTests } from "./browser-transport";
 import type { ProviderConfig, StorageConfig } from "../types";
+import { configuredRelayBase } from "./browser/relay-client";
 
 type CapturedRequest = {
   url: string;
@@ -582,17 +583,43 @@ describe("browserApi", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
         requests.push({ url: String(input), init });
-        if (String(input) === "https://mock.example/v1/images/generations") {
+        if (String(input) === "https://mock.example/v1/models") {
           throw new TypeError("Failed to fetch");
         }
-        if (String(input) === "/api/relay") {
+        if (String(input) === "/api/relay/v2/session") {
+          return okJson({ active: true });
+        }
+        if (String(input) === "/api/relay/v2/models") {
           const headers = new Headers(init?.headers);
-          expect(headers.get("X-GPT-Image-2-Upstream")).toBe(
-            "https://mock.example/v1/images/generations",
+          expect(headers.get("X-GPT-Image-2-Api-Base")).toBe(
+            "https://mock.example/v1",
           );
-          expect(headers.get("X-GPT-Image-2-Method")).toBe("POST");
+          expect(headers.get("X-GPT-Image-2-Relay-Version")).toBe("2");
           expect(headers.get("Authorization")).toBe("Bearer sk-test");
-          return okJson({ data: [{ b64_json: tinyPng }] });
+          return new Response(JSON.stringify({ data: [] }), {
+            headers: {
+              "Content-Type": "application/json",
+              "X-GPT-Image-2-Relay": "1",
+            },
+          });
+        }
+        if (String(input) === "/api/relay/v2/generations") {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("X-GPT-Image-2-Api-Base")).toBe(
+            "https://mock.example/v1",
+          );
+          expect(headers.get("X-GPT-Image-2-Relay-Version")).toBe("2");
+          expect(headers.get("X-GPT-Image-2-Upstream")).toBeNull();
+          expect(headers.get("Authorization")).toBe("Bearer sk-test");
+          return new Response(
+            JSON.stringify({ data: [{ b64_json: tinyPng }] }),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                "X-GPT-Image-2-Relay": "1",
+              },
+            },
+          );
         }
         throw new Error(`unexpected fetch: ${String(input)}`);
       }),
@@ -609,8 +636,195 @@ describe("browserApi", () => {
 
     expect(job.status).toBe("completed");
     expect(requests.map((request) => request.url)).toEqual([
+      "https://mock.example/v1/models",
+      "/api/relay/v2/session",
+      "/api/relay/v2/models",
+      "/api/relay/v2/generations",
+    ]);
+  });
+
+  it("establishes an inactive relay session through Turnstile", async () => {
+    const host = {
+      dataset: {},
+      style: {},
+      setAttribute: vi.fn(),
+      remove: vi.fn(),
+    } as unknown as HTMLElement;
+    const turnstile: TurnstileApi = {
+      render: vi.fn((_container, options) => {
+        options.callback("verified-turnstile-token");
+        return "widget-1";
+      }),
+      remove: vi.fn(),
+    };
+    vi.stubGlobal("document", {
+      body: { appendChild: vi.fn() },
+      head: { appendChild: vi.fn() },
+      createElement: vi.fn(() => host),
+      getElementById: vi.fn(() => null),
+      querySelectorAll: vi.fn(() => []),
+    });
+    installBrowserGlobals({
+      __GPT_IMAGE_2_RELAY_BASE__: "/api/relay",
+      turnstile,
+    });
+    await __resetBrowserApiForTests();
+    const requests: CapturedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({ url: String(input), init });
+        if (String(input) === "https://mock.example/v1/models") {
+          throw new TypeError("Failed to fetch");
+        }
+        if (
+          String(input) === "/api/relay/v2/session" &&
+          init?.method === "GET"
+        ) {
+          return okJson({ active: false });
+        }
+        if (String(input) === "/api/relay/v2/config") {
+          return okJson({
+            version: 2,
+            enabled: true,
+            auth_mode: "turnstile",
+            turnstile_site_key: "site-key",
+          });
+        }
+        if (
+          String(input) === "/api/relay/v2/session" &&
+          init?.method === "POST"
+        ) {
+          expect(JSON.parse(String(init.body))).toEqual({
+            token: "verified-turnstile-token",
+          });
+          expect(
+            new Headers(init.headers).get("X-GPT-Image-2-Relay-Version"),
+          ).toBe("2");
+          return okJson({ active: true });
+        }
+        if (String(input) === "/api/relay/v2/models") {
+          return new Response(JSON.stringify({ data: [] }), {
+            headers: {
+              "Content-Type": "application/json",
+              "X-GPT-Image-2-Relay": "1",
+            },
+          });
+        }
+        throw new Error(`unexpected fetch: ${String(input)}`);
+      }),
+    );
+    await addProvider();
+
+    const result = await browserApi.testProvider("mock");
+
+    expect(result.ok).toBe(true);
+    expect(turnstile.render).toHaveBeenCalledOnce();
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://mock.example/v1/models",
+      "/api/relay/v2/session",
+      "/api/relay/v2/config",
+      "/api/relay/v2/session",
+      "/api/relay/v2/models",
+    ]);
+  });
+
+  it("sends signed asset URLs in the relay body and never in a header", async () => {
+    installBrowserGlobals({ __GPT_IMAGE_2_RELAY_BASE__: "/api/relay" });
+    await __resetBrowserApiForTests();
+    const signedUrl = "https://cdn.example.com/image.png?signature=secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url === "https://mock.example/v1/models") {
+          return okJson({ data: [] });
+        }
+        if (url === "https://mock.example/v1/images/generations") {
+          return okJson({ data: [{ url: signedUrl }] });
+        }
+        if (url === signedUrl) throw new TypeError("Failed to fetch");
+        if (url === "/api/relay/v2/session") return okJson({ active: true });
+        if (url === "/api/relay/v2/asset") {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("X-GPT-Image-2-Upstream")).toBeNull();
+          expect([...headers.values()].join(" ")).not.toContain(signedUrl);
+          expect(JSON.parse(String(init?.body))).toEqual({ url: signedUrl });
+          return new Response(new Uint8Array([1, 2, 3]), {
+            headers: {
+              "Content-Type": "image/png",
+              "X-GPT-Image-2-Relay": "1",
+            },
+          });
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+    await addProvider();
+
+    const result = await browserApi.createGenerate({
+      prompt: "signed asset",
+      provider: "mock",
+      format: "png",
+      n: 1,
+    });
+    const job = await waitForJob(result.job_id);
+
+    expect(job.status).toBe("completed");
+  });
+
+  it("rejects a runtime relay URL that is not same-origin", () => {
+    installBrowserGlobals({
+      __GPT_IMAGE_2_RELAY_BASE__: "https://attacker.example.com/api/relay",
+      location: {
+        origin: "https://image.codex-pool.com",
+        hostname: "image.codex-pool.com",
+      },
+    });
+
+    expect(configuredRelayBase()).toBeUndefined();
+
+    installBrowserGlobals({
+      location: {
+        origin: "https://gpt-image-2-dpm.pages.dev",
+        hostname: "gpt-image-2-dpm.pages.dev",
+      },
+    });
+    expect(configuredRelayBase()).toBeUndefined();
+  });
+
+  it("does not replay a generation POST after an ambiguous network failure", async () => {
+    installBrowserGlobals({ __GPT_IMAGE_2_RELAY_BASE__: "/api/relay" });
+    await __resetBrowserApiForTests();
+    const requests: CapturedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        requests.push({ url: String(input), init });
+        if (String(input) === "https://mock.example/v1/models") {
+          return okJson({ data: [] });
+        }
+        if (String(input) === "https://mock.example/v1/images/generations") {
+          throw new TypeError("Failed to fetch after send");
+        }
+        throw new Error(`unsafe automatic replay: ${String(input)}`);
+      }),
+    );
+    await addProvider();
+
+    const result = await browserApi.createGenerate({
+      prompt: "ambiguous response",
+      provider: "mock",
+      format: "png",
+      n: 1,
+    });
+    const job = await waitForJob(result.job_id);
+
+    expect(job.status).toBe("failed");
+    expect(job.error?.message).toContain("不会自动切换中转站重试");
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://mock.example/v1/models",
       "https://mock.example/v1/images/generations",
-      "/api/relay",
     ]);
   });
 
@@ -623,7 +837,16 @@ describe("browserApi", () => {
         if (String(input) === "https://api.duckcoding.com/v1/models") {
           throw new TypeError("Failed to fetch");
         }
-        return new Response("error code: 1016", { status: 530 });
+        if (String(input) === "/api/relay/v2/session") {
+          return okJson({ active: true });
+        }
+        if (String(input) === "/api/relay/v2/models") {
+          return new Response("error code: 1016", {
+            status: 530,
+            headers: { "X-GPT-Image-2-Relay": "1" },
+          });
+        }
+        throw new Error(`unexpected fetch: ${String(input)}`);
       }),
     );
     await addProvider({ api_base: "https://api.duckcoding.com/v1" });

--- a/apps/gpt-image-2-app/src/lib/api/browser/index.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/index.ts
@@ -4,5 +4,6 @@ export * from "./events";
 export * from "./config";
 export * from "./capabilities";
 export * from "./openai";
+export * from "./relay-client";
 export * from "./queue";
 export * from "./downloads";

--- a/apps/gpt-image-2-app/src/lib/api/browser/openai.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/openai.ts
@@ -1,57 +1,24 @@
 import type { GenerateRequest, Job, ProviderConfig } from "../../types";
+import {
+  configuredRelayBase,
+  fetchWithSafeTransport,
+  isLikelyCorsError,
+  trimTrailingSlash,
+} from "./relay-client";
 import { CORS_MESSAGE } from "./state";
-import type { OpenAiImageItem, OpenAiImagePayload, StoredJobInput, StoredUpload } from "./state";
+import type {
+  OpenAiImageItem,
+  OpenAiImagePayload,
+  StoredJobInput,
+  StoredUpload,
+} from "./state";
+
+export { configuredRelayBase, isLikelyCorsError, trimTrailingSlash };
 
 export function endpointFor(provider: ProviderConfig, path: string) {
   const base = provider.api_base?.trim().replace(/\/+$/, "");
   if (!base) throw new Error("服务地址不能为空。");
   return `${base}${path}`;
-}
-
-export function trimTrailingSlash(value: string) {
-  return value.endsWith("/") ? value.slice(0, -1) : value;
-}
-
-export function configuredRelayBase() {
-  if (typeof window === "undefined") return undefined;
-  const configured =
-    window.__GPT_IMAGE_2_RELAY_BASE__ ||
-    import.meta.env.VITE_GPT_IMAGE_2_RELAY_BASE;
-  const value = configured?.trim();
-  if (value) return trimTrailingSlash(value);
-  const host = window.location?.hostname;
-  if (
-    host === "image.codex-pool.com" ||
-    host === "gpt-image-2-dpm.pages.dev" ||
-    host?.endsWith(".gpt-image-2-dpm.pages.dev")
-  ) {
-    return "/api/relay";
-  }
-  return undefined;
-}
-
-export function relayRequest(endpoint: string, init: RequestInit) {
-  const relayBase = configuredRelayBase();
-  if (!relayBase) return undefined;
-  try {
-    const upstream = new URL(endpoint);
-    if (window.location?.origin && upstream.origin === window.location.origin) {
-      return undefined;
-    }
-  } catch {
-    return undefined;
-  }
-  const headers = new Headers(init.headers);
-  headers.set("X-GPT-Image-2-Upstream", endpoint);
-  headers.set("X-GPT-Image-2-Method", init.method || "GET");
-  return {
-    url: relayBase,
-    init: {
-      ...init,
-      method: "POST",
-      headers,
-    } satisfies RequestInit,
-  };
 }
 
 export function imageMime(format?: string) {
@@ -66,7 +33,9 @@ export function imageExtensionFromBlob(blob: Blob) {
   return "png";
 }
 
-export function cloneGenerateRequest(request: GenerateRequest): GenerateRequest {
+export function cloneGenerateRequest(
+  request: GenerateRequest,
+): GenerateRequest {
   return JSON.parse(JSON.stringify(request)) as GenerateRequest;
 }
 
@@ -79,31 +48,27 @@ export function base64ToBlob(value: string, type: string) {
   return new Blob([bytes], { type });
 }
 
-export function isLikelyCorsError(error: unknown) {
-  return (
-    error instanceof TypeError || String(error).includes("Failed to fetch")
-  );
+function endpointForMessage(endpoint: string) {
+  try {
+    const parsed = new URL(endpoint);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return "服务地址已省略";
+  }
 }
 
 export function networkError(error: unknown, endpoint: string) {
   if (isLikelyCorsError(error)) {
-    return new Error(`${CORS_MESSAGE}\n${endpoint}`);
+    return new Error(`${CORS_MESSAGE}\n${endpointForMessage(endpoint)}`);
   }
   return error instanceof Error ? error : new Error(String(error));
 }
 
 export async function fetchProvider(endpoint: string, init: RequestInit) {
   try {
-    return await fetch(endpoint, init);
+    return await fetchWithSafeTransport(endpoint, init);
   } catch (error) {
-    if (!isLikelyCorsError(error)) throw networkError(error, endpoint);
-    const relay = relayRequest(endpoint, init);
-    if (!relay) throw networkError(error, endpoint);
-    try {
-      return await fetch(relay.url, relay.init);
-    } catch (relayError) {
-      throw networkError(relayError, endpoint);
-    }
+    throw networkError(error, endpoint);
   }
 }
 
@@ -120,7 +85,10 @@ export function explainOriginDnsError(endpoint?: string) {
   return `上游服务域名无法解析或回源失败（Cloudflare 1016/530）。请检查 Base URL 是否写错，或换一个当前可公网访问的服务地址。${hostHint}`;
 }
 
-export async function parseErrorResponse(response: Response, endpoint?: string) {
+export async function parseErrorResponse(
+  response: Response,
+  endpoint?: string,
+) {
   const text = await response.text().catch(() => "");
   if (response.status === 530 && /error code:\s*1016/i.test(text)) {
     return explainOriginDnsError(endpoint);
@@ -299,7 +267,9 @@ export async function storedEditInputFromForm(jobId: string, form: FormData) {
   return { jobId, kind: "edit" as const, meta, files };
 }
 
-export function formFromStoredEdit(input: Extract<StoredJobInput, { kind: "edit" }>) {
+export function formFromStoredEdit(
+  input: Extract<StoredJobInput, { kind: "edit" }>,
+) {
   const form = new FormData();
   form.append("meta", JSON.stringify(input.meta));
   for (const file of input.files) {

--- a/apps/gpt-image-2-app/src/lib/api/browser/queue.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/queue.ts
@@ -18,6 +18,7 @@ import {
   runEditRequest,
   runGenerationRequest,
 } from "./openai";
+import { resetRelayClientForTests } from "./relay-client";
 import { deleteDatabase, readStoredJobs, storeOutput, writeJob } from "./store";
 import {
   dbPromise,
@@ -408,6 +409,7 @@ export function prepareBrowserRuntime() {
 }
 
 export async function __resetBrowserApiForTests() {
+  resetRelayClientForTests();
   queue.splice(0, queue.length);
   for (const task of running.values()) {
     task.cancelled = true;

--- a/apps/gpt-image-2-app/src/lib/api/browser/relay-client.ts
+++ b/apps/gpt-image-2-app/src/lib/api/browser/relay-client.ts
@@ -1,0 +1,531 @@
+type RelayOperation = "models" | "generations" | "edits" | "asset";
+type ApiRelayOperation = Exclude<RelayOperation, "asset">;
+type TransportMode = "direct" | "relay";
+
+type RelayConfig = {
+  version?: number;
+  enabled?: boolean;
+  auth_mode?: string;
+  turnstile_site_key?: string | null;
+};
+
+type SessionStatus = {
+  active?: boolean;
+};
+
+type EndpointInfo =
+  | { operation: ApiRelayOperation; apiBase: string }
+  | { operation: "asset"; target: string };
+
+const OPERATION_SUFFIXES: Record<ApiRelayOperation, string> = {
+  models: "/models",
+  generations: "/images/generations",
+  edits: "/images/edits",
+};
+const RELAY_VERSION_HEADER = "X-GPT-Image-2-Relay-Version";
+const API_BASE_HEADER = "X-GPT-Image-2-Api-Base";
+const TURNSTILE_SCRIPT_ID = "gpt-image-2-turnstile-script";
+const TURNSTILE_SCRIPT_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+const transportModes = new Map<string, TransportMode>();
+const transportNegotiations = new Map<string, Promise<TransportMode>>();
+let relaySessionKnown = false;
+let relaySessionPromise: Promise<void> | undefined;
+let relayConfigPromise: Promise<RelayConfig> | undefined;
+let turnstileScriptPromise: Promise<TurnstileApi> | undefined;
+
+export class AmbiguousProviderRequestError extends Error {
+  constructor() {
+    super(
+      "请求可能已经到达服务商，但浏览器没有收到响应。为避免重复生成或重复扣费，本次不会自动切换中转站重试；请先到服务商后台确认结果，再决定是否手动重试。",
+    );
+    this.name = "AmbiguousProviderRequestError";
+  }
+}
+
+export function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function safeSameOriginRelayBase(value: string): string | undefined {
+  if (/\\|[\u0000-\u001f\u007f]/u.test(value) || value.includes("#")) {
+    return undefined;
+  }
+  const pageOrigin = window.location?.origin;
+  if (!pageOrigin) {
+    if (
+      !value.startsWith("/") ||
+      value.startsWith("//") ||
+      value.includes("?")
+    ) {
+      return undefined;
+    }
+    return trimTrailingSlash(value);
+  }
+  try {
+    const resolved = new URL(value, pageOrigin);
+    if (
+      resolved.origin !== pageOrigin ||
+      resolved.username ||
+      resolved.password ||
+      resolved.search ||
+      resolved.hash
+    ) {
+      return undefined;
+    }
+    if (value.startsWith("/") && !value.startsWith("//")) {
+      return trimTrailingSlash(resolved.pathname);
+    }
+    return trimTrailingSlash(resolved.href);
+  } catch {
+    return undefined;
+  }
+}
+
+export function configuredRelayBase(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  const configured =
+    window.__GPT_IMAGE_2_RELAY_BASE__ ||
+    import.meta.env.VITE_GPT_IMAGE_2_RELAY_BASE;
+  const value = configured?.trim();
+  if (value) return safeSameOriginRelayBase(value);
+  const host = window.location?.hostname;
+  if (host === "image.codex-pool.com") {
+    return "/api/relay";
+  }
+  return undefined;
+}
+
+export function isLikelyCorsError(error: unknown): boolean {
+  return (
+    error instanceof TypeError ||
+    (error instanceof Error && error.name === "TimeoutError") ||
+    String(error).includes("Failed to fetch")
+  );
+}
+
+function endpointInfo(endpoint: string, init: RequestInit): EndpointInfo {
+  const authorization = new Headers(init.headers).get("Authorization");
+  if (!authorization) return { operation: "asset", target: endpoint };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    throw new Error("服务地址不是有效的 URL。");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("API 请求地址不能包含查询参数或片段。");
+  }
+  const method = (init.method ?? "GET").toUpperCase();
+  for (const [operation, suffix] of Object.entries(OPERATION_SUFFIXES) as [
+    ApiRelayOperation,
+    string,
+  ][]) {
+    const expectedMethod = operation === "models" ? "GET" : "POST";
+    if (method !== expectedMethod || !parsed.pathname.endsWith(suffix))
+      continue;
+    const prefix = parsed.pathname.slice(0, -suffix.length) || "/";
+    return { operation, apiBase: `${parsed.origin}${prefix}` };
+  }
+  throw new Error("中转站只支持模型检查、图片生成、图片编辑和图片下载。");
+}
+
+function relayUrl(relayBase: string, path: string): string {
+  return `${relayBase}/v2/${path}`;
+}
+
+async function responseJson<T>(response: Response): Promise<T | undefined> {
+  try {
+    return (await response.clone().json()) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+async function relayConfig(relayBase: string): Promise<RelayConfig> {
+  if (!relayConfigPromise) {
+    relayConfigPromise = (async () => {
+      const response = await fetch(relayUrl(relayBase, "config"), {
+        method: "GET",
+        credentials: "same-origin",
+        cache: "no-store",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+      const config = await responseJson<RelayConfig>(response);
+      if (
+        !response.ok ||
+        config?.version !== 2 ||
+        config.enabled !== true ||
+        config.auth_mode !== "turnstile" ||
+        typeof config.turnstile_site_key !== "string" ||
+        !config.turnstile_site_key ||
+        config.turnstile_site_key.length > 256
+      ) {
+        throw new Error(
+          "本站中转服务尚未准备好，请稍后再试或改用支持浏览器 CORS 的服务地址。",
+        );
+      }
+      return config;
+    })().catch((error) => {
+      relayConfigPromise = undefined;
+      throw error;
+    });
+  }
+  return relayConfigPromise;
+}
+
+function loadTurnstile(): Promise<TurnstileApi> {
+  if (window.turnstile) return Promise.resolve(window.turnstile);
+  if (turnstileScriptPromise) return turnstileScriptPromise;
+  if (typeof document === "undefined") {
+    return Promise.reject(new Error("当前浏览器无法加载安全验证组件。"));
+  }
+
+  turnstileScriptPromise = new Promise<TurnstileApi>((resolve, reject) => {
+    const existing = document.getElementById(
+      TURNSTILE_SCRIPT_ID,
+    ) as HTMLScriptElement | null;
+    const script = existing ?? document.createElement("script");
+    const timeout = window.setTimeout(() => {
+      reject(new Error("安全验证组件加载超时，请检查网络后重试。"));
+    }, 20_000);
+    const finish = () => {
+      window.clearTimeout(timeout);
+      if (window.turnstile) resolve(window.turnstile);
+      else reject(new Error("安全验证组件加载失败，请稍后重试。"));
+    };
+    script.addEventListener("load", finish, { once: true });
+    script.addEventListener(
+      "error",
+      () => {
+        window.clearTimeout(timeout);
+        reject(new Error("安全验证组件加载失败，请检查网络后重试。"));
+      },
+      { once: true },
+    );
+    if (!existing) {
+      script.id = TURNSTILE_SCRIPT_ID;
+      script.src = TURNSTILE_SCRIPT_URL;
+      script.async = true;
+      script.defer = true;
+      document.head.appendChild(script);
+    }
+  }).catch((error) => {
+    turnstileScriptPromise = undefined;
+    throw error;
+  });
+  return turnstileScriptPromise;
+}
+
+async function turnstileToken(siteKey: string): Promise<string> {
+  const api = await loadTurnstile();
+  if (typeof document === "undefined" || !document.body) {
+    throw new Error("当前浏览器无法显示安全验证组件。");
+  }
+  const host = document.createElement("div");
+  host.dataset.gptImage2Turnstile = "true";
+  host.setAttribute("role", "status");
+  host.setAttribute("aria-label", "正在进行中转站安全验证");
+  Object.assign(host.style, {
+    position: "fixed",
+    right: "20px",
+    bottom: "20px",
+    zIndex: "2147483647",
+    minWidth: "300px",
+    minHeight: "70px",
+  });
+  document.body.appendChild(host);
+
+  return new Promise<string>((resolve, reject) => {
+    let widgetId: string | undefined;
+    let settled = false;
+    const cleanup = () => {
+      if (widgetId) api.remove(widgetId);
+      host.remove();
+    };
+    const finish = (token?: string, error?: Error) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      window.setTimeout(cleanup, 0);
+      if (token) resolve(token);
+      else reject(error ?? new Error("安全验证未完成，请重试。"));
+    };
+    const timeout = window.setTimeout(
+      () => finish(undefined, new Error("安全验证超时，请重试。")),
+      120_000,
+    );
+    try {
+      widgetId = api.render(host, {
+        sitekey: siteKey,
+        action: "relay_session",
+        appearance: "interaction-only",
+        theme: "auto",
+        callback: (token) => finish(token),
+        "error-callback": () =>
+          finish(undefined, new Error("安全验证失败，请稍后重试。")),
+        "expired-callback": () =>
+          finish(undefined, new Error("安全验证已过期，请重试。")),
+        "timeout-callback": () =>
+          finish(undefined, new Error("安全验证超时，请重试。")),
+      });
+    } catch {
+      finish(undefined, new Error("安全验证组件初始化失败，请稍后重试。"));
+    }
+  });
+}
+
+async function establishRelaySession(relayBase: string): Promise<void> {
+  const statusResponse = await fetch(relayUrl(relayBase, "session"), {
+    method: "GET",
+    credentials: "same-origin",
+    cache: "no-store",
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+  });
+  const status = await responseJson<SessionStatus>(statusResponse);
+  if (statusResponse.ok && status?.active === true) {
+    relaySessionKnown = true;
+    return;
+  }
+
+  const config = await relayConfig(relayBase);
+  const token = await turnstileToken(config.turnstile_site_key!);
+  const response = await fetch(relayUrl(relayBase, "session"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [RELAY_VERSION_HEADER]: "2",
+    },
+    body: JSON.stringify({ token }),
+    credentials: "same-origin",
+    cache: "no-store",
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+  });
+  const result = await responseJson<SessionStatus>(response);
+  if (!response.ok || result?.active !== true) {
+    throw new Error("中转站安全会话建立失败，请稍后重试。");
+  }
+  relaySessionKnown = true;
+}
+
+async function ensureRelaySession(relayBase: string): Promise<void> {
+  if (relaySessionKnown) return;
+  if (!relaySessionPromise) {
+    relaySessionPromise = establishRelaySession(relayBase).finally(() => {
+      relaySessionPromise = undefined;
+    });
+  }
+  return relaySessionPromise;
+}
+
+function relayInit(
+  info: EndpointInfo,
+  init: RequestInit,
+): { path: RelayOperation; init: RequestInit } {
+  const headers = new Headers();
+  headers.set(RELAY_VERSION_HEADER, "2");
+  const sourceHeaders = new Headers(init.headers);
+  const authorization = sourceHeaders.get("Authorization");
+  const accept = sourceHeaders.get("Accept");
+  const contentType = sourceHeaders.get("Content-Type");
+  if (authorization) headers.set("Authorization", authorization);
+  if (accept) headers.set("Accept", accept);
+  if (contentType) headers.set("Content-Type", contentType);
+
+  if (info.operation === "asset") {
+    headers.set("Content-Type", "application/json");
+    return {
+      path: "asset",
+      init: {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ url: info.target }),
+        signal: init.signal,
+      },
+    };
+  }
+  headers.set(API_BASE_HEADER, info.apiBase);
+  return {
+    path: info.operation,
+    init: {
+      method: "POST",
+      headers,
+      body: info.operation === "models" ? undefined : init.body,
+      signal: init.signal,
+    },
+  };
+}
+
+async function workerSessionRequired(response: Response): Promise<boolean> {
+  if (
+    response.status !== 401 ||
+    response.headers.get("X-GPT-Image-2-Relay") === "1"
+  ) {
+    return false;
+  }
+  const payload = await responseJson<{ error?: { code?: string } }>(response);
+  return payload?.error?.code === "session_required";
+}
+
+async function fetchViaRelay(
+  relayBase: string,
+  info: EndpointInfo,
+  init: RequestInit,
+  retrySession = true,
+): Promise<Response> {
+  await ensureRelaySession(relayBase);
+  const relay = relayInit(info, init);
+  const response = await fetch(relayUrl(relayBase, relay.path), {
+    ...relay.init,
+    credentials: "same-origin",
+    cache: "no-store",
+    redirect: "error",
+    referrerPolicy: "no-referrer",
+  });
+  if (retrySession && (await workerSessionRequired(response))) {
+    relaySessionKnown = false;
+    await ensureRelaySession(relayBase);
+    return fetchViaRelay(relayBase, info, init, false);
+  }
+  if (response.ok && response.headers.get("X-GPT-Image-2-Relay") !== "1") {
+    response.body?.cancel("invalid relay response");
+    throw new Error("中转站返回了无法验证的响应，请稍后重试。");
+  }
+  return response;
+}
+
+async function cancelProbeBody(response: Response): Promise<void> {
+  await response.body
+    ?.cancel("transport probe completed")
+    .catch(() => undefined);
+}
+
+async function negotiateTransport(
+  relayBase: string,
+  info: Extract<EndpointInfo, { operation: ApiRelayOperation }>,
+  init: RequestInit,
+): Promise<TransportMode> {
+  const cached = transportModes.get(info.apiBase);
+  if (cached) return cached;
+  const existing = transportNegotiations.get(info.apiBase);
+  if (existing) return existing;
+
+  const negotiation = (async () => {
+    const modelsEndpoint = `${trimTrailingSlash(info.apiBase)}/models`;
+    const sourceHeaders = new Headers(init.headers);
+    try {
+      const direct = await fetch(modelsEndpoint, {
+        method: "GET",
+        headers: {
+          Authorization: sourceHeaders.get("Authorization") ?? "",
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(15_000),
+        cache: "no-store",
+        redirect: "error",
+        referrerPolicy: "no-referrer",
+      });
+      await cancelProbeBody(direct);
+      transportModes.set(info.apiBase, "direct");
+      return "direct";
+    } catch (error) {
+      if (!isLikelyCorsError(error)) throw error;
+    }
+
+    const relayProbe = await fetchViaRelay(
+      relayBase,
+      { operation: "models", apiBase: info.apiBase },
+      {
+        headers: {
+          Authorization: sourceHeaders.get("Authorization") ?? "",
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    if (relayProbe.headers.get("X-GPT-Image-2-Relay") !== "1") {
+      const payload = await responseJson<{ error?: { message?: string } }>(
+        relayProbe,
+      );
+      throw new Error(
+        payload?.error?.message || "中转站连接检查失败，请稍后重试。",
+      );
+    }
+    await cancelProbeBody(relayProbe);
+    transportModes.set(info.apiBase, "relay");
+    return "relay";
+  })().finally(() => {
+    transportNegotiations.delete(info.apiBase);
+  });
+  transportNegotiations.set(info.apiBase, negotiation);
+  return negotiation;
+}
+
+async function fetchSafeOperation(
+  relayBase: string,
+  info: EndpointInfo,
+  endpoint: string,
+  init: RequestInit,
+): Promise<Response> {
+  if (info.operation === "asset") {
+    try {
+      return await fetch(endpoint, init);
+    } catch (error) {
+      if (!isLikelyCorsError(error)) throw error;
+      return fetchViaRelay(relayBase, info, init);
+    }
+  }
+
+  if (info.operation === "models") {
+    try {
+      const response = await fetch(endpoint, init);
+      transportModes.set(info.apiBase, "direct");
+      return response;
+    } catch (error) {
+      if (!isLikelyCorsError(error)) throw error;
+      const response = await fetchViaRelay(relayBase, info, init);
+      transportModes.set(info.apiBase, "relay");
+      return response;
+    }
+  }
+
+  const mode = await negotiateTransport(relayBase, info, init);
+  if (init.signal?.aborted) throw init.signal.reason;
+  try {
+    return mode === "direct"
+      ? await fetch(endpoint, init)
+      : await fetchViaRelay(relayBase, info, init);
+  } catch (error) {
+    if (isLikelyCorsError(error)) throw new AmbiguousProviderRequestError();
+    throw error;
+  }
+}
+
+export async function fetchWithSafeTransport(
+  endpoint: string,
+  init: RequestInit,
+): Promise<Response> {
+  const relayBase = configuredRelayBase();
+  if (!relayBase) return fetch(endpoint, init);
+  const info = endpointInfo(endpoint, init);
+  return fetchSafeOperation(relayBase, info, endpoint, init);
+}
+
+export function resetRelayClientForTests(): void {
+  transportModes.clear();
+  transportNegotiations.clear();
+  relaySessionKnown = false;
+  relaySessionPromise = undefined;
+  relayConfigPromise = undefined;
+  turnstileScriptPromise = undefined;
+  if (typeof document !== "undefined") {
+    document
+      .querySelectorAll("[data-gpt-image2-turnstile]")
+      .forEach((node) => node.remove());
+  }
+}

--- a/apps/gpt-image-2-app/src/vite-env.d.ts
+++ b/apps/gpt-image-2-app/src/vite-env.d.ts
@@ -10,8 +10,25 @@ interface ImportMetaEnv {
   readonly VITE_GPT_IMAGE_2_RELAY_BASE?: string;
 }
 
+interface TurnstileRenderOptions {
+  sitekey: string;
+  action: string;
+  appearance: "interaction-only";
+  theme: "auto" | "light" | "dark";
+  callback(token: string): void;
+  "error-callback"(): void;
+  "expired-callback"(): void;
+  "timeout-callback"(): void;
+}
+
+interface TurnstileApi {
+  render(container: HTMLElement, options: TurnstileRenderOptions): string;
+  remove(widgetId: string): void;
+}
+
 interface Window {
   __GPT_IMAGE_2_API_BASE__?: string;
   __GPT_IMAGE_2_RELAY_BASE__?: string;
   __GPT_IMAGE_2_RUNTIME__?: "browser" | "http";
+  turnstile?: TurnstileApi;
 }

--- a/crates/gpt-image-2-core/Cargo.toml
+++ b/crates/gpt-image-2-core/Cargo.toml
@@ -18,7 +18,7 @@ keyring = "3.6.3"
 image = { version = "0.25.8", default-features = false, features = ["jpeg", "png", "webp"] }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
 hmac = "0.12.1"
-lettre = { version = "0.11.21", default-features = false, features = ["builder", "hostname", "pool", "ring", "rustls", "smtp-transport", "webpki-roots"] }
+lettre = { version = "0.11.23", default-features = false, features = ["builder", "hostname", "pool", "ring", "rustls", "smtp-transport", "webpki-roots"] }
 md-5 = "0.10.6"
 mime_guess = "2.0.5"
 reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "charset", "http2", "json", "multipart", "rustls-tls", "socks"] }

--- a/crates/gpt-image-2-web/Cargo.toml
+++ b/crates/gpt-image-2-web/Cargo.toml
@@ -14,11 +14,14 @@ dist = false
 
 [dependencies]
 axum = "0.8.7"
+base64 = "0.22.1"
 gpt-image-2-core = { path = "../gpt-image-2-core", version = "0.7.3" }
 gpt-image-2-runtime = { path = "../gpt-image-2-runtime", version = "0.7.3" }
+hmac = "0.12.1"
 mime_guess = "2.0.5"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+sha2 = "0.10.9"
 tokio = { version = "1.48.0", features = ["fs", "macros", "net", "rt-multi-thread"] }
 tower-http = { version = "0.6.7", features = ["fs"] }
 

--- a/crates/gpt-image-2-web/src/auth.rs
+++ b/crates/gpt-image-2-web/src/auth.rs
@@ -3,11 +3,22 @@
 use super::*;
 use axum::extract::Request;
 use axum::middleware::Next;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) const SESSION_COOKIE: &str = "gpt2_session";
 const TOKEN_ENV: &str = "GPT_IMAGE_2_WEB_TOKEN";
 const ALLOWED_HOSTS_ENV: &str = "GPT_IMAGE_2_WEB_ALLOWED_HOSTS";
 const ALLOW_UNAUTH_ENV: &str = "GPT_IMAGE_2_WEB_ALLOW_UNAUTHENTICATED";
+const SECURE_COOKIE_ENV: &str = "GPT_IMAGE_2_WEB_SECURE_COOKIE";
+const SESSION_TTL_ENV: &str = "GPT_IMAGE_2_WEB_SESSION_TTL_SECONDS";
+const DEFAULT_SESSION_TTL_SECONDS: u64 = 43_200;
+const MIN_SESSION_TTL_SECONDS: u64 = 300;
+const MAX_SESSION_TTL_SECONDS: u64 = 604_800;
+type HmacSha256 = Hmac<Sha256>;
 
 fn env_flag(name: &str) -> bool {
     env::var(name)
@@ -16,12 +27,29 @@ fn env_flag(name: &str) -> bool {
 }
 
 /// Resolved auth policy for the server, decided once at startup.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct AuthPolicy {
     /// The shared secret from `GPT_IMAGE_2_WEB_TOKEN`, if configured.
     token: Option<String>,
     /// Host names allowed when running token-less (anti-DNS-rebinding).
     allowed_hosts: Vec<String>,
+    /// Whether the browser session cookie is restricted to HTTPS.
+    secure_cookie: bool,
+    /// Lifetime of the signed browser session. The shared token itself is
+    /// never copied into the cookie.
+    session_ttl_seconds: u64,
+}
+
+impl fmt::Debug for AuthPolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AuthPolicy")
+            .field("token_configured", &self.token.is_some())
+            .field("allowed_hosts", &self.allowed_hosts)
+            .field("secure_cookie", &self.secure_cookie)
+            .field("session_ttl_seconds", &self.session_ttl_seconds)
+            .finish()
+    }
 }
 
 impl Default for AuthPolicy {
@@ -35,6 +63,8 @@ impl Default for AuthPolicy {
                 "127.0.0.1".to_string(),
                 "::1".to_string(),
             ],
+            secure_cookie: false,
+            session_ttl_seconds: DEFAULT_SESSION_TTL_SECONDS,
         }
     }
 }
@@ -87,15 +117,119 @@ impl AuthPolicy {
             ];
         }
 
+        let secure_cookie = env_flag(SECURE_COOKIE_ENV);
+        let session_ttl_seconds = match env::var(SESSION_TTL_ENV) {
+            Ok(value) => value.trim().parse::<u64>().map_err(|_| {
+                format!(
+                    "{SESSION_TTL_ENV} must be an integer between \
+                     {MIN_SESSION_TTL_SECONDS} and {MAX_SESSION_TTL_SECONDS} seconds."
+                )
+            })?,
+            Err(_) => DEFAULT_SESSION_TTL_SECONDS,
+        };
+        if !(MIN_SESSION_TTL_SECONDS..=MAX_SESSION_TTL_SECONDS).contains(&session_ttl_seconds) {
+            return Err(format!(
+                "{SESSION_TTL_ENV} must be between {MIN_SESSION_TTL_SECONDS} and \
+                 {MAX_SESSION_TTL_SECONDS} seconds."
+            ));
+        }
+        if token.is_some() && !host_is_loopback(bind_host) && !secure_cookie {
+            eprintln!(
+                "gpt-image-2-web: WARNING — browser sessions do not have the Secure cookie \
+                 attribute. Set {SECURE_COOKIE_ENV}=1 when HTTPS terminates at a reverse proxy; \
+                 leave it unset only for intentional plain-HTTP deployments."
+            );
+        }
+
         Ok(Self {
             token,
             allowed_hosts,
+            secure_cookie,
+            session_ttl_seconds,
         })
     }
 
     pub(crate) fn requires_token(&self) -> bool {
         self.token.is_some()
     }
+
+    fn issue_session_at(&self, now: u64) -> Option<String> {
+        let token = self.token.as_deref()?;
+        let expires_at = now.checked_add(self.session_ttl_seconds)?;
+        let payload = format!("v1.{expires_at}");
+        let mut mac = HmacSha256::new_from_slice(token.as_bytes()).ok()?;
+        mac.update(payload.as_bytes());
+        let signature = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+        Some(format!("{payload}.{signature}"))
+    }
+
+    fn issue_session(&self) -> Option<String> {
+        self.issue_session_at(unix_time_seconds()?)
+    }
+
+    fn verify_session_at(&self, value: &str, now: u64) -> bool {
+        let Some(token) = self.token.as_deref() else {
+            return false;
+        };
+        let mut parts = value.split('.');
+        let (Some(version), Some(expires), Some(signature), None) =
+            (parts.next(), parts.next(), parts.next(), parts.next())
+        else {
+            return false;
+        };
+        if version != "v1" {
+            return false;
+        }
+        let Ok(expires_at) = expires.parse::<u64>() else {
+            return false;
+        };
+        if expires_at < now || expires_at > now.saturating_add(self.session_ttl_seconds) {
+            return false;
+        }
+        let Ok(signature) = URL_SAFE_NO_PAD.decode(signature) else {
+            return false;
+        };
+        let payload = format!("{version}.{expires}");
+        let Ok(mut mac) = HmacSha256::new_from_slice(token.as_bytes()) else {
+            return false;
+        };
+        mac.update(payload.as_bytes());
+        mac.verify_slice(&signature).is_ok()
+    }
+
+    fn verify_session(&self, value: &str) -> bool {
+        unix_time_seconds()
+            .map(|now| self.verify_session_at(value, now))
+            .unwrap_or(false)
+    }
+
+    fn request_is_authorized(&self, request: &Request) -> bool {
+        let Some(expected) = self.token.as_deref() else {
+            return true;
+        };
+        bearer_token(request)
+            .map(|token| constant_time_eq(&token, expected))
+            .unwrap_or(false)
+            || session_cookie(request)
+                .map(|cookie| self.verify_session(&cookie))
+                .unwrap_or(false)
+    }
+
+    fn session_cookie_header(&self, value: &str) -> String {
+        let secure = if self.secure_cookie { "; Secure" } else { "" };
+        format!(
+            "{SESSION_COOKIE}={value}; HttpOnly; SameSite=Strict; Path=/; \
+             Max-Age={}{secure}",
+            self.session_ttl_seconds
+        )
+    }
+}
+
+fn unix_time_seconds() -> Option<u64> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_secs())
 }
 
 fn host_is_loopback(host: &str) -> bool {
@@ -140,15 +274,18 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     diff == 0
 }
 
-fn presented_token(request: &Request) -> Option<String> {
-    if let Some(value) = request
+fn bearer_token(request: &Request) -> Option<String> {
+    let value = request
         .headers()
         .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        && let Some(token) = value.strip_prefix("Bearer ")
-    {
-        return Some(token.trim().to_string());
-    }
+        .and_then(|value| value.to_str().ok())?;
+    let (scheme, token) = value.split_once(' ')?;
+    scheme
+        .eq_ignore_ascii_case("Bearer")
+        .then(|| token.trim().to_string())
+}
+
+fn session_cookie(request: &Request) -> Option<String> {
     request
         .headers()
         .get(header::COOKIE)
@@ -181,10 +318,8 @@ pub(crate) async fn require_auth(
     }
 
     match &policy.token {
-        Some(expected) => match presented_token(&request) {
-            Some(token) if constant_time_eq(&token, expected) => next.run(request).await,
-            _ => unauthorized("Missing or invalid access token."),
-        },
+        Some(_) if policy.request_is_authorized(&request) => next.run(request).await,
+        Some(_) => unauthorized("Missing or invalid access token."),
         None => {
             let host_ok = request
                 .headers()
@@ -214,11 +349,22 @@ pub(crate) async fn create_session(
         return (StatusCode::NO_CONTENT, ()).into_response();
     };
     if constant_time_eq(body.token.trim(), expected) {
-        let cookie = format!(
-            "{SESSION_COOKIE}={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=1209600",
-            expected
-        );
-        (StatusCode::NO_CONTENT, [(header::SET_COOKIE, cookie)]).into_response()
+        let Some(session) = state.auth.issue_session() else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": { "message": "Could not create session." } })),
+            )
+                .into_response();
+        };
+        let cookie = state.auth.session_cookie_header(&session);
+        (
+            StatusCode::NO_CONTENT,
+            [
+                (header::SET_COOKIE, cookie),
+                (header::CACHE_CONTROL, "no-store".to_string()),
+            ],
+        )
+            .into_response()
     } else {
         unauthorized("Invalid access token.")
     }
@@ -231,12 +377,7 @@ pub(crate) async fn session_status(
     request: Request,
 ) -> Json<Value> {
     let required = state.auth.requires_token();
-    let authorized = match &state.auth.token {
-        Some(expected) => presented_token(&request)
-            .map(|token| constant_time_eq(&token, expected))
-            .unwrap_or(false),
-        None => true,
-    };
+    let authorized = state.auth.request_is_authorized(&request);
     Json(json!({ "auth_required": required, "authorized": authorized }))
 }
 
@@ -291,5 +432,55 @@ mod tests {
         assert!(!constant_time_eq("secret", "secret-longer"));
         assert!(!constant_time_eq("", "x"));
         assert!(constant_time_eq("", ""));
+    }
+
+    fn token_policy(secure_cookie: bool) -> AuthPolicy {
+        AuthPolicy {
+            token: Some("shared-secret-that-must-not-enter-the-cookie".to_string()),
+            allowed_hosts: vec!["localhost".to_string()],
+            secure_cookie,
+            session_ttl_seconds: 3_600,
+        }
+    }
+
+    #[test]
+    fn signed_session_never_contains_the_shared_token() {
+        let policy = token_policy(true);
+        let session = policy.issue_session_at(1_000).expect("session");
+        assert!(!session.contains("shared-secret"));
+        assert!(policy.verify_session_at(&session, 1_001));
+        assert!(policy.verify_session_at(&session, 4_600));
+        assert!(!policy.verify_session_at(&session, 4_601));
+    }
+
+    #[test]
+    fn signed_session_rejects_tampering_and_wrong_keys() {
+        let policy = token_policy(true);
+        let session = policy.issue_session_at(1_000).expect("session");
+        let tampered = session.replacen("4600", "5600", 1);
+        assert!(!policy.verify_session_at(&tampered, 1_001));
+
+        let mut other_policy = policy.clone();
+        other_policy.token = Some("rotated-secret".to_string());
+        assert!(!other_policy.verify_session_at(&session, 1_001));
+    }
+
+    #[test]
+    fn session_cookie_uses_secure_only_when_configured() {
+        let secure = token_policy(true).session_cookie_header("signed-value");
+        assert!(secure.contains("; Secure"));
+        assert!(secure.contains("HttpOnly"));
+        assert!(secure.contains("SameSite=Strict"));
+        assert!(secure.contains("Max-Age=3600"));
+
+        let plain_http = token_policy(false).session_cookie_header("signed-value");
+        assert!(!plain_http.contains("; Secure"));
+    }
+
+    #[test]
+    fn auth_policy_debug_output_redacts_the_token() {
+        let debug = format!("{:?}", token_policy(true));
+        assert!(debug.contains("token_configured: true"));
+        assert!(!debug.contains("shared-secret"));
     }
 }

--- a/docs/docker-web.md
+++ b/docs/docker-web.md
@@ -27,11 +27,26 @@ back stored provider keys — is reachable by anything that can reach the port.
 The server therefore **refuses to start on a non-loopback host unless
 `GPT_IMAGE_2_WEB_TOKEN` is set**. Set it to a secret and the whole `/api`
 surface requires that token (sent as `Authorization: Bearer <token>` or, for
-the web UI, exchanged for an HttpOnly session cookie at first load):
+the web UI, exchanged for a short-lived signed HttpOnly session cookie at first
+load). The shared token itself is never copied into the cookie:
 
 ```bash
 -e GPT_IMAGE_2_WEB_TOKEN="$(openssl rand -hex 32)"
 ```
+
+When HTTPS terminates at a reverse proxy, require HTTPS at that proxy and add
+the `Secure` attribute to browser sessions:
+
+```bash
+-e GPT_IMAGE_2_WEB_SECURE_COOKIE=1
+```
+
+The signed session lasts 12 hours by default. It can be changed with
+`GPT_IMAGE_2_WEB_SESSION_TTL_SECONDS` from 300 seconds through 604800 seconds
+(7 days). Rotating `GPT_IMAGE_2_WEB_TOKEN` immediately invalidates all existing
+browser sessions. Leave `GPT_IMAGE_2_WEB_SECURE_COOKIE` unset only for an
+intentional plain-HTTP local deployment; the server emits a warning when a
+token-protected non-loopback listener lacks it.
 
 To run without a token, bind loopback only (`-e GPT_IMAGE_2_WEB_HOST=127.0.0.1`
 and publish to `127.0.0.1:8787:8787`); token-less mode also rejects requests

--- a/docs/relay-security-design.md
+++ b/docs/relay-security-design.md
@@ -1,0 +1,542 @@
+# 公共 Relay v2 安全设计
+
+状态：代码已实施，尚未部署生产；上线门禁见 [`relay-security-runbook.md`](relay-security-runbook.md)  
+日期：2026-08-22  
+适用范围：`image.codex-pool.com` 静态 Web 与 `gpt-image-2-relay` Cloudflare Worker
+
+## 1. 决策摘要
+
+生产环境不采用“中转站域名白名单”作为主要边界。用户可以继续填写任意公网 OpenAI-compatible API Base；系统限制的是 Relay 可执行的操作，而不是提前枚举域名。
+
+推荐方案是：
+
+1. 浏览器先用无副作用的 `/models` 请求探测传输能力，并按 Provider 记住 `direct` 或 `relay`；确认可以直连时不经过我们的 Worker。
+2. 探测发生 CORS 网络失败时，静态 Web 才为后续生成/编辑选择 Relay。状态不明的生成/编辑 POST 不允许自动换通道重试，避免重复扣费。
+3. Relay 不再接受任意 URL、任意路径和任意方法，而只提供四种产品实际需要的能力：测试模型接口、图片生成、图片编辑、结果图片下载。
+4. 首次使用 Relay 时，通过 Cloudflare Turnstile 换取短期、HttpOnly 的匿名会话；Worker 同时校验同源请求并按会话限速。
+5. API Key、提示词和图片只流经内存转发，不保存到 Relay；API Key 不写入日志，也不用于会话或限速标识。
+6. 无法满足该协议的非标准服务，继续由桌面 App 或 Docker 直连，不为它们重新开放通用公网代理。
+
+这套设计保留任意中转站域名，同时把当前的“匿名通用 HTTPS 代理”收缩为“经过人机验证、限速、只会调用图片 API 的能力代理”。
+
+## 2. 为什么不用其他方案
+
+| 方案                         | 任意域名兼容 | 防滥用能力 | 结论                                 |
+| ---------------------------- | ------------ | ---------- | ------------------------------------ |
+| 枚举上游域名白名单           | 差           | 强         | 不符合产品需求                       |
+| 在前端内置 Relay 密钥        | 好           | 无         | 浏览器中的密钥必然可提取，拒绝       |
+| 只检查 `Origin`              | 好           | 弱         | 非浏览器客户端可以伪造，不能作为认证 |
+| 保持开放代理，仅阻止内网 IP  | 好           | 弱         | 仍可代理任意公网请求，拒绝           |
+| 操作级协议 + 匿名会话 + 限速 | 好           | 较强       | 推荐                                 |
+| 完全取消 Web Relay           | 差           | 最强       | 作为紧急关闭和桌面/Docker 兜底       |
+
+OWASP 将“目标域名预先未知”的场景单独归类：此时域名 allowlist 不成立，需要结合输入约束、公共网络边界和滥用控制做纵深防御。参见 [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html#case-2-application-can-send-requests-to-any-external-ip-address-or-domain-name)。
+
+## 3. 当前事实与兼容约束
+
+### 3.1 实施前代码路径（迁移基线）
+
+- `apps/gpt-image-2-app/src/lib/api/browser/openai.ts` 实施前会先直接 `fetch(endpoint)`；疑似 CORS 网络失败时再调用 `/api/relay`。
+- 静态 Web 只支持 OpenAI-compatible Provider，实际调用路径是 `/models`、`/images/generations` 和 `/images/edits`。
+- API Key 当前通过 `Authorization: Bearer ...` 转发；生成结果若返回 URL，浏览器还可能通过 Relay 下载图片。
+- 当前 direct-first 对有副作用的 POST 存在一个兼容风险：请求可能已被上游处理，但响应因 CORS 或断网不可见，随后 Relay 重试会导致重复生成/扣费。v2 必须用无副作用探测提前选择通道，并把“结果未知”与“确定失败”分开。
+- 浏览器队列默认并发为 2；单个不支持 `n` 的 Provider 最多会并发拆出 16 个子请求，因此限速不能按普通表单接口设置得过低。
+- 桌面 App、Docker 和 CLI 有自己的服务端/本地 HTTP 客户端，不依赖这个公共 Relay。
+
+### 3.2 生产流量基线
+
+2026-07-23 至 2026-08-22 的 Worker 后台数据，在排除本次审计请求后为：
+
+- 65 次调用，分布在 23 个自然日；
+- 54 次成功、10 次异常、1 次客户端中断；
+- 单分钟历史峰值为 5 次，单日峰值为 8 次；
+- 已确认的真实请求使用标准 `/v1/images/generations` 或 `/v1/images/edits` 路径；近期真实请求体约为 669 B、126 KiB 和 5.9 MiB，均远低于当前 50 MiB 上限。
+
+因此这是低流量但有真实用户的生产服务。迁移必须兼容标准图片接口，不能直接关闭或突然启用域名白名单。
+
+### 3.3 本次实施结果
+
+- Worker 已拆分为 `config.ts`、`policy.ts`、`session.ts`、`streams.ts`、`types.ts` 与路由入口 `index.ts`。
+- 前端新增 `relay-client.ts`，以 `/models` 安全探测选择传输，并阻止状态不明的生成/编辑 POST 自动重放。
+- v2 已强制 Turnstile 会话、固定操作、同源与 Fetch Metadata、三个独立限流绑定、SSRF 校验、大小上限和 header allowlist。
+- v1 已从开放代理改为受限兼容，只接受模型检查、生成、编辑和无凭证 asset 下载。
+- Pages 已增加 CSP/安全头；Release workflow 已固定为 secret 检查、Worker-first、线上 v2 readiness、Pages-last。
+- 这些改动只在本地分支完成；尚未部署 Worker 或 Pages，也未改变当前生产行为。
+
+## 4. 安全目标和非目标
+
+### 4.1 必须达到
+
+- 不需要预知用户选择的 API 域名。
+- 未经授权的脚本不能把 Relay 当作任意 URL/方法的通用代理。
+- Relay 不能访问显式的本机、私网、链路本地或特殊用途地址。
+- 跳转不能绕过目标检查。
+- 用户 API Key、提示词、上传图片和带签名的下载 URL 不得进入应用日志。
+- 单个客户端不能无上限消耗 Worker 请求、入站流量和出站流量。
+- 安全控制失败时必须关闭 Relay 请求，不能静默退回开放模式。
+- 正常用户可以识别“上游错误”“Relay 策略拒绝”“限流”和“人机验证失败”，避免把所有问题都误报成 CORS。
+
+### 4.2 明确不承诺
+
+- Relay 无法判断一个任意第三方 API 是否诚实；用户主动配置的上游仍能看到其 API Key、提示词和图片。
+- Turnstile 与限速提高滥用成本，但不能绝对阻止分布式真人或 Bot 网络。
+- 静态 Web 无法安全支持任意自定义 HTTP 方法、任意路径、任意请求头和非标准端口；这些高级场景应使用桌面 App 或 Docker。
+- 本设计不把浏览器 IndexedDB 变成密钥保险箱。静态 Web 的 API Key 仍属于浏览器可访问数据，需要 CSP、无 XSS 和明确的用户提示共同保护。
+
+## 5. 威胁模型
+
+### 5.1 需要保护的资产
+
+- 用户的上游 API Key、提示词、参考图片和生成结果；
+- 用户上游账户的调用额度；
+- Cloudflare Worker 配额、带宽、账单与域名信誉；
+- 生产站点可用性；
+- 后台日志中可能出现的上游地址与请求元数据。
+
+### 5.2 攻击者
+
+- 不访问网页、直接用脚本调用 `/api/relay` 的匿名攻击者；
+- 能伪造 `Origin`、User-Agent 等浏览器头的程序；
+- 诱导用户打开恶意网页的攻击者；
+- 返回恶意重定向、超大响应或伪造内容类型的上游；
+- 已经通过 Turnstile、但试图滥用服务的客户端；
+- 利用未来前端 XSS 读取浏览器内 API Key 的攻击者。
+
+### 5.3 关键结论
+
+`CORS` 和 `Origin` 只能限制正常浏览器，不能认证命令行或 Bot。前端固定密钥也不是秘密。真正的安全边界必须在 Worker 内由“短期会话 + 固定操作 + 请求约束 + 限速”共同建立。
+
+## 6. 目标架构
+
+```text
+静态 Web
+  │
+  ├─ 1. 用 /models 无副作用探测任意 HTTPS API Base ─> 用户上游
+  │       └─ 可达：记住 direct，生成/编辑均直连
+  │
+  └─ 2. 探测确认 CORS/网络层不可直连时，记住 relay
+          │
+          ├─ 懒加载 Turnstile，换取匿名 HttpOnly 会话
+          │
+          └─ 调用 Relay v2 的固定操作
+                 │
+                 ├─ 会话、Origin、Fetch Metadata 校验
+                 ├─ 会话级与应急 IP 级限速
+                 ├─ URL/方法/路径/头/大小/跳转校验
+                 ├─ 只构造产品允许的上游请求
+                 └──────────────────────────────────> 任意公网 HTTPS API Base
+
+桌面 App / Docker / CLI ── 本地或自托管客户端直连 ──> 用户上游
+```
+
+## 7. Relay v2 协议
+
+### 7.1 公共配置
+
+`GET /api/relay/v2/config`
+
+只返回公开信息：
+
+```json
+{
+  "version": 2,
+  "enabled": true,
+  "auth_mode": "turnstile",
+  "turnstile_site_key": "<public-site-key>",
+  "session_ttl_seconds": 86400,
+  "operations": ["models", "generations", "edits", "asset"]
+}
+```
+
+要求：
+
+- 不返回任何 Worker secret、内部规则或限速 key；
+- `Cache-Control: no-store`，避免 kill switch、secret 缺失或 readiness 变化被缓存；
+- 可通过 `enabled=false` 向前端提供明确的紧急关闭状态。
+
+### 7.2 匿名会话
+
+`POST /api/relay/v2/session`
+
+请求体仅包含一次性 Turnstile token。Worker 必须调用 Siteverify 服务端验证，并校验返回的 `hostname` 与 `action`。Turnstile token 五分钟过期且只能使用一次，不能只在前端显示组件而跳过服务端验证。参见 [Cloudflare Turnstile server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)。
+
+验证成功后设置：
+
+```text
+Set-Cookie: __Host-gpt2_relay=<signed-token>;
+            Path=/; Max-Age=86400; Secure; HttpOnly; SameSite=Strict
+```
+
+签名 token 只包含：协议版本、128-bit 随机会话 ID、签发时间和到期时间。使用 Worker secret 中的 HMAC-SHA-256 密钥签名；不包含 API Key、上游域名、IP 或用户身份。
+
+规则：
+
+- 会话只在真正需要 Relay 时懒创建；
+- 前端对并发的 `ensureRelaySession()` 做 Promise 去重，避免一个 16 图批次触发 16 次验证；
+- 会话过期时只重试一次，不允许无限刷新；
+- HMAC 密钥支持当前值和前一值的短期双读，以便无中断轮换；
+- Turnstile/Siteverify 不可用时返回结构化 `503 relay_auth_unavailable`，不得自动放行。
+
+### 7.3 固定操作
+
+| 外部端点                         | 上游行为                             | API Key      | 典型上限                          |
+| -------------------------------- | ------------------------------------ | ------------ | --------------------------------- |
+| `POST /api/relay/v2/models`      | `GET <api-base>/models`              | 转发         | 响应 2 MiB，15 秒                 |
+| `POST /api/relay/v2/generations` | `POST <api-base>/images/generations` | 转发         | 请求 1 MiB，响应 120 MiB，300 秒  |
+| `POST /api/relay/v2/edits`       | `POST <api-base>/images/edits`       | 转发         | 请求 50 MiB，响应 120 MiB，300 秒 |
+| `POST /api/relay/v2/asset`       | `GET <signed-image-url>`             | **绝不转发** | 请求 8 KiB，响应 32 MiB，60 秒    |
+
+前三个端点通过 `X-GPT-Image-2-Api-Base` 接收 API Base，而不是任意最终 URL。Worker 自己拼接固定后缀。`asset` 的带签名完整 URL 放在很小的 JSON 请求体里，避免 Cloudflare 自动请求日志记录自定义头时把签名查询参数写入日志。
+
+禁止继续支持：
+
+- 由客户端指定上游 method；
+- 任意 API path；
+- 把上游 URL 中的用户名、密码、query 或 fragment 当成 API Base；
+- 向 asset 下载请求转发 `Authorization`；
+- WebSocket、CONNECT、HTTP 或非 443 端口。
+
+### 7.4 请求头策略
+
+从“黑名单删除危险头”改为“白名单复制必要头”。
+
+API 操作最多允许转发：
+
+- `Authorization`
+- `Accept`
+- `Content-Type`
+
+禁止转发：
+
+- `Cookie`、`Origin`、`Referer`
+- `Host`、`Connection`、`Transfer-Encoding`
+- `CF-*`、`X-Forwarded-*`、`X-Real-IP`
+- 所有 `X-GPT-Image-2-*` 内部协议头
+
+响应只复制安全的内容头和 Provider 的诊断 ID；始终删除 `Set-Cookie`，增加 `Cache-Control: no-store`、`X-Content-Type-Options: nosniff`、Relay 标记和策略版本。
+
+## 8. 目标 URL 与 SSRF 防护
+
+### 8.1 API Base 规范化
+
+只接受满足全部条件的 API Base：
+
+- `https:`；
+- 默认 443 端口；
+- 没有 username/password、query、fragment；
+- hostname 经过 WHATWG URL 解析和 IDNA 规范化；
+- 拒绝所有 IPv4/IPv6 literal，包括十进制、八进制、十六进制和混合写法；
+- 拒绝 `localhost`、`*.localhost`、`*.local`、`*.internal`、`home.arpa` 等特殊名称；
+- 拒绝 Relay 自己的生产 hostname 和 Pages hostname，避免递归回源；
+- 路径长度有限，拒绝控制字符、反斜杠、编码后的 `/`、`\`、`.`/`..` 绕过形式；
+- 整个值不超过 2 KiB。
+
+Worker 只在规范化后的 Base 后追加固定路径，不允许客户端控制拼接后的 operation path。
+
+### 8.2 网络层
+
+- Wrangler 启用 `global_fetch_strictly_public` compatibility flag，使全局 `fetch()` 始终按公共互联网入口路由；参见 [Cloudflare compatibility flags](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#global-fetch-strictly-public)。
+- 不给 Worker 配置通向内部服务的 Service Binding、Cloudflare Tunnel 私网路由或其他私网能力。
+- 应用层继续拒绝显式私网/保留地址，但不依赖一次“先 DNS 解析、后 fetch”的自制校验，因为这会产生 DNS rebinding/TOCTOU 窗口。
+- API 操作使用 `redirect: "manual"`，任何 3xx 原样作为错误返回，不跟随。
+- asset 最多允许两次 GET 跳转；每一级都重新执行完整 URL 策略，且始终不携带 Authorization、Cookie 或 Referer。
+
+### 8.3 内容与流量限制
+
+- 先检查 `Content-Length`，缺失或分块传输时仍用计数 TransformStream 约束真实读取字节；不能只相信客户端头。
+- 响应同样流式计数，超过限制时立即取消上游 reader。
+- `models`、`generations`、`edits` 的成功响应要求 JSON-compatible Content-Type；非 2xx 错误允许有限大小的文本/JSON，便于向用户显示 Provider 错误。
+- `asset` 的 2xx 响应只接受 `image/*` 或明确兼容的 `application/octet-stream`；不把 HTML 伪装成图片返回给应用。
+- 每个上游请求使用 `AbortSignal.timeout()`；浏览器取消任务时向上游传播 abort。
+- 当前代码每个 API 请求只发一个上游 subrequest，asset 最多两次重定向，另由操作超时和流量上限约束；若生产套餐支持额外的 CPU/subrequest 配额控制，再按 canary 数据收紧，不能在缺少真实长任务数据时直接设得过低。参见 [Workers limits](https://developers.cloudflare.com/workers/platform/limits/)。
+
+## 9. 访问控制与限速
+
+### 9.1 每次 Relay 请求必须同时通过
+
+1. 路径和外层 HTTP method 正确；
+2. `Origin` 精确等于生产站点；
+3. `Sec-Fetch-Site` 为 `same-origin`（作为纵深防御，不单独作为认证）；
+4. `__Host-gpt2_relay` 会话签名、版本和有效期正确；
+5. 会话级限速通过；
+6. URL、操作、头、请求体和响应策略通过。
+
+生产 v2 不接受“没有 Origin 但可能是 CLI”的例外。CLI、桌面和 Docker 本来就不需要公共 Relay。
+
+### 9.2 建议阈值
+
+初始值根据现有流量和浏览器最大批次设置：
+
+- 会话创建：同一网络来源 10 次/分钟，超出后 429；
+- 普通 Relay：同一会话 120 次/分钟，以覆盖两个并行任务各 16 次生成请求和 16 次图片下载的合法峰值；
+- 受限 v1：同一网络来源 80 次/分钟；WAF 可另设更宽松的 IP 应急兜底；
+- 全局告警：超过 1,000 次/日或出站字节显著偏离基线时通知并可自动切换 kill switch；
+- 5 分钟内高比例 401/403/404/5xx 或持续触发大小限制时，把该会话升级为重新验证或临时封禁；跨请求自动风控若需要精确状态，应另行使用 Durable Object，不能假装无状态 Rate Limiting binding 可以完成。
+
+Cloudflare Workers Rate Limiting binding 适合用随机 session ID 作为 key；官方不建议把共享 IP 作为唯一用户标识，而且该计数是按 Cloudflare location、最终一致的，所以 IP 规则只作为更宽松的应急层，而不是精确配额。参见 [Cloudflare Workers Rate Limiting](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/)。
+
+限速响应统一为：
+
+```json
+{
+  "error": {
+    "code": "relay_rate_limited",
+    "message": "请求过于频繁，请稍后重试。",
+    "retry_after_seconds": 60
+  }
+}
+```
+
+并设置真实的 `Retry-After`，前端队列不得无间隔重试。
+
+## 10. 浏览器端设计
+
+### 10.1 回退流程
+
+1. 根据 Provider 配置和缓存确定传输模式。
+2. `auto` 模式先对 `/models` 做无副作用探测；只有该探测的 `TypeError/Failed to fetch` 才触发 Relay 协商。
+3. 探测拿到任意 HTTP Response 时选择 direct；上游返回 4xx/5xx 不切换路径。
+4. 探测确认不可直连时，根据调用函数确定 operation，不能再从任意 URL 猜 method。
+5. `ensureRelaySession()` 懒加载 Turnstile；同一时间所有调用共享一个 bootstrap Promise。
+6. generation/edit 随后直接调用已选定的 direct 或 v2 通道，不做有副作用的试错重放。
+7. 如果一个 generation/edit POST 已经发出后出现结果不明的网络错误，不自动改用另一个通道重放；标记为“请求结果未知”，由用户明确决定是否重试。
+8. 401/403、429、413、502/504 和本地验证错误分别显示，不统一包装成 CORS 文案。
+
+### 10.2 传输协商
+
+静态 Web 在当前页面会话内按规范化 API Base 缓存 `direct | relay`；初始状态等价于 `auto`：
+
+- Provider 新建、API Base 改变或缓存过期时，先请求 `/models`；只要浏览器拿到任意 HTTP `Response`（包括 401/404），就证明 CORS 通道可用，记为 `direct`。
+- 若无副作用探测得到浏览器网络/CORS `TypeError`，建立 Relay 会话并通过 v2 再测试，成功后记为 `relay`。
+- 探测结果按规范化 API Base 保存在内存；刷新页面或修改 API Base 后会重新检测，避免把过期网络判断长期写入用户配置。
+- `auto` 不能对已经发出的 generation/edit POST 自动从 direct 切到 relay，也不能反向自动重放。
+- 对支持幂等键的 Provider，可为每个逻辑任务生成稳定 request ID，并按 Provider capability 转发 `Idempotency-Key`；未知 Provider 不假设一定支持。
+
+这一协商既减少不必要的 Relay 流量，也避免把“响应不可见”误判为“上游完全没有执行”。
+
+### 10.3 用户体验
+
+- 正常直连用户完全看不到验证流程。
+- 第一次确实需要 Relay 时显示“正在建立安全中转连接”；Turnstile 使用 Managed + `interaction-only`，只有高风险访问才显示交互。
+- 会话有效期内不重复验证。
+- 明确提示 API Key 仅保存在当前浏览器并会经过用户选择的上游及本站 Relay 内存转发。
+- 若 Turnstile 在特定网络不可达，提示切换桌面 App/Docker；不把安全控制失败伪装成 Provider 故障。
+- 在中国大陆网络正式强制前，必须做真实网络可达性和交互成功率验证；不能只用海外 CI 冒烟测试代替。
+
+### 10.4 CSP 配套
+
+生产 Pages 增加 HTTP 响应头 CSP，并只为 Turnstile 精确开放 `challenges.cloudflare.com` 所需的 script/frame/connect；同时设置 `frame-ancestors 'none'`、`X-Content-Type-Options: nosniff`、`Referrer-Policy` 和最小 `Permissions-Policy`。
+
+不能为了接入 Turnstile 加入 `unsafe-eval` 或宽泛 `script-src *`。Turnstile 官方说明了其受控 hostname、sitekey/secret 和 CSP 依赖，参见 [Cloudflare Turnstile widgets](https://developers.cloudflare.com/turnstile/concepts/widget/)。
+
+## 11. 日志、隐私与可观测性
+
+### 11.1 允许记录
+
+- 随机 request ID；
+- operation；
+- policy version；
+- 上游 hostname 的带密钥 HMAC 截断值，或经过明确审批后的 hostname；
+- 上游状态码、Relay 错误码；
+- 请求/响应字节档位，不记录内容；
+- 总耗时与上游耗时；
+- 是否直连失败后回退、是否限流、是否触发重新验证。
+
+### 11.2 永不记录
+
+- `Authorization` 或 API Key 的 hash/prefix；
+- Cookie、会话 token、Turnstile token；
+- prompt、JSON body、multipart 内容、文件名；
+- 完整 IP；
+- 带 query 的 asset URL；
+- Provider 响应正文。
+
+当前分支只启用 Cloudflare Workers 的自动 invocation logs，不增加会记录业务字段的 `console.log`。后台用固定请求 path 和响应 status 区分 v1/v2 使用量；不查询或导出请求头、正文和上游目标。自动日志仍会采集请求 URL 等元数据，因此 v2 协议不能把签名 URL 或其他秘密放入 URL 或自定义请求头。后续如需长期聚合，再单独评审 Analytics Engine/OpenTelemetry 的字段和 retention。
+
+### 11.3 告警
+
+- 调用量、出站字节或 distinct session 相对 7 日基线突增；
+- 429、策略拒绝、超限和异常比例持续升高；
+- 单一会话访问大量不同 hostname；
+- v1 端点仍有真实请求；
+- Turnstile 验证失败或不可用率超过阈值；
+- Worker 每日配额接近安全预算。
+
+## 12. 配置与代码组织
+
+### 12.1 Wrangler
+
+已采用：
+
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
+  "vars": {
+    "RELAY_V2_ENABLED": "true",
+    "RELAY_V1_MODE": "restricted",
+    "RELAY_SESSION_TTL_SECONDS": "86400",
+    "RELAY_ALLOWED_ORIGINS": "https://image.codex-pool.com",
+  },
+  "ratelimits": [
+    {
+      "name": "RELAY_SESSION_RATE",
+      "namespace_id": "983746201",
+      "simple": { "limit": 120, "period": 60 },
+    },
+    {
+      "name": "RELAY_SESSION_ISSUE_RATE",
+      "namespace_id": "983746202",
+      "simple": { "limit": 10, "period": 60 },
+    },
+    {
+      "name": "RELAY_LEGACY_RATE",
+      "namespace_id": "983746203",
+      "simple": { "limit": 80, "period": 60 },
+    },
+  ],
+}
+```
+
+以下只允许通过 Cloudflare secret 管理，不写入仓库：
+
+- `RELAY_SESSION_HMAC_KEY`
+- `RELAY_SESSION_HMAC_KEY_PREVIOUS`（仅轮换窗口）
+- `TURNSTILE_SITE_KEY`（公开值，但由部署环境注入，避免仓库内占位误上线）
+- `TURNSTILE_SECRET_KEY`
+- 可选的 hostname 日志 HMAC key
+
+### 12.2 Worker 模块
+
+当前实现拆成：
+
+- `session.ts`：Siteverify、cookie、HMAC、过期与轮换；
+- `policy.ts`：固定操作映射、API Base、asset URL、跳转、Origin 与内容类型策略；
+- `streams.ts`：请求/响应流计数和 JSON 限长读取；
+- `config.ts` / `types.ts`：环境配置、readiness 与公共类型；
+- `index.ts`：路由和统一错误映射。
+
+### 12.3 前端模块
+
+- `relay-client.ts`：配置发现、Turnstile 懒加载、Promise 去重、传输协商和 operation-specific 请求构造；
+- `openai.ts`：把已知操作交给安全传输层，并对错误中的签名 query 做脱敏；
+- Provider 设置页：明确 Web Relay 的标准协议限制与桌面/Docker 兜底。
+
+## 13. 迁移方案
+
+不能直接把当前 `/api/relay` 切成强制 v2。生产流量低，迁移应同时以时间和真实请求数量作为判据。
+
+### 阶段 0：只读基线
+
+- 保留当前配置；
+- 建立按 operation、状态、字节和来源类型的无敏感数据指标；
+- 确认中国大陆与海外的真实访问路径；
+- 记录 v1 所有标准/非标准路径，但不记录 API Key、正文或签名 query。
+
+### 阶段 1：部署向后兼容的 Worker
+
+- 新增 v2、session、限速和 kill switch；
+- v1 暂时保留，但立即拒绝无 `Origin`、限制为标准四类操作并加宽松应急限速；
+- v2 从第一天就强制会话和操作策略，但在新前端发布前只供 canary 使用；
+- Worker 必须先于新前端部署。
+
+### 阶段 2：部署新静态 Web
+
+- 新前端开始使用 v2；
+- v1 从新 Worker 上线起返回 `Deprecation: true`；只有在关闭日期经真实流量观察确认后才增加 `Sunset`，不能提前写一个无法兑现的日期；
+- 旧缓存页面仍可通过受限 v1 工作；
+- 观察至少 14 天，并且至少取得 20 次成功 v2 真实调用；如果请求不足 20 次，继续观察而不是按日历强切。
+
+### 阶段 3：强制 v2
+
+满足上线判据后：
+
+- v2 强制会话、操作策略和限速；
+- v1 仅对精确生产 Origin 保留短期兼容，返回明确升级错误；
+- 再观察 14 天无合法 v1 请求后关闭 v1；
+- 最终删除 `RELAY_MODE=open` 和 allowlist report-only 旧逻辑，避免误配置重新打开通用代理。
+
+### 部署编排
+
+Pages workflow 已把发布顺序固化为：
+
+1. Worker test + typecheck + dry-run；
+2. 进入 `cloudflare-production` Environment 审批，并检查 Worker secret 名称；
+3. 部署向后兼容 Worker；
+4. 轮询线上 v2 config，只有返回 `enabled=true` 才部署 Pages；
+5. 执行真实浏览器 canary；
+6. 不满足判据时停止，不自动把 Relay 切回 open。
+
+## 14. 测试矩阵
+
+### 14.1 URL/SSRF 单元测试
+
+- HTTPS 正常域名、IDNA、合法 base path；
+- `http:`、非 443 端口、userinfo、query、fragment；
+- IPv4/IPv6 literal；十进制、八进制、十六进制和混合 IP；
+- `localhost`、`.local`、`.internal`、`home.arpa`；
+- 编码斜杠、反斜杠、dot segment、双重编码、控制字符；
+- API 3xx 一律不跟随；asset 每一级跳转重新校验且最多两次；
+- 任何路径构造都不能逃出固定 operation suffix。
+
+### 14.2 会话与访问控制
+
+- 缺少/伪造/过期/篡改 cookie；
+- Turnstile token 缺失、过期、重复、hostname/action 不匹配；
+- HMAC key 无中断轮换与旧 key 到期；
+- 缺少 Origin、恶意 Origin、跨站 Fetch Metadata；
+- 16/32 个并发前端调用只创建一次 session；
+- 会话级 429 与 `Retry-After`；
+- session endpoint 被刷时的 WAF/Worker 双层限制。
+
+### 14.3 数据边界
+
+- JSON、multipart 和 chunked 请求真实超限；
+- 缺失/伪造 `Content-Length`；
+- 上游超大/无限响应流；
+- HTML 伪装 asset、错误 Content-Type；
+- `Set-Cookie`、跳转和 hop-by-hop headers 不泄漏；
+- asset 请求永不带 Authorization；
+- 日志扫描确认没有 API Key、prompt、正文、cookie 和签名 query。
+
+### 14.4 用户流程
+
+- 任意支持 CORS 的新域名通过无副作用探测后仍可直接使用；
+- 不支持 CORS 的标准 OpenAI-compatible 域名通过 v2 成功；
+- `/models`、生成、编辑、多图批次、返回 base64、返回 URL 均成功；
+- 上游 401/429/5xx 保持原意，不误触发另一条 Relay；
+- direct generation/edit 在响应状态不明时不会自动通过 Relay 重放；
+- Turnstile 不可达、session 过期、Worker kill switch 均有清楚提示；
+- 桌面 App、Docker 和 CLI 不受影响。
+
+## 15. 上线与回滚判据
+
+### 15.1 上线必须满足
+
+- Worker/前端全部单元和集成测试通过；
+- 生产负向探针确认无 session、无 Origin、任意 path、私网目标和超限请求均被拒绝；
+- 中国大陆与至少一个海外网络的浏览器 canary 通过；
+- v2 成功率不低于同期 v1，策略误拒绝率低于 1%；
+- Turnstile bootstrap 失败率低于 2%，大多数正常用户无交互完成；
+- 至少 20 次真实 v2 成功调用覆盖 generations、edits 和 asset；
+- 日志抽查无敏感内容；
+- kill switch 和 secret 轮换演练通过。
+
+### 15.2 回滚原则
+
+- Worker v2 必须始终兼容旧前端，所以可以先回滚 Pages；
+- 协议故障可把前端回滚到受限 v1，但不得恢复“无 Origin + 任意 URL”的 open 行为；
+- Turnstile 故障可以临时切换为“受限操作 + 更严格会话/IP 限速”的降级模式，但必须有到期时间、告警和人工批准；不能永久 fail-open；
+- 发生主动滥用时优先关闭公共 Relay，直连、桌面 App 和 Docker 仍可继续服务。
+
+## 16. 残余风险与最终边界
+
+即使采用 v2，能够通过 Turnstile 的攻击者仍可让自己控制的域名实现 `/images/generations`，因此公共匿名 Relay 不可能达到“只有好人能用”的绝对保证。v2 的价值在于：
+
+- 请求不再是任意 method/path；
+- 不能访问非公网目标或跟随未校验跳转；
+- 不能无成本高速调用；
+- 不能借 asset 通道携带用户 Authorization；
+- 可以快速识别、限流和关闭异常会话；
+- 正常用户仍可使用未知的新中转站域名。
+
+如果未来流量或滥用规模超过这些控制能承受的范围，下一道边界只能是用户账号/组织登录，或停止为任意域名提供公共 Web Relay；不存在一个可以安全藏在前端里的万能密钥。

--- a/docs/relay-security-runbook.md
+++ b/docs/relay-security-runbook.md
@@ -1,0 +1,130 @@
+# Relay v2 安全上线手册
+
+本文只适用于静态 Web 的 Cloudflare Worker 中转。CLI、桌面 App 和 Docker Web 不经过该 Worker。
+
+## 上线前置条件
+
+1. 在 Cloudflare Turnstile 创建 **Managed** widget，只绑定 `image.codex-pool.com`。Pages 预览域名没有同源 Worker route，只用于验证直连流程，不应跨域调用生产 Relay。
+2. 先在中国大陆和海外各完成一次真实浏览器 canary。Turnstile 不可达时，支持 CORS 的服务仍会直连；只有依赖中转的用户会被阻止。
+3. 在 Worker secret 中配置以下三项，值不得写入仓库、GitHub Actions 日志或聊天：
+   - `TURNSTILE_SITE_KEY`
+   - `TURNSTILE_SECRET_KEY`
+   - `RELAY_SESSION_HMAC_KEY`：至少 32 字节随机值，建议 48 字节以上
+4. GitHub 的 `CLOUDFLARE_API_TOKEN` 使用账号/区域受限的 API Token，不使用 Global API Key。最小部署权限包括 Account / Workers Scripts / Edit、Account / Cloudflare Pages / Edit，以及仅针对 `codex-pool.com` 的 Zone / Workers Routes / Edit；把 account 和 zone resource 收窄到本项目实际范围。权限依据见 [Workers CI](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/) 与 [Pages API](https://developers.cloudflare.com/pages/configuration/api/)。
+5. 在 GitHub 为 `cloudflare-production` Environment 配置 required reviewer，并把 `CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_API_TOKEN` 收敛为该 Environment 的 secrets。Workflow 已绑定此 Environment；在 reviewer 和 canary 均未确认前不要批准部署 job。
+
+交互式写入命令如下；每条命令会在终端中提示输入值：
+
+```bash
+cd workers/gpt-image-2-relay
+npx wrangler secret put TURNSTILE_SITE_KEY
+npx wrangler secret put TURNSTILE_SECRET_KEY
+npx wrangler secret put RELAY_SESSION_HMAC_KEY
+```
+
+只检查名称、不显示 secret 值：
+
+```bash
+cd workers/gpt-image-2-relay
+npx wrangler secret list --format json | jq 'map(.name)'
+```
+
+## 本地门禁
+
+```bash
+npm --prefix workers/gpt-image-2-relay audit --audit-level=high
+npm --prefix apps/gpt-image-2-app audit --audit-level=high
+just relay-test
+just relay-dry
+just app-test-browser
+just app-build
+test -f apps/gpt-image-2-app/dist/_headers
+```
+
+必须同时满足：
+
+- Worker 测试、TypeScript 类型检查和 Wrangler dry-run 全部成功；
+- 前端测试和构建成功；
+- `dist/_headers` 存在 CSP；
+- diff 中没有 API Key、Turnstile secret、cookie、签名 URL 或真实 prompt；
+- 旧 `/api/relay` 仍通过受限兼容测试，且任意方法/路径被拒绝。
+
+当前会话限速为 120 次/分钟，旧入口为 80 次/分钟，session 签发为 10 次/IP/分钟。前两项特意覆盖两个并行任务各拆分 16 次请求、随后各下载 16 张图片的合法峰值；不要在没有真实流量证据时调低。
+
+`wrangler.jsonc` 中三个 `namespace_id` 必须在同一个 Cloudflare account 内保持唯一。正式部署前先核对现有 Worker 的 Rate Limiting bindings；若任一 ID 已被占用，换成该账号未使用的新整数 ID，并重新执行 Worker 测试和 dry-run。不要把三个 limiter 复用为同一个 namespace。
+
+## 安全部署顺序
+
+正式 Release 的 `.github/workflows/pages-deploy.yml` 已固定以下顺序：
+
+1. 测试 Worker 与静态 Web；
+2. 检查三个 Worker secret 的名称均存在；
+3. 先部署 Worker；
+4. 轮询 `https://image.codex-pool.com/api/relay/v2/config`；
+5. 只有配置返回 `version=2`、`enabled=true`、`auth_mode=turnstile` 才部署 Pages。
+
+这保证新网页不会先于新 Worker 上线。Worker 部署后即使 Pages 步骤失败，旧缓存页面仍走受限 v1；不会回退到开放代理。
+
+首次上线不要直接发正式 Pages。先单独部署 Worker并验证旧页面，再安排静态页面 canary：
+
+```bash
+just relay-deploy
+curl --fail --silent https://image.codex-pool.com/api/relay/v2/config | jq
+```
+
+配置响应只能包含公开的 site key 和能力信息，不应包含任何 secret。
+
+## 负向探针
+
+以下探针不使用真实 API Key：
+
+```bash
+# v1 缺少 Origin，必须是 403
+curl --silent --output /dev/null --write-out '%{http_code}\n' \
+  --request POST https://image.codex-pool.com/api/relay \
+  --header 'X-GPT-Image-2-Upstream: https://example.com/v1/models' \
+  --header 'X-GPT-Image-2-Method: GET'
+
+# v2 缺少会话，必须是 401
+curl --silent --output /dev/null --write-out '%{http_code}\n' \
+  --request POST https://image.codex-pool.com/api/relay/v2/models \
+  --header 'Origin: https://image.codex-pool.com' \
+  --header 'Sec-Fetch-Site: same-origin' \
+  --header 'X-GPT-Image-2-Relay-Version: 2' \
+  --header 'X-GPT-Image-2-Api-Base: https://example.com/v1' \
+  --header 'Authorization: Bearer non-secret-probe'
+```
+
+真实浏览器 canary 还必须确认：
+
+- 支持 CORS 的自定义域名只出现 `/models` 探测与直接生成请求，不出现 Turnstile；
+- 不支持 CORS 的标准 OpenAI-compatible 域名显示 Turnstile，并经 v2 成功；
+- 生成/编辑 POST 发生网络结果不明时，页面提示先去服务商后台确认，Network 面板中没有第二次 POST；
+- 返回签名图片 URL 时，URL 只在 `/v2/asset` JSON body 内，不出现在自定义 header；
+- 桌面 App、Docker 和 CLI 的请求路径完全不变。
+
+## 后台用量观察
+
+部署后在 Cloudflare Workers & Pages → `gpt-image-2-relay` → Observability → Query Builder 中，只按 `$workers.event.request.path` 与 `$workers.event.response.status` 分组计数。重点区分 `/api/relay`、`/api/relay/v2/session` 和四个 v2 operation；不要查询、复制或导出请求头、正文、Cookie、API Key、完整 IP、上游域名或签名 URL。Cloudflare 的 invocation logs 会自动包含请求/响应元数据，字段用法见 [Workers Logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/) 与 [Query Builder](https://developers.cloudflare.com/workers/observability/query-builder/)。
+
+在 v1 观察期每天保存一次仅含日期、v1 总数、v2 总数、状态码分布的汇总。若账号日志 retention 短于 14 天，这份无敏感字段的日汇总就是关闭 v1 的连续性证据；不能只凭某一天“后台没看到请求”判断无人使用。
+
+## 灰度与关闭 v1
+
+新 Pages 上线后至少观察 14 天，并至少取得 20 次成功 v2 真实调用；流量不足 20 次时继续观察。期间保留 `RELAY_V1_MODE=restricted`。
+
+同时满足以下条件后，才可把 `RELAY_V1_MODE` 改为 `disabled`：
+
+- 连续 14 天没有确认属于合法旧页面的 v1 请求；
+- 中国大陆与海外 Turnstile 成功率均可接受；
+- 没有会话 401 循环、异常 429、重复生成或资源下载回归；
+- 出站流量、失败率与 Cloudflare 费用没有异常。
+
+## 回滚
+
+- Worker canary 失败：不要发布 Pages，在 Cloudflare Workers 版本页恢复上一个已知正常版本；禁止把 `RELAY_MODE=open` 加回来。
+- Pages 已发布但 v2 用户受影响：先恢复上一个 Pages deployment；受限 v1 在观察期内保持可用。
+- 发现 SSRF、密钥泄漏或异常出站：立即将 `RELAY_ENABLED` 设为 `false` 并部署 Worker，随后轮换相关上游 API Key、Turnstile secret 和会话 HMAC key。
+- HMAC 常规轮换：将旧值暂存为 `RELAY_SESSION_HMAC_KEY_PREVIOUS`，写入新 `RELAY_SESSION_HMAC_KEY`；等待最长会话 TTL（当前 24 小时）后删除 previous secret。
+
+回滚完成的判据是线上行为验证，不是 workflow 变绿：至少重新检查 config、负向探针、一个直连 canary 和一个 relay canary。

--- a/scripts/release/install-cargo-dist.ps1
+++ b/scripts/release/install-cargo-dist.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+
+# The Windows ARM runner can execute the signed x64 build under emulation. The
+# pinned digest keeps the release tool immutable even if a mutable installer
+# script or release metadata changes later.
+$Version = "0.31.0"
+$Asset = "cargo-dist-x86_64-pc-windows-msvc.zip"
+$ExpectedSha256 = "a14e17557b269b101405e0cc6b647581d56313c954a51c7fddd423bba21e17b2"
+$DownloadDirectory = Join-Path ([IO.Path]::GetTempPath()) ("gpt-image-2-cargo-dist-" + [Guid]::NewGuid())
+$ArchivePath = Join-Path $DownloadDirectory $Asset
+
+New-Item -ItemType Directory -Path $DownloadDirectory | Out-Null
+try {
+  $Uri = "https://github.com/axodotdev/cargo-dist/releases/download/v$Version/$Asset"
+  Invoke-WebRequest -Uri $Uri -OutFile $ArchivePath
+
+  $ActualSha256 = (Get-FileHash -Path $ArchivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+  if ($ActualSha256 -ne $ExpectedSha256) {
+    throw "cargo-dist archive checksum mismatch for $Asset"
+  }
+
+  Expand-Archive -Path $ArchivePath -DestinationPath $DownloadDirectory -Force
+  $Binary = Get-ChildItem -Path $DownloadDirectory -Filter dist.exe -File -Recurse | Select-Object -First 1
+  if (-not $Binary) {
+    throw "Verified cargo-dist archive did not contain dist.exe"
+  }
+
+  $CargoRoot = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE ".cargo" }
+  $CargoBinDirectory = Join-Path $CargoRoot "bin"
+  New-Item -ItemType Directory -Path $CargoBinDirectory -Force | Out-Null
+  Copy-Item -Path $Binary.FullName -Destination (Join-Path $CargoBinDirectory "dist.exe") -Force
+  if ($env:GITHUB_PATH) {
+    Add-Content -Path $env:GITHUB_PATH -Value $CargoBinDirectory
+  }
+  & (Join-Path $CargoBinDirectory "dist.exe") --version
+}
+finally {
+  Remove-Item -Path $DownloadDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/release/install-cargo-dist.sh
+++ b/scripts/release/install-cargo-dist.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep the release tool immutable: both the version and each platform archive
+# digest are reviewed in this repository. Do not replace this with pipe-to-shell.
+version="0.31.0"
+platform="$(uname -s)-$(uname -m)"
+
+case "$platform" in
+  Darwin-arm64)
+    asset="cargo-dist-aarch64-apple-darwin.tar.xz"
+    expected_sha256="decb01c64c12501931c3cac3111b368a7f48adf8d9e65455c08e5757b9a1fd6f"
+    ;;
+  Darwin-x86_64)
+    asset="cargo-dist-x86_64-apple-darwin.tar.xz"
+    expected_sha256="fd4d8f9f07802359cbcdc52bac3abd7d5201c4b73a7cbcdd6faca2232a389f0c"
+    ;;
+  Linux-aarch64 | Linux-arm64)
+    asset="cargo-dist-aarch64-unknown-linux-gnu.tar.xz"
+    expected_sha256="382cc29ff91ef12a5bf78ad8ee1804661d24e2fbe64b1bdedd6078723b677ae5"
+    ;;
+  Linux-x86_64)
+    asset="cargo-dist-x86_64-unknown-linux-gnu.tar.xz"
+    expected_sha256="cd355dab0b4c02fb59038fef87655550021d07f45f1d82f947a34ef98560abb8"
+    ;;
+  *)
+    echo "Unsupported cargo-dist installer platform: $platform" >&2
+    exit 1
+    ;;
+esac
+
+download_dir="$(mktemp -d "${TMPDIR:-/tmp}/gpt-image-2-cargo-dist.XXXXXX")"
+cleanup() {
+  find "$download_dir" -depth -type f -delete
+  find "$download_dir" -depth -type d -exec rmdir {} \;
+}
+trap cleanup EXIT
+
+archive_path="$download_dir/$asset"
+curl --proto '=https' --tlsv1.2 --fail --location --silent --show-error \
+  --retry 3 --output "$archive_path" \
+  "https://github.com/axodotdev/cargo-dist/releases/download/v${version}/${asset}"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_sha256="$(sha256sum "$archive_path" | awk '{print $1}')"
+else
+  actual_sha256="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+fi
+if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+  echo "cargo-dist archive checksum mismatch for $asset" >&2
+  exit 1
+fi
+
+tar -xJf "$archive_path" -C "$download_dir"
+binary_path="$(find "$download_dir" -type f -name dist -print -quit)"
+if [[ -z "$binary_path" ]]; then
+  echo "Verified cargo-dist archive did not contain the dist binary" >&2
+  exit 1
+fi
+
+cargo_bin_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
+mkdir -p "$cargo_bin_dir"
+install -m 0755 "$binary_path" "$cargo_bin_dir/dist"
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "$cargo_bin_dir" >> "$GITHUB_PATH"
+fi
+"$cargo_bin_dir/dist" --version

--- a/scripts/release/patch-release-workflow.mjs
+++ b/scripts/release/patch-release-workflow.mjs
@@ -18,7 +18,21 @@ const muslStepPattern =
   /      - name: Configure musl toolchain\n        if: \$\{\{ runner\.os == 'Linux' && contains\(join\(matrix\.targets, ','\), 'unknown-linux-musl'\) \}\}\n        shell: bash\n        run: \|\n(?:.*\n)+?(?=      - name: (?:Refresh WiX path|Build artifacts))/;
 const wixStepName = "      - name: Refresh WiX path";
 const announceSectionMarker = "  announce:\n";
-const announceCheckoutMarker = `      - uses: actions/checkout@v6
+const actionPins = new Map([
+  [
+    "actions/checkout@v6",
+    "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6",
+  ],
+  [
+    "actions/upload-artifact@v6",
+    "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6",
+  ],
+  [
+    "actions/download-artifact@v7",
+    "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7",
+  ],
+]);
+const announceCheckoutMarker = `      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
           submodules: recursive
@@ -83,6 +97,13 @@ const legacyLinuxDepsStepPattern =
   /      - name: Install Linux keyring build dependencies\n        if: \$\{\{ runner\.os == 'Linux' \}\}\n        run: \|\n(?:          .+\n)+/;
 
 let source = fs.readFileSync(workflowPath, "utf8");
+
+// cargo-dist regenerates mutable major-version refs. Normalize them before
+// applying structural patches so a regenerated release workflow still obeys
+// the repository-wide full-SHA policy.
+for (const [mutableRef, pinnedRef] of actionPins) {
+  source = source.replaceAll(mutableRef, pinnedRef);
+}
 
 source = source.replace(legacyLinuxDepsStepPattern, "");
 source = source.replace(

--- a/scripts/security/check-workflows.sh
+++ b/scripts/security/check-workflows.sh
@@ -2,18 +2,36 @@
 set -euo pipefail
 
 workflow_dir=".github/workflows"
+invalid=0
 
-if rg --hidden --no-ignore --pcre2 \
-  'uses:\s*(?!\./)[^\s@]+@(?![0-9a-f]{40}(?:\s|$))' \
-  "$workflow_dir"; then
-  echo "Every external GitHub Action must use a full 40-character commit SHA." >&2
-  exit 1
-fi
+# Keep this check dependency-free: GitHub's Ubuntu image does not guarantee
+# that ripgrep is installed, and a missing scanner must never fail open.
+while IFS= read -r file; do
+  line_number=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
 
-if rg --hidden --no-ignore --pcre2 \
-  '(?i:(?:curl|wget)[^\n]*\|\s*(?:ba)?sh\b|(?:irm|Invoke-RestMethod)[^\n]*\|\s*(?:iex|Invoke-Expression)\b)' \
-  "$workflow_dir"; then
-  echo "Remote pipe-to-shell execution is forbidden in release workflows." >&2
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*uses:[[:space:]]*([^[:space:]#]+) ]]; then
+      action_ref="${BASH_REMATCH[1]}"
+      if [[ "$action_ref" != ./* && ! "$action_ref" =~ @[0-9a-f]{40}$ ]]; then
+        printf '%s:%d: unpinned external Action: %s\n' \
+          "$file" "$line_number" "$action_ref" >&2
+        invalid=1
+      fi
+    fi
+
+    shopt -s nocasematch
+    if [[ "$line" =~ (curl|wget).*\|[[:space:]]*(ba)?sh([[:space:]]|$) ]] ||
+      [[ "$line" =~ (irm|Invoke-RestMethod).*\|[[:space:]]*(iex|Invoke-Expression)([[:space:]]|$) ]]; then
+      printf '%s:%d: remote pipe-to-shell execution is forbidden\n' \
+        "$file" "$line_number" >&2
+      invalid=1
+    fi
+    shopt -u nocasematch
+  done <"$file"
+done < <(find "$workflow_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -print)
+
+if ((invalid != 0)); then
   exit 1
 fi
 

--- a/scripts/security/check-workflows.sh
+++ b/scripts/security/check-workflows.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow_dir=".github/workflows"
+
+if rg --hidden --no-ignore --pcre2 \
+  'uses:\s*(?!\./)[^\s@]+@(?![0-9a-f]{40}(?:\s|$))' \
+  "$workflow_dir"; then
+  echo "Every external GitHub Action must use a full 40-character commit SHA." >&2
+  exit 1
+fi
+
+if rg --hidden --no-ignore --pcre2 \
+  '(?i:(?:curl|wget)[^\n]*\|\s*(?:ba)?sh\b|(?:irm|Invoke-RestMethod)[^\n]*\|\s*(?:iex|Invoke-Expression)\b)' \
+  "$workflow_dir"; then
+  echo "Remote pipe-to-shell execution is forbidden in release workflows." >&2
+  exit 1
+fi
+
+echo "Workflow supply-chain policy: OK"

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -1,0 +1,148 @@
+# 安全审查报告
+
+审查日期：2026-08-22；修复复核：2026-08-23（Asia/Shanghai）  
+审查基线：GitHub `main`，commit `49b0a6b8e6692869027f9ffd39d6b8240a6b50cc`  
+范围：GitHub 安全设置、GitHub Actions、Rust workspace、React/Vite/Tauri、Docker Web、Cloudflare relay、npm/Cargo 依赖，以及线上响应头。
+
+## 执行摘要
+
+没有发现已提交的真实密钥，GitHub Secret Scanning 当前也没有未关闭告警。最需要立即处理的是生产 Cloudflare relay 仍以 `open` 模式运行：未带 `Origin` 的任意客户端无需认证即可让它访问任意公网 HTTPS 地址。线上实测已通过该 relay 成功获取 `https://example.com/`，响应明确返回 `x-gpt-image-2-relay-policy: open`。这使项目承担公开代理滥用、Cloudflare 配额/费用和来源信誉风险。
+
+GitHub 当前有 9 个未关闭的 Dependabot 告警，但应按本项目可达性重新排序：`lettre` 的 Critical 告警只影响 `boring-tls`，本项目明确启用 `rustls`，因此不是当前可利用的 Critical；`undici` 位于 Wrangler 开发依赖链；`nanoid` 位于构建工具链。与此同时，`cargo audit` 发现 GitHub 列表尚未显示的 `h2` 与多个 `quick-xml` 告警。
+
+本报告保留审查时的生产基线证据。`codex/relay-v2-security` 已完成 operation-based Relay v2、受限 v1、Turnstile 会话、限速和 SSRF 纵深防御，也已处理可升级的 Rust 漏洞、Pages/Tauri CSP、GitHub Actions SHA pinning、CodeQL/Dependabot 配置与 Docker Web 会话安全。截至 2026-08-23 的本地复核，两个 npm workspace 均为 0 漏洞，`cargo audit` 为 0 个 vulnerability；生产部署和 GitHub 仓库级设置仍须在合并后验证，不能把本地通过表述为线上已修复。
+
+## High
+
+### SEC-001：生产 relay 是无认证的开放公网代理
+
+- Rule ID：REACT-NET-001 / 服务端访问控制
+- 严重度：High
+- 位置：`workers/gpt-image-2-relay/wrangler.jsonc:18-25`；`workers/gpt-image-2-relay/src/index.ts:121-125, 201-230, 299-357`
+- 证据：部署配置设置 `RELAY_MODE="open"`、`RELAY_ALLOWLIST_REPORT_ONLY="true"`；`originAllowed()` 对没有 `Origin` 的请求直接返回 `true`；服务端只限制 HTTPS、端口和显式私网 IP，随后将请求转发到调用者指定的任意公网主机。
+- 线上验证：无 `Origin`、无认证的 POST 请求可代理 GET `https://example.com/`，返回 HTTP 200、Example Domain 页面，以及 `x-gpt-image-2-relay-policy: open`。
+- 影响：任意脚本或机器人可借项目域名做代理、消耗 50 MiB 请求/120 MiB 响应额度、隐藏来源并损害域名/IP 信誉。CORS 只约束浏览器读取响应，不是服务端访问控制；命令行客户端可完全绕过。
+- 修复：不枚举用户上游域名，改为 operation-based Relay：服务端只拼接模型检查、生成、编辑三个固定路径和无凭证图片下载；通过 Turnstile 换取短期签名 HttpOnly 会话，并叠加精确 Origin、Fetch Metadata、Cloudflare Rate Limiting、请求大小与公网 HTTPS/重定向校验。旧入口只保留同样四类操作的受限兼容；删除 `RELAY_MODE=open`，且绝不把 `Origin` 当作唯一认证信号。
+- 缓解：修复发布前，先在 Cloudflare WAF/Worker route 层限制请求速率、请求体大小和允许的上游；监控异常目的域名、出站字节和 4xx/5xx。
+- False positive notes：不是误报；已对生产端点做最小化只读验证并成功代理公开测试站点。
+- 本分支状态：已实现并通过 Worker/前端安全测试与 Wrangler dry-run，生产 Turnstile、灰度和部署结果见最终上线记录；在上线验证完成前，本条仍按生产未修复处理。
+
+## Medium
+
+### SEC-002：Rust HTTP/2 依赖存在可导致内存耗尽的 `h2` 漏洞
+
+- Rule ID：RUSTSEC-2026-0258 / GHSA-q83h-524g-xf6h
+- 严重度：Medium
+- 位置：`Cargo.lock` 中 `h2 0.4.13`；反向依赖包含 `axum -> gpt-image-2-web`、`reqwest -> gpt-image-2-core`。
+- 证据：`cargo audit` 报告 `h2 0.4.13` 可无限排队空 DATA frame，修复版本为 `>=0.4.16`。
+- 影响：若 Docker Web 的 HTTP/2 连接直接暴露或反向代理向后端保留可攻击的 HTTP/2 流量，远程客户端可能造成内存增长或 panic。客户端侧恶意 HTTP/2 peer 也可能影响使用 `reqwest` 的路径。
+- 修复：更新 lockfile 使 `h2 >=0.4.16`，运行 workspace 测试与 Docker Web 冒烟测试。
+- 缓解：在反向代理限制连接/流并设置资源上限；在升级前避免直接暴露 h2c。
+- False positive notes：是否能从当前生产拓扑直达 h2 需要结合反向代理协议确认，但受影响依赖确实进入运行时图。
+- 本分支状态：已升至 `h2 0.4.16`，workspace Clippy、测试及 Docker Web 签名会话集成探针通过，`cargo audit` 不再报告该漏洞。
+
+### SEC-003：Web 与 Tauri 都缺少 CSP，线上页面也缺少点击劫持等响应头
+
+- Rule ID：REACT-CSP-001 / REACT-HEADERS-001
+- 严重度：Medium
+- 位置：`apps/gpt-image-2-app/src-tauri/tauri.conf.json:29-39`；`apps/gpt-image-2-app/index.html:1-25`
+- 证据：Tauri 配置明确为 `"csp": null`，同时启用了 `assetProtocol`，范围包括 `$APPDATA/**`、`$PICTURE/**`、`$HOME/.codex/gpt-image-2-skill/**`、`$TEMP/**`。HTML 没有 CSP。2026-08-22 实测 `https://image.codex-pool.com/` 与 Pages 域名均没有 `Content-Security-Policy`、`X-Frame-Options` 或 `Permissions-Policy`；已有 `nosniff` 和 `Referrer-Policy`。
+- 影响：当前 React 扫描未发现已证实的 XSS sink，但一旦未来依赖或渲染路径出现 XSS，缺少 CSP 会扩大浏览器与桌面 WebView 中的影响；桌面端可读取较宽的本地 asset scope，风险更高。
+- 修复：为 Tauri 配置最小可用 CSP；为 Cloudflare Pages/自托管 Web 设置响应头 CSP（至少严格 `script-src`）、`frame-ancestors 'none'`、`Permissions-Policy`。字体来源应精确允许，避免 `unsafe-eval`/`unsafe-inline`。
+- 缓解：缩小 asset protocol scope；继续避免 `dangerouslySetInnerHTML`、动态脚本和任意 URL sink。
+- False positive notes：线上头部已验证，不是“仓库中不可见”的推断。
+- 本分支状态：静态 Pages 已新增并构建验证 CSP、`frame-ancestors 'none'`、Permissions Policy、HSTS、nosniff、DENY 等响应头；Tauri 已启用拒绝远程脚本/对象/Frame/Form 的最小 CSP，并保留 IPC、本地 asset、用户 HTTPS 图片与指定字体来源。Tauri crate 编译通过；生产 Pages 仍需部署后验头。
+
+### SEC-004：发布工作流使用可变 action 标签和 pipe-to-shell，且持有发布权限/签名密钥
+
+- Rule ID：CI/CD supply-chain hardening
+- 严重度：Medium
+- 位置：例如 `.github/workflows/release.yml:63-75`、`.github/workflows/tauri-app-release.yml:81-112`、`.github/workflows/ghcr-publish.yml:145-163`，以及其他 workflow 的 `uses:`。
+- 证据：Actions 普遍使用 `actions/checkout@v6`、`dtolnay/rust-toolchain@stable`、`docker/*@vN` 等可移动标签；仓库设置 `sha_pinning_required=false`、`allowed_actions=all`。Release Candidate/Release 还直接执行固定 URL 的安装脚本 `curl ... | sh`。这些 job 中有的可以写 Release、npm/GHCR/Homebrew，并可读取代码签名相关 secrets。
+- 影响：上游 action 标签、action 仓库或下载链被攻陷时，攻击者可能接管发布流程、窃取可用凭据或发布被植入的安装包。
+- 修复：把第三方与官方 actions 全部固定到完整 commit SHA，并由 Dependabot/Renovate 更新；下载工具后校验 SHA256/签名再执行；把发布 job 的 permissions 与 secrets 拆到最小粒度环境并加 environment approval。
+- 缓解：仓库层启用 SHA pinning，限制允许的 actions 到 GitHub-owned 与明确 allowlist。
+- False positive notes：可变标签本身不表示当前 action 已被攻陷；这是高价值发布链上的防御缺口。
+- 本分支状态：全部外部 Actions 已固定到 40 位 commit SHA；cargo-dist 改为仓库内跨平台安装器并固定各平台归档 SHA-256；CI 新增检查，拒绝可变 Action 引用及远程 pipe-to-shell。
+
+### SEC-005：GitHub 安全与合并门禁不完整
+
+- Rule ID：REACT-SUPPLY-001 / repository governance
+- 严重度：Medium
+- 位置：GitHub repository settings（2026-08-22 实时查询）。
+- 证据：Code Scanning API 返回 `no analysis found`；Dependabot Security Updates 为 disabled；`main` 没有 required status checks、required PR review、conversation resolution 或 admin enforcement；Actions SHA pinning 关闭。Secret Scanning 与 push protection 已启用且当前 0 条未关闭告警。
+- 影响：静态漏洞缺少持续发现；已知依赖漏洞不会自动生成修复 PR；维护者或凭据被盗后可以绕过 CI/评审直接推送到默认分支。
+- 修复：启用 CodeQL（Rust、JavaScript/TypeScript）；启用 Dependabot security updates；要求 CI、至少 1 个 review、conversation resolution，并对管理员执行规则；启用 action SHA pinning。
+- 缓解：若单人维护不适合强制 review，至少强制 CI、禁止绕过规则，并为 release environment 设置人工批准。
+- False positive notes：以上均来自当前 GitHub API 设置，不涉及推断。
+- 本分支状态：已新增 Rust/JavaScript/TypeScript/GitHub Actions CodeQL、四类 Dependabot 更新和 `Security` CI 门禁。Dependabot security updates、Actions SHA enforcement、main 分支保护和 Environment reviewer 属于 GitHub 后台状态，须在合并后通过 API 启用并复核。
+
+### SEC-006：HTTPS 部署时 session cookie 没有 `Secure`
+
+- Rule ID：session cookie hardening
+- 严重度：Medium（仅影响通过 HTTPS 暴露且 HTTP 仍可达的部署）
+- 位置：`crates/gpt-image-2-web/src/auth.rs:205-221`
+- 证据：cookie 包含 `HttpOnly; SameSite=Strict; Path=/; Max-Age=1209600`，但没有 `Secure`；cookie 值本身就是共享访问 token，并保存 14 天。
+- 影响：若同一主机仍可通过明文 HTTP 访问，浏览器可在 HTTP 请求中发送该 cookie，网络路径上的攻击者可窃取完整共享 token。
+- 修复：增加显式的外部 HTTPS/secure-cookie 配置，在 TLS 终止于反向代理时设置 `Secure`；生产文档要求 HTTPS，并考虑让 session 使用独立随机值而不是直接复制长期共享 token。
+- 缓解：HTTP 强制跳转到 HTTPS；防火墙关闭明文端口；缩短 cookie 生命周期并支持注销/轮换。
+- False positive notes：纯本机 HTTP 开发环境不能无条件加 `Secure`，因此应按部署模式控制。
+- 本分支状态：浏览器 Cookie 已改为 12 小时 HMAC 签名会话，不再复制共享 token；`GPT_IMAGE_2_WEB_SECURE_COOKIE=1` 为 HTTPS 部署追加 `Secure`，TTL 可在 5 分钟至 7 天内配置，token 轮换会立即使旧会话失效。单元测试与真实本机 HTTP 集成探针均通过。
+
+## Low / 依赖可达性待确认
+
+### SEC-007：GitHub Dependabot 的 9 条告警需要清理，但严重度不能照单全收
+
+- Rule ID：REACT-SUPPLY-001
+- 严重度：Low 到 High（依赖具体路径）
+- 位置：GitHub Dependabot；`Cargo.lock`；两个 npm lockfile。
+- 证据与判断：
+  - `lettre 0.11.21`：GitHub 标 Critical，修复为 0.11.22；但漏洞仅影响 `boring-tls`。`crates/gpt-image-2-core/Cargo.toml:21` 明确启用 `rustls`，实际不可利用性高，仍应升级以关闭告警。
+  - `nanoid <3.3.18`：1 条 High，位于前端构建依赖链；漏洞要求调用自定义生成器且传入 size 0，目前未发现项目代码调用。
+  - `undici 7.28.0`：1 High + 4 Medium，均经 Wrangler/Miniflare 开发依赖链进入；生产 Worker 使用 Cloudflare 原生 `fetch`，未发现项目直接调用这些受影响 API。升级 Wrangler 仍是正确处理。
+  - `glib 0.18.5`：1 Medium，Linux Tauri GTK 运行时依赖；项目自身未使用 `VariantStrIter`，触发性待上游/平台路径确认。
+  - `rand 0.7.3`：1 Low，构建依赖链；漏洞需要 `log` + `thread_rng` + 自定义 logger 重入等组合，当前 feature tree 未显示 `log`，实际不可达。
+- 修复：更新 lockfile：`lettre >=0.11.22`、Wrangler/Undici、nanoid 所属父依赖、可升级的 GTK/Tauri 依赖；对不可达告警在完成证据记录后再 dismiss，不要仅凭严重度关闭。
+- 缓解：CI 增加 `npm audit` 与 `cargo audit`，并对确认为不可达的 advisory 使用有到期日和理由的审计配置。
+- False positive notes：本节明确区分“存在受影响版本”与“本项目路径可利用”。
+- 本分支状态：Wrangler 已升至 4.125.0、其工具链 `undici` 已升至 7.29.0，两个 npm lockfile 的 `nanoid` 已升至 3.3.18，`lettre` 已升至 0.11.23；当前两个 npm workspace 的 `npm audit` 均为 0，并显式允许必要的 `esbuild`/`workerd` install script、拒绝可选 `fsevents`。GitHub 告警要等改动进入默认分支后重新计算。
+
+### SEC-008：`cargo audit` 另报多个 `quick-xml` DoS，主要位于平台/构建依赖链
+
+- Rule ID：RUSTSEC-2026-0194 / RUSTSEC-2026-0195
+- 严重度：Low（当前项目可达性未证实）
+- 位置：`Cargo.lock` 中 `quick-xml 0.37.5`、`0.38.4`、`0.39.3`。
+- 证据：三套版本均低于 0.41.0，分别经 Windows notification、Tauri plist、Wayland scanner 链进入；项目源代码未直接使用 `quick_xml`、`NsReader` 或 attributes API。
+- 影响：只有在相关上游组件解析攻击者可控 XML 并走受影响 API 时才会造成 CPU/内存耗尽；当前未证实这样的输入路径。
+- 修复：跟进上游 Tauri/notification/Wayland 依赖升级，尽量统一到 `quick-xml >=0.41.0`；记录无法立即升级的原因。
+- False positive notes：`cargo audit` 按 lockfile 报告，不会自动判断目标平台、build dependency 或 API 可达性。
+- 本分支状态：`plist 1.10.0` 与 `wayland-scanner 0.31.11` 已统一到 `quick-xml 0.41.0`；`tauri-winrt-notification 0.7.3` 已移除其 quick-xml 依赖。锁文件不再包含受影响的 quick-xml 版本。
+
+## 已确认的积极控制
+
+- Secret Scanning 和 push protection 已启用，当前无未关闭 secret alert。
+- Docker Web 在非 loopback 绑定且无 token 时默认拒绝启动；API 包含 Host 检查、常量时间 token 比较、HttpOnly + SameSite=Strict cookie。
+- Tauri updater 使用公钥签名校验，macOS 开启 hardened runtime。
+- React 扫描未发现 `dangerouslySetInnerHTML`、`eval`、`document.write` 或不安全 `postMessage` 处理。
+- 新 Relay v2 分支采用请求/响应 header allowlist、固定操作、公网 HTTPS 目标校验、Cloudflare 公网出站限制、逐级重定向复验和请求/响应流上限；生产环境仍是报告前述旧版本，需完成灰度后才能把该项视为线上控制。
+- CI 使用 lockfile + `npm ci`；GitHub 默认 workflow token 权限为 read，不能批准 PR。
+
+## 上游残余风险（未静默忽略）
+
+2026-08-23 使用最新 RustSec advisory database 复核时，`cargo audit` 为 0 个 vulnerability，另有 17 条 unmaintained 与 4 条 unsound 信息性警告。它们均没有当前可用的兼容修复：GTK3 系列是 Tauri 2.11.5 在 Linux 上的 WebKit 运行时；`anyhow 1.0.102`、`event-listener 5.4.1` 均是当前可选最新版；`glib 0.18.5` 由 Linux Tauri 链引入；`rand 0.7.3` 只在 Tauri HTML 解析构建链中出现。项目未调用 advisory 指向的 `anyhow::Error::downcast_mut` 或 `glib::VariantStrIter`，rand 路径也不进入产品运行时。
+
+这些项目没有写入 `audit.toml` ignore，也没有在 GitHub 告警中 dismiss。CI 每次运行 `cargo audit`，Dependabot 每周检查 Cargo 与 Actions；上游一旦发布兼容修复，门禁会把升级变成明确改动。Linux 桌面端仍应把系统 WebKit/GTK 安全更新视为部署前置条件。
+
+## 建议修复顺序
+
+1. 按 `docs/relay-security-runbook.md` 配置 Turnstile/会话 secret，先部署向后兼容 Worker并做负向探针，再发布 v2 前端；不得回退到 open/report-only。
+2. 用真实浏览器完成可直连与必须 Relay 两条 canary，确认未知结果的生成 POST 不会自动重放；随后检查无敏感字段的后台路径/状态码汇总。
+3. 合并后启用 CodeQL、Dependabot security updates、main 分支 CI 门禁、Actions SHA enforcement 和 production Environment reviewer，并通过 API 回读结果。
+4. 持续跟进 Tauri 平台依赖中的 GTK3、`glib`、`anyhow` 与 `event-listener`；兼容修复出现后立即升级，不以 ignore/dismiss 代替处理。
+
+## 验证方法
+
+- GitHub API：repository security settings、Dependabot/Code/Secret Scanning、Actions permissions、main branch protection。
+- 依赖：`npm audit --omit=dev`、relay 全量 `npm audit`、`cargo audit --json`、`cargo tree -i ... --target all`。
+- 静态扫描：React/DOM sink、storage/token、网络目标、Tauri capability/CSP、GitHub workflow 权限与 action 引用。
+- 线上只读验证：两个页面的 HTTP 响应头；relay 的无 Origin/非法 Origin行为；通过 relay 获取 `https://example.com/`。

--- a/workers/gpt-image-2-relay/package-lock.json
+++ b/workers/gpt-image-2-relay/package-lock.json
@@ -11,7 +11,7 @@
         "@cloudflare/workers-types": "^5.20260726.1",
         "typescript": "^5.7.0",
         "vitest": "^4.1.5",
-        "wrangler": "^4.114.0"
+        "wrangler": "^4.125.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
-      "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260820.1.tgz",
+      "integrity": "sha512-5F2/t7SVnugG3rscSe9da1LoHst+GiuVGPaE9BP6j5AonlFpiYi0eoJrl3wof9zDBIIgJZ87NjRj9TKjbbYgHg==",
       "cpu": [
         "x64"
       ],
@@ -58,9 +58,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
-      "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-jFnG7715+r9FXRZPpuWWe5Ayd9v/IJKDODARg56ffFJWWtte6bFNi5VY3GazBM04hEmxny6OjXQBh3j2E/wNZw==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
-      "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260820.1.tgz",
+      "integrity": "sha512-TbTYaCBht0OaOWmnVpg43hXVYtIti/Kg6lvO819H2DwbxPpK1BH0z2C+Y7ySrVJLlxZQeic5eN7/noqbP80hJg==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
-      "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260820.1.tgz",
+      "integrity": "sha512-FQmri1UF7hBnnpeyC5SZJCAnsSRs3+Ykn9wlO5zxmE2qIgKfbJZ+toJ6qrQyugWlxE65juT33HU6aYLtutLJHw==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
-      "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260820.1.tgz",
+      "integrity": "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +126,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "5.20260726.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260726.1.tgz",
-      "integrity": "sha512-fKgRSm3sDmOdak1LGWehS4vSPSj7/zeu0NfmE62VPjBMqWgODcOGljYvq6A75sL+7YfY3iGFGb0jVEDYq+hlmw==",
+      "version": "5.20260822.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260822.1.tgz",
+      "integrity": "sha512-z922wN0pEWwYaAcYdncSf11fTPfj2j1Q2n2LCLbtBBhpkIu/aC8fotol5q4ek4isWgTKfWzUx389Dsa+lhF6yw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -1116,17 +1116,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@img/sharp-webcontainers-wasm32": {
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
@@ -1589,9 +1578,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
-      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -2215,30 +2204,27 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260722.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.0.tgz",
-      "integrity": "sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==",
+      "version": "5.20260820.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260820.0-alpha.tgz",
+      "integrity": "sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
-        "undici": "7.28.0",
-        "workerd": "1.20260722.1",
+        "undici": "7.29.0",
+        "workerd": "1.20260820.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
       },
       "engines": {
         "node": ">=22.0.0"
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2531,9 +2517,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2736,9 +2722,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260722.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
-      "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
+      "version": "1.20260820.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260820.1.tgz",
+      "integrity": "sha512-/wk4rFNHH6IVMXFe6aPEZsT5YWpWtfKTUMt7+rFkyeGbXcGCy4yxODmJatbqYj0jmqHETdz0+m2mT+vNjXnF7w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2749,17 +2735,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260722.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
-        "@cloudflare/workerd-linux-64": "1.20260722.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260722.1",
-        "@cloudflare/workerd-windows-64": "1.20260722.1"
+        "@cloudflare/workerd-darwin-64": "1.20260820.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260820.1",
+        "@cloudflare/workerd-linux-64": "1.20260820.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260820.1",
+        "@cloudflare/workerd-windows-64": "1.20260820.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.114.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.114.0.tgz",
-      "integrity": "sha512-M65P25t5UHA1TIJfgZXDcj+YzVobgKdRguM2QPz0xnxLFuOcuE3ErgllDht0iaho7MS4o0g/Bb4YK2+GT+bibg==",
+      "version": "4.125.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.125.0.tgz",
+      "integrity": "sha512-yFpvggu+xk1Hdm/Uxwaqa19bb7GArME4CrCS3Vov68a2TZq2MPO+wLocKbbnIC9K0oLowcdau7/ycxbbNHKCEg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -2767,10 +2753,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260722.0",
+        "miniflare": "5.20260820.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260722.1"
+        "workerd": "1.20260820.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -2784,7 +2770,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260722.1"
+        "@cloudflare/workers-types": "^5.20260820.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/workers/gpt-image-2-relay/package.json
+++ b/workers/gpt-image-2-relay/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents": false,
+    "workerd@1.20260820.1": true
+  },
   "scripts": {
     "deploy": "wrangler deploy",
     "dry-run": "wrangler deploy --dry-run",
@@ -13,6 +18,6 @@
     "@cloudflare/workers-types": "^5.20260726.1",
     "typescript": "^5.7.0",
     "vitest": "^4.1.5",
-    "wrangler": "^4.114.0"
+    "wrangler": "^4.125.0"
   }
 }

--- a/workers/gpt-image-2-relay/src/config.ts
+++ b/workers/gpt-image-2-relay/src/config.ts
@@ -1,0 +1,88 @@
+import type { Env } from "./types";
+
+export const DEFAULT_ALLOWED_ORIGINS = ["https://image.codex-pool.com"];
+
+export const DEFAULT_BLOCKED_HOSTS = [
+  "image.codex-pool.com",
+  "gpt-image-2-dpm.pages.dev",
+];
+
+export function boolEnv(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value.trim() === "") return fallback;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+export function boundedIntEnv(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function csv(value: string | undefined, fallback: string[]): string[] {
+  const items = (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : fallback;
+}
+
+export function allowedOrigins(env: Env): string[] {
+  const origins = csv(env.RELAY_ALLOWED_ORIGINS, DEFAULT_ALLOWED_ORIGINS)
+    .filter((item) => item !== "*")
+    .flatMap((item) => {
+      try {
+        const parsed = new URL(item);
+        if (
+          !["https:", "http:"].includes(parsed.protocol) ||
+          parsed.username ||
+          parsed.password ||
+          parsed.pathname !== "/" ||
+          parsed.search ||
+          parsed.hash
+        ) {
+          return [];
+        }
+        return [parsed.origin];
+      } catch {
+        return [];
+      }
+    });
+  return [...new Set(origins)];
+}
+
+export function blockedHosts(env: Env): Set<string> {
+  return new Set(
+    csv(env.RELAY_BLOCKED_HOSTS, DEFAULT_BLOCKED_HOSTS).map((item) =>
+      item.toLowerCase().replace(/\.$/, ""),
+    ),
+  );
+}
+
+export function sessionTtlSeconds(env: Env): number {
+  return boundedIntEnv(env.RELAY_SESSION_TTL_SECONDS, 86_400, 300, 86_400);
+}
+
+export function cookieSecure(env: Env): boolean {
+  return boolEnv(env.RELAY_COOKIE_SECURE, true);
+}
+
+export function relayEnabled(env: Env): boolean {
+  return boolEnv(env.RELAY_ENABLED, true);
+}
+
+export function v2Ready(env: Env): boolean {
+  return (
+    relayEnabled(env) &&
+    boolEnv(env.RELAY_V2_ENABLED, true) &&
+    Boolean(env.TURNSTILE_SITE_KEY?.trim()) &&
+    Boolean(env.TURNSTILE_SECRET_KEY?.trim()) &&
+    (env.RELAY_SESSION_HMAC_KEY?.length ?? 0) >= 32 &&
+    Boolean(env.RELAY_SESSION_RATE) &&
+    Boolean(env.RELAY_SESSION_ISSUE_RATE)
+  );
+}

--- a/workers/gpt-image-2-relay/src/index.test.ts
+++ b/workers/gpt-image-2-relay/src/index.test.ts
@@ -1,15 +1,40 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import worker, { type Env } from "./index";
+import {
+  API_BASE_HEADER,
+  RELAY_VERSION_HEADER,
+  validateApiBase,
+  validateAssetTarget,
+} from "./policy";
+import { createSessionCookie } from "./session";
+import { RelayHttpError, type RateLimitBinding } from "./types";
 
-const env: Env = {
-  RELAY_ENABLED: "true",
-  RELAY_MODE: "open",
-  RELAY_ALLOWLIST_REPORT_ONLY: "true",
-  RELAY_ALLOWED_ORIGINS: "https://image.codex-pool.com",
-  RELAY_ALLOWED_METHODS: "GET,POST,OPTIONS",
-  RELAY_MAX_REQUEST_BYTES: "1024",
-  RELAY_MAX_RESPONSE_BYTES: "1024",
-};
+const SITE_ORIGIN = "https://image.codex-pool.com";
+const RELAY_URL = `${SITE_ORIGIN}/api/relay`;
+const V2_URL = `${RELAY_URL}/v2`;
+
+function allowRateLimit(): RateLimitBinding {
+  return { limit: vi.fn(async () => ({ success: true })) };
+}
+
+function testEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    RELAY_ENABLED: "true",
+    RELAY_V2_ENABLED: "true",
+    RELAY_V1_MODE: "restricted",
+    RELAY_ALLOWED_ORIGINS: SITE_ORIGIN,
+    RELAY_BLOCKED_HOSTS: "image.codex-pool.com",
+    RELAY_SESSION_TTL_SECONDS: "86400",
+    RELAY_COOKIE_SECURE: "true",
+    TURNSTILE_SITE_KEY: "test-site-key",
+    TURNSTILE_SECRET_KEY: "test-turnstile-secret",
+    RELAY_SESSION_HMAC_KEY: "s".repeat(64),
+    RELAY_SESSION_RATE: allowRateLimit(),
+    RELAY_SESSION_ISSUE_RATE: allowRateLimit(),
+    RELAY_LEGACY_RATE: allowRateLimit(),
+    ...overrides,
+  };
+}
 
 function ctx(): ExecutionContext {
   return {
@@ -19,105 +44,680 @@ function ctx(): ExecutionContext {
   } as unknown as ExecutionContext;
 }
 
+function v2Headers(extra: HeadersInit = {}): Headers {
+  const headers = new Headers(extra);
+  headers.set("Origin", SITE_ORIGIN);
+  headers.set("Sec-Fetch-Site", "same-origin");
+  headers.set(RELAY_VERSION_HEADER, "2");
+  return headers;
+}
+
+async function sessionCookie(env: Env): Promise<string> {
+  const { header } = await createSessionCookie(env);
+  return header.split(";", 1)[0];
+}
+
 describe("gpt-image-2 relay worker", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it("handles CORS preflight for the static site", async () => {
+  it("reports v2 disabled until every secret and rate binding exists", async () => {
     const response = await worker.fetch(
-      new Request("https://image.codex-pool.com/api/relay", {
-        method: "OPTIONS",
-        headers: { Origin: "https://image.codex-pool.com" },
+      new Request(`${V2_URL}/config`),
+      testEnv({ TURNSTILE_SECRET_KEY: undefined }),
+      ctx(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      version: 2,
+      enabled: false,
+      auth_mode: "turnstile",
+      turnstile_site_key: "test-site-key",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("exchanges a valid Turnstile token for a signed HttpOnly session", async () => {
+    const env = testEnv();
+    const verifyFetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe(
+          "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+        );
+        const body = init?.body as URLSearchParams;
+        expect(body.get("response")).toBe("valid-token");
+        expect(body.get("remoteip")).toBe("203.0.113.8");
+        return new Response(
+          JSON.stringify({
+            success: true,
+            hostname: "image.codex-pool.com",
+            action: "relay_session",
+          }),
+          { headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
+    vi.stubGlobal("fetch", verifyFetch);
+
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/session`, {
+        method: "POST",
+        headers: v2Headers({
+          "Content-Type": "application/json",
+          "CF-Connecting-IP": "203.0.113.8",
+        }),
+        body: JSON.stringify({ token: "valid-token" }),
       }),
       env,
       ctx(),
     );
 
-    expect(response.status).toBe(204);
-    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
-      "https://image.codex-pool.com",
+    expect(response.status).toBe(201);
+    expect(await response.json()).toMatchObject({ active: true });
+    const setCookie = response.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__Host-gpt2_relay=v2.");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain("SameSite=Strict");
+    expect(setCookie).not.toContain("Domain=");
+    expect(env.RELAY_SESSION_ISSUE_RATE?.limit).toHaveBeenCalledOnce();
+
+    const status = await worker.fetch(
+      new Request(`${V2_URL}/session`, {
+        headers: {
+          "Sec-Fetch-Site": "same-origin",
+          Cookie: setCookie.split(";", 1)[0],
+        },
+      }),
+      env,
+      ctx(),
     );
+    expect(await status.json()).toMatchObject({ active: true });
   });
 
-  it("streams an HTTPS upstream while stripping cookies", async () => {
-    const upstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
-      expect(String(input)).toBe("https://api.example.com/v1/models");
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "Set-Cookie": "secret=1",
-        },
-      });
+  it("rejects a Turnstile token bound to another hostname", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              success: true,
+              hostname: "attacker.example.com",
+              action: "relay_session",
+            }),
+          ),
+      ),
+    );
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/session`, {
+        method: "POST",
+        headers: v2Headers({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ token: "wrong-host-token" }),
+      }),
+      testEnv(),
+      ctx(),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { code: "turnstile_rejected" },
     });
+  });
+
+  it("fails closed when Turnstile verification is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("network unavailable");
+      }),
+    );
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/session`, {
+        method: "POST",
+        headers: v2Headers({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ token: "unverifiable-token" }),
+      }),
+      testEnv(),
+      ctx(),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: { code: "relay_auth_unavailable" },
+    });
+  });
+
+  it("proxies only the fixed models path with a valid session", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    const upstreamFetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(String(input)).toBe("https://api.example.com/v1/models");
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBe("Bearer sk-test");
+        expect(headers.get("Accept-Encoding")).toBe("identity");
+        expect(headers.get("Cookie")).toBeNull();
+        expect(headers.get(API_BASE_HEADER)).toBeNull();
+        return new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": "upstream-secret=1",
+            Location: "https://attacker.example.com/",
+            "X-Request-Id": "req_123",
+          },
+        });
+      },
+    );
     vi.stubGlobal("fetch", upstreamFetch);
 
     const response = await worker.fetch(
-      new Request("https://image.codex-pool.com/api/relay", {
+      new Request(`${V2_URL}/models`, {
         method: "POST",
-        headers: {
-          Origin: "https://image.codex-pool.com",
-          "X-GPT-Image-2-Upstream": "https://api.example.com/v1/models",
-          "X-GPT-Image-2-Method": "GET",
+        headers: v2Headers({
+          Cookie: cookie,
           Authorization: "Bearer sk-test",
-        },
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+        }),
       }),
       env,
       ctx(),
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ ok: true });
+    expect(await response.json()).toEqual({ data: [] });
     expect(response.headers.get("Set-Cookie")).toBeNull();
-    expect(response.headers.get("X-GPT-Image-2-Relay")).toBe("1");
+    expect(response.headers.get("Location")).toBeNull();
+    expect(response.headers.get("X-Request-Id")).toBe("req_123");
+    expect(response.headers.get("X-GPT-Image-2-Relay-Policy")).toBe("v2");
+    expect(env.RELAY_SESSION_RATE?.limit).toHaveBeenCalledOnce();
   });
 
-  it("blocks non-HTTPS and private upstreams", async () => {
-    for (const upstream of [
-      "http://api.example.com/v1/models",
-      "https://127.0.0.1/v1/models",
-      "https://192.168.1.10/v1/models",
-      "https://localhost/v1/models",
-    ]) {
+  it("requires exact origin, fetch metadata, protocol version, and session", async () => {
+    const env = testEnv({
+      RELAY_ALLOWED_ORIGINS: `${SITE_ORIGIN},https://gpt-image-2-dpm.pages.dev`,
+    });
+    const baseHeaders = {
+      Authorization: "Bearer sk-test",
+      [API_BASE_HEADER]: "https://api.example.com/v1",
+    };
+    const cases: Array<[HeadersInit, string]> = [
+      [baseHeaders, "origin_denied"],
+      [
+        { ...baseHeaders, Origin: "https://attacker.example.com" },
+        "origin_denied",
+      ],
+      [
+        {
+          ...baseHeaders,
+          Origin: "https://gpt-image-2-dpm.pages.dev",
+          "Sec-Fetch-Site": "same-origin",
+          [RELAY_VERSION_HEADER]: "2",
+        },
+        "origin_denied",
+      ],
+      [{ ...baseHeaders, Origin: SITE_ORIGIN }, "cross_site_denied"],
+      [
+        {
+          ...baseHeaders,
+          Origin: SITE_ORIGIN,
+          "Sec-Fetch-Site": "same-origin",
+        },
+        "protocol_version_required",
+      ],
+      [v2Headers(baseHeaders), "session_required"],
+    ];
+
+    for (const [headers, code] of cases) {
       const response = await worker.fetch(
-        new Request("https://image.codex-pool.com/api/relay", {
+        new Request(`${V2_URL}/models`, { method: "POST", headers }),
+        env,
+        ctx(),
+      );
+      expect(response.status).toBe(code === "session_required" ? 401 : 403);
+      expect(await response.json()).toMatchObject({ error: { code } });
+    }
+  });
+
+  it("rejects tampered and expired session cookies", async () => {
+    const env = testEnv();
+    const tampered = `${await sessionCookie(env)}x`;
+    const expired = (
+      await createSessionCookie(env, Math.floor(Date.now() / 1000) - 90_000)
+    ).header.split(";", 1)[0];
+    for (const cookie of [tampered, expired]) {
+      const response = await worker.fetch(
+        new Request(`${V2_URL}/models`, {
           method: "POST",
-          headers: {
-            Origin: "https://image.codex-pool.com",
-            "X-GPT-Image-2-Upstream": upstream,
-            "X-GPT-Image-2-Method": "GET",
-          },
+          headers: v2Headers({
+            Cookie: cookie,
+            Authorization: "Bearer sk-test",
+            [API_BASE_HEADER]: "https://api.example.com/v1",
+          }),
         }),
         env,
         ctx(),
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(401);
+      expect(await response.json()).toMatchObject({
+        error: { code: "session_required" },
+      });
     }
   });
 
-  it("can enforce allowlist mode later", async () => {
+  it("blocks SSRF URL forms while preserving arbitrary public domains", () => {
+    const env = testEnv();
+    const requestUrl = new URL(`${V2_URL}/models`);
+    for (const target of [
+      "http://api.example.com/v1",
+      "https://127.0.0.1/v1",
+      "https://2130706433/v1",
+      "https://0x7f000001/v1",
+      "https://0177.0.0.1/v1",
+      "https://127.1/v1",
+      "https://[::1]/v1",
+      "https://localhost/v1",
+      "https://metadata.google.internal/v1",
+      "https://image.codex-pool.com/v1",
+      "https://user:password@api.example.com/v1",
+      "https://api.example.com:8443/v1",
+      "https://api.example.com/%2e%2e/v1",
+      "https://api.example.com/v1?target=x",
+      "https://api.example.com/v1#fragment",
+    ]) {
+      expect(() => validateApiBase(target, requestUrl, env)).toThrow(
+        RelayHttpError,
+      );
+    }
+
+    expect(
+      validateApiBase(
+        "https://user-chosen-relay.example.com/openai/v1",
+        requestUrl,
+        env,
+      ).href,
+    ).toBe("https://user-chosen-relay.example.com/openai/v1");
+    expect(
+      validateAssetTarget(
+        "https://cdn.example.com/file?X-Amz-Credential=a%2Fb",
+        requestUrl,
+        env,
+      ).search,
+    ).toContain("X-Amz-Credential");
+  });
+
+  it("enforces generation request size before contacting the upstream", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    const upstreamFetch = vi.fn();
+    vi.stubGlobal("fetch", upstreamFetch);
     const response = await worker.fetch(
-      new Request("https://image.codex-pool.com/api/relay", {
+      new Request(`${V2_URL}/generations`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          Authorization: "Bearer sk-test",
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+          "Content-Type": "application/json",
+          "Content-Length": String(1024 * 1024 + 1),
+        }),
+        body: "{}",
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toMatchObject({
+      error: { code: "request_too_large" },
+    });
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it("enforces the generation limit on a chunked body with no Content-Length", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    const chunk = new Uint8Array(600 * 1024);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(chunk);
+        controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+    const upstreamFetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const reader = (init?.body as ReadableStream<Uint8Array>).getReader();
+        while (!(await reader.read()).done) {
+          // Consume the transformed stream so its byte counter is exercised.
+        }
+        return new Response("unreachable");
+      },
+    );
+    vi.stubGlobal("fetch", upstreamFetch);
+    const request = new Request(`${V2_URL}/generations`, {
+      method: "POST",
+      headers: v2Headers({
+        Cookie: cookie,
+        Authorization: "Bearer sk-test",
+        [API_BASE_HEADER]: "https://api.example.com/v1",
+        "Content-Type": "application/json",
+      }),
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" });
+
+    const response = await worker.fetch(request, env, ctx());
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toMatchObject({
+      error: { code: "request_too_large" },
+    });
+    expect(upstreamFetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an oversized upstream response before streaming it", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("x", {
+            headers: {
+              "Content-Type": "application/json",
+              "Content-Length": String(2 * 1024 * 1024 + 1),
+            },
+          }),
+      ),
+    );
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/models`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          Authorization: "Bearer sk-test",
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+        }),
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toMatchObject({
+      error: { code: "response_too_large" },
+    });
+  });
+
+  it("rejects encoded upstream bodies before applying the byte limit", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("compressed", {
+            headers: {
+              "Content-Type": "application/json",
+              "Content-Encoding": "gzip",
+            },
+          }),
+      ),
+    );
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/models`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          Authorization: "Bearer sk-test",
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+        }),
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: { code: "upstream_encoding_denied" },
+    });
+  });
+
+  it("rejects non-JSON successful API responses", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("<html>unexpected</html>", {
+            headers: { "Content-Type": "text/html" },
+          }),
+      ),
+    );
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/models`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          Authorization: "Bearer sk-test",
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+        }),
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: { code: "upstream_content_type_denied" },
+    });
+  });
+
+  it("downloads an asset without forwarding credentials or cookies", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    const upstreamFetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        expect(headers.get("Authorization")).toBeNull();
+        expect(headers.get("Cookie")).toBeNull();
+        expect(headers.get("Referer")).toBeNull();
+        return new Response(new Uint8Array([1, 2, 3]), {
+          headers: {
+            "Content-Type": "image/png",
+            "Set-Cookie": "cdn-secret=1",
+          },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", upstreamFetch);
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/asset`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          Authorization: "Bearer must-not-be-forwarded",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({
+          url: "https://cdn.example.com/signed.png?token=sensitive",
+        }),
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+    expect(response.headers.get("Set-Cookie")).toBeNull();
+  });
+
+  it("revalidates asset redirects and blocks a redirect to an IP literal", async () => {
+    const env = testEnv();
+    const cookie = await sessionCookie(env);
+    const upstreamFetch = vi.fn(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { Location: "https://127.0.0.1/private" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstreamFetch);
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/asset`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: cookie,
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ url: "https://cdn.example.com/image.png" }),
+      }),
+      env,
+      ctx(),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: { code: "asset_redirect_denied" },
+    });
+    expect(upstreamFetch).toHaveBeenCalledOnce();
+  });
+
+  it("rejects bodies on the legacy asset compatibility path", async () => {
+    const upstreamFetch = vi.fn();
+    vi.stubGlobal("fetch", upstreamFetch);
+    const response = await worker.fetch(
+      new Request(RELAY_URL, {
         method: "POST",
         headers: {
-          Origin: "https://image.codex-pool.com",
+          Origin: SITE_ORIGIN,
+          "X-GPT-Image-2-Upstream": "https://cdn.example.com/image.png",
+          "X-GPT-Image-2-Method": "GET",
+          "Content-Type": "text/plain",
+        },
+        body: "unexpected",
+      }),
+      testEnv(),
+      ctx(),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "body_not_allowed" },
+    });
+    expect(upstreamFetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps legacy clients working during v2 secret setup but rejects arbitrary paths and missing origins", async () => {
+    const env = testEnv({ RELAY_SESSION_HMAC_KEY: undefined });
+    const upstreamFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [] }), {
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", upstreamFetch);
+
+    const valid = await worker.fetch(
+      new Request(RELAY_URL, {
+        method: "POST",
+        headers: {
+          Origin: SITE_ORIGIN,
+          Authorization: "Bearer sk-test",
           "X-GPT-Image-2-Upstream": "https://api.example.com/v1/models",
           "X-GPT-Image-2-Method": "GET",
         },
       }),
-      {
-        ...env,
-        RELAY_MODE: "allowlist",
-        RELAY_ALLOWLIST_REPORT_ONLY: "false",
-        RELAY_ALLOWLIST_JSON: JSON.stringify([
-          { origin: "https://api.duckcoding.com", basePath: "/v1" },
-        ]),
+      env,
+      ctx(),
+    );
+    expect(valid.status).toBe(200);
+    expect(valid.headers.get("X-GPT-Image-2-Relay-Policy")).toBe(
+      "restricted-v1",
+    );
+    expect(valid.headers.get("Deprecation")).toBe("true");
+
+    const arbitrary = await worker.fetch(
+      new Request(RELAY_URL, {
+        method: "POST",
+        headers: {
+          Origin: SITE_ORIGIN,
+          Authorization: "Bearer sk-test",
+          "X-GPT-Image-2-Upstream": "https://api.example.com/admin/delete",
+          "X-GPT-Image-2-Method": "DELETE",
+        },
+      }),
+      env,
+      ctx(),
+    );
+    expect(arbitrary.status).toBe(403);
+    expect(await arbitrary.json()).toMatchObject({
+      error: { code: "operation_not_allowed" },
+    });
+
+    const missingOrigin = await worker.fetch(
+      new Request(RELAY_URL, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer sk-test",
+          "X-GPT-Image-2-Upstream": "https://api.example.com/v1/models",
+          "X-GPT-Image-2-Method": "GET",
+        },
+      }),
+      env,
+      ctx(),
+    );
+    expect(missingOrigin.status).toBe(403);
+  });
+
+  it("returns 429 when the session rate limiter rejects a request", async () => {
+    const env = testEnv({
+      RELAY_SESSION_RATE: {
+        limit: vi.fn(async () => ({ success: false })),
       },
+    });
+    const response = await worker.fetch(
+      new Request(`${V2_URL}/models`, {
+        method: "POST",
+        headers: v2Headers({
+          Cookie: await sessionCookie(env),
+          Authorization: "Bearer sk-test",
+          [API_BASE_HEADER]: "https://api.example.com/v1",
+        }),
+      }),
+      env,
       ctx(),
     );
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(await response.json()).toMatchObject({
+      error: { code: "relay_rate_limited", retry_after_seconds: 60 },
+    });
+  });
+
+  it("handles the restricted legacy CORS preflight", async () => {
+    const response = await worker.fetch(
+      new Request(RELAY_URL, {
+        method: "OPTIONS",
+        headers: { Origin: SITE_ORIGIN },
+      }),
+      testEnv(),
+      ctx(),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(
+      SITE_ORIGIN,
+    );
   });
 });

--- a/workers/gpt-image-2-relay/src/index.ts
+++ b/workers/gpt-image-2-relay/src/index.ts
@@ -1,385 +1,620 @@
-type RelayMode = "open" | "allowlist";
+import {
+  allowedOrigins,
+  relayEnabled,
+  sessionTtlSeconds,
+  v2Ready,
+} from "./config";
+import {
+  API_BASE_HEADER,
+  API_MAX_ERROR_RESPONSE_BYTES,
+  ASSET_MAX_REDIRECTS,
+  ASSET_MAX_ERROR_RESPONSE_BYTES,
+  ASSET_MAX_REQUEST_BYTES,
+  ASSET_MAX_RESPONSE_BYTES,
+  ASSET_TIMEOUT_MS,
+  classifyLegacyRequest,
+  LEGACY_METHOD_HEADER,
+  LEGACY_UPSTREAM_HEADER,
+  operationUrl,
+  OPERATION_SPECS,
+  requireLegacyRequestOrigin,
+  requireSameOriginPost,
+  requireSameOriginRead,
+  validateApiBase,
+  validateAssetTarget,
+  validateContentLength,
+  validateContentType,
+  type OperationSpec,
+} from "./policy";
+import {
+  createSessionCookie,
+  enforceRateLimit,
+  rateKeyForRequest,
+  verifySession,
+  verifyTurnstile,
+} from "./session";
+import {
+  limitRequestBody,
+  limitResponseBody,
+  readJsonLimited,
+} from "./streams";
+import { RelayHttpError, type Env, type RelayOperation } from "./types";
 
-export interface Env {
-  RELAY_ENABLED?: string;
-  RELAY_MODE?: string;
-  RELAY_ALLOWLIST_REPORT_ONLY?: string;
-  RELAY_ALLOWED_ORIGINS?: string;
-  RELAY_ALLOWED_METHODS?: string;
-  RELAY_MAX_REQUEST_BYTES?: string;
-  RELAY_MAX_RESPONSE_BYTES?: string;
-  RELAY_ALLOWLIST_JSON?: string;
-}
+export type { Env } from "./types";
 
-type AllowlistEntry = {
-  name?: string;
-  origin: string;
-  basePath?: string;
-  paths?: string[];
-  methods?: string[];
-};
-
-const RELAY_HEADER = "x-gpt-image-2-upstream";
-const RELAY_METHOD_HEADER = "x-gpt-image-2-method";
-const DEFAULT_ALLOWED_METHODS = ["GET", "POST", "OPTIONS"];
-const DEFAULT_ALLOWED_ORIGINS = [
-  "https://image.codex-pool.com",
-  "https://gpt-image-2-dpm.pages.dev",
-];
-const DEFAULT_MAX_REQUEST_BYTES = 50 * 1024 * 1024;
-const DEFAULT_MAX_RESPONSE_BYTES = 120 * 1024 * 1024;
-
-const REQUEST_HEADER_BLOCKLIST = new Set([
-  "accept-encoding",
-  "cf-connecting-ip",
-  "cf-ipcountry",
-  "cf-ray",
-  "cf-visitor",
-  "connection",
-  "cookie",
-  "host",
-  "origin",
-  "referer",
-  "x-forwarded-for",
-  "x-forwarded-host",
-  "x-forwarded-proto",
+const RELAY_ROOT = "/api/relay";
+const V2_ROOT = `${RELAY_ROOT}/v2`;
+const API_RESPONSE_HEADERS = new Set([
+  "content-disposition",
+  "content-type",
+  "openai-request-id",
+  "request-id",
+  "retry-after",
+  "x-request-id",
 ]);
 
-const RESPONSE_HEADER_BLOCKLIST = new Set([
-  "connection",
-  "content-length",
-  "set-cookie",
-  "transfer-encoding",
-]);
-
-function csv(value: string | undefined, fallback: string[]) {
-  const items = (value ?? "")
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-  return items.length > 0 ? items : fallback;
+function securityHeaders(headers = new Headers()): Headers {
+  headers.set("Cache-Control", "no-store");
+  headers.set("Referrer-Policy", "no-referrer");
+  headers.set("X-Content-Type-Options", "nosniff");
+  return headers;
 }
 
-function boolEnv(value: string | undefined, fallback: boolean) {
-  if (value === undefined || value.trim() === "") return fallback;
-  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
-}
-
-function numberEnv(value: string | undefined, fallback: number) {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
-}
-
-function relayMode(env: Env): RelayMode {
-  return env.RELAY_MODE === "allowlist" ? "allowlist" : "open";
-}
-
-function allowedOrigins(env: Env) {
-  return csv(env.RELAY_ALLOWED_ORIGINS, DEFAULT_ALLOWED_ORIGINS);
-}
-
-function allowedMethods(env: Env) {
-  return csv(env.RELAY_ALLOWED_METHODS, DEFAULT_ALLOWED_METHODS).map((method) =>
-    method.toUpperCase(),
+function legacyCorsHeaders(request: Request, env: Env): Headers {
+  const headers = new Headers();
+  const origin = request.headers.get("Origin");
+  if (origin && allowedOrigins(env).includes(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Vary", "Origin");
+  }
+  headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+  headers.set(
+    "Access-Control-Allow-Headers",
+    "authorization,content-type,accept,x-gpt-image-2-upstream,x-gpt-image-2-method",
   );
+  headers.set(
+    "Access-Control-Expose-Headers",
+    "content-type,content-disposition,deprecation,retry-after,request-id,x-request-id,openai-request-id,x-gpt-image-2-relay,x-gpt-image-2-relay-policy",
+  );
+  headers.set("Access-Control-Max-Age", "86400");
+  return headers;
 }
 
 function jsonResponse(
   status: number,
-  message: string,
-  request: Request,
-  env: Env,
-) {
-  return new Response(JSON.stringify({ error: { message } }), {
+  value: unknown,
+  request?: Request,
+  env?: Env,
+  legacy = false,
+  extraHeaders?: HeadersInit,
+): Response {
+  const headers = new Headers(extraHeaders);
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  if (legacy && request && env) {
+    legacyCorsHeaders(request, env).forEach((value, key) =>
+      headers.set(key, value),
+    );
+    headers.set("Deprecation", "true");
+  }
+  return new Response(JSON.stringify(value), {
     status,
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      ...corsHeaders(request, env),
-    },
+    headers: securityHeaders(headers),
   });
 }
 
-function corsHeaders(request: Request, env: Env) {
-  const origin = request.headers.get("Origin");
-  const allowed = allowedOrigins(env);
-  const allowOrigin =
-    origin && (allowed.includes("*") || allowed.includes(origin))
-      ? origin
-      : allowed[0];
-  return {
-    "Access-Control-Allow-Origin": allowOrigin,
-    "Access-Control-Allow-Methods": allowedMethods(env).join(", "),
-    "Access-Control-Allow-Headers":
-      "authorization,content-type,accept,x-gpt-image-2-upstream,x-gpt-image-2-method",
-    "Access-Control-Expose-Headers":
-      "content-type,x-gpt-image-2-relay,x-gpt-image-2-relay-policy",
-    "Access-Control-Max-Age": "86400",
-    Vary: "Origin",
-  };
-}
-
-function originAllowed(request: Request, env: Env) {
-  const origin = request.headers.get("Origin");
-  if (!origin) return true;
-  const allowed = allowedOrigins(env);
-  return allowed.includes("*") || allowed.includes(origin);
-}
-
-function parseAllowlist(env: Env): AllowlistEntry[] {
-  if (!env.RELAY_ALLOWLIST_JSON?.trim()) return [];
-  try {
-    const parsed = JSON.parse(env.RELAY_ALLOWLIST_JSON) as AllowlistEntry[];
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-function matchAllowlistEntry(
-  upstream: URL,
-  method: string,
-  entry: AllowlistEntry,
-) {
-  let origin: URL;
-  try {
-    origin = new URL(entry.origin);
-  } catch {
-    return false;
-  }
-  if (origin.origin !== upstream.origin) return false;
-  if (entry.basePath && !upstream.pathname.startsWith(entry.basePath)) {
-    return false;
-  }
-  if (entry.paths && !entry.paths.includes(upstream.pathname)) return false;
-  if (
-    entry.methods &&
-    !entry.methods.map((item) => item.toUpperCase()).includes(method)
-  ) {
-    return false;
-  }
-  return true;
-}
-
-function allowlistDecision(upstream: URL, method: string, env: Env) {
-  const entries = parseAllowlist(env);
-  return entries.some((entry) => matchAllowlistEntry(upstream, method, entry));
-}
-
-function parseIpv4(hostname: string) {
-  const parts = hostname.split(".");
-  if (parts.length !== 4) return undefined;
-  const bytes = parts.map((part) => Number(part));
-  if (
-    bytes.some(
-      (byte, index) =>
-        !Number.isInteger(byte) ||
-        byte < 0 ||
-        byte > 255 ||
-        String(byte) !== parts[index],
-    )
-  ) {
-    return undefined;
-  }
-  return bytes;
-}
-
-function privateIpv4(bytes: number[]) {
-  const [a, b] = bytes;
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168) ||
-    (a === 198 && (b === 18 || b === 19)) ||
-    a >= 224
-  );
-}
-
-function validateUpstream(raw: string | null) {
-  if (!raw?.trim()) return "Missing x-gpt-image-2-upstream.";
-  let upstream: URL;
-  try {
-    upstream = new URL(raw);
-  } catch {
-    return "Invalid upstream URL.";
-  }
-  if (upstream.protocol !== "https:")
-    return "Only HTTPS upstreams are allowed.";
-  if (upstream.username || upstream.password) {
-    return "Upstream URLs must not include credentials.";
-  }
-  if (upstream.port && upstream.port !== "443") {
-    return "Only the default HTTPS port is allowed.";
-  }
-  const hostname = upstream.hostname.toLowerCase();
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname.endsWith(".local")
-  ) {
-    return "Local upstreams are not allowed.";
-  }
-  if (hostname.includes(":")) return "IPv6 literal upstreams are not allowed.";
-  const ipv4 = parseIpv4(hostname);
-  if (ipv4 && privateIpv4(ipv4)) {
-    return "Private network upstreams are not allowed.";
-  }
-  return upstream;
-}
-
-function validateContentLength(request: Request, env: Env) {
-  const max = numberEnv(env.RELAY_MAX_REQUEST_BYTES, DEFAULT_MAX_REQUEST_BYTES);
-  const header = request.headers.get("Content-Length");
-  if (!header) return undefined;
-  const length = Number(header);
-  if (Number.isFinite(length) && length > max) {
-    return `Relay request is too large. Limit is ${max} bytes.`;
-  }
-  return undefined;
-}
-
-function requestHeadersForUpstream(request: Request) {
-  const headers = new Headers();
-  request.headers.forEach((value, key) => {
-    const normalized = key.toLowerCase();
-    if (REQUEST_HEADER_BLOCKLIST.has(normalized)) return;
-    if (normalized.startsWith("x-gpt-image-2-")) return;
-    headers.set(key, value);
-  });
-  return headers;
-}
-
-function responseHeadersForBrowser(
-  response: Response,
+function errorResponse(
+  error: RelayHttpError,
   request: Request,
   env: Env,
-  policy: RelayMode,
-) {
+  legacy: boolean,
+): Response {
   const headers = new Headers();
-  response.headers.forEach((value, key) => {
-    if (RESPONSE_HEADER_BLOCKLIST.has(key.toLowerCase())) return;
-    headers.set(key, value);
+  if (error.retryAfter) headers.set("Retry-After", String(error.retryAfter));
+  const payload: {
+    error: {
+      message: string;
+      code: string;
+      retry_after_seconds?: number;
+    };
+  } = { error: { message: error.message, code: error.code } };
+  if (error.retryAfter) {
+    payload.error.retry_after_seconds = error.retryAfter;
+  }
+  return jsonResponse(error.status, payload, request, env, legacy, headers);
+}
+
+function responseHeaders(
+  upstream: Response,
+  request: Request,
+  env: Env,
+  legacy: boolean,
+): Headers {
+  const headers = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const normalized = key.toLowerCase();
+    if (
+      API_RESPONSE_HEADERS.has(normalized) ||
+      normalized.startsWith("x-ratelimit-") ||
+      normalized.startsWith("ratelimit-")
+    ) {
+      headers.set(key, value);
+    }
   });
-  Object.entries(corsHeaders(request, env)).forEach(([key, value]) => {
-    headers.set(key, value);
-  });
-  headers.set("Cache-Control", "no-store");
+  if (legacy) {
+    legacyCorsHeaders(request, env).forEach((value, key) =>
+      headers.set(key, value),
+    );
+    headers.set("Deprecation", "true");
+  }
   headers.set("X-GPT-Image-2-Relay", "1");
-  headers.set("X-GPT-Image-2-Relay-Policy", policy);
+  headers.set("X-GPT-Image-2-Relay-Policy", legacy ? "restricted-v1" : "v2");
+  return securityHeaders(headers);
+}
+
+function checkUpstreamContentLength(
+  response: Response,
+  maxBytes: number,
+): void {
+  const raw = response.headers.get("Content-Length");
+  if (!raw) return;
+  const length = Number(raw);
+  if (Number.isFinite(length) && length > maxBytes) {
+    response.body?.cancel("relay response exceeded size limit");
+    throw new RelayHttpError(
+      413,
+      `Relay response exceeds the ${maxBytes}-byte limit.`,
+      "response_too_large",
+    );
+  }
+}
+
+function relayResponse(
+  upstream: Response,
+  maxBytes: number,
+  request: Request,
+  env: Env,
+  legacy: boolean,
+): Response {
+  checkUpstreamContentLength(upstream, maxBytes);
+  return new Response(
+    upstream.body ? limitResponseBody(upstream.body, maxBytes) : null,
+    {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: responseHeaders(upstream, request, env, legacy),
+    },
+  );
+}
+
+function authorizationHeader(request: Request): string {
+  const authorization = request.headers.get("Authorization")?.trim() ?? "";
+  if (!authorization || authorization.length > 16 * 1024) {
+    throw new RelayHttpError(
+      400,
+      "A valid Authorization header is required.",
+      "authorization_required",
+    );
+  }
+  return authorization;
+}
+
+function apiRequestHeaders(request: Request, spec: OperationSpec): Headers {
+  const headers = new Headers({
+    Authorization: authorizationHeader(request),
+    "Accept-Encoding": "identity",
+  });
+  const accept = request.headers.get("Accept");
+  if (accept && accept.length <= 512) headers.set("Accept", accept);
+  if (spec.requestContentType) {
+    const contentType = request.headers.get("Content-Type");
+    if (!contentType || contentType.length > 1024) {
+      throw new RelayHttpError(
+        415,
+        "Invalid relay request Content-Type.",
+        "unsupported_media_type",
+      );
+    }
+    headers.set("Content-Type", contentType);
+  }
   return headers;
 }
 
-function limitResponseBody(body: ReadableStream<Uint8Array>, maxBytes: number) {
-  const reader = body.getReader();
-  let total = 0;
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      const chunk = await reader.read();
-      if (chunk.done) {
-        controller.close();
-        return;
+function requireIdentityEncoding(response: Response): void {
+  const encoding = response.headers
+    .get("Content-Encoding")
+    ?.trim()
+    .toLowerCase();
+  if (encoding && encoding !== "identity") {
+    response.body?.cancel("encoded upstream response rejected");
+    throw new RelayHttpError(
+      502,
+      "Upstream ignored the relay's identity encoding requirement.",
+      "upstream_encoding_denied",
+    );
+  }
+}
+
+function requireJsonSuccessResponse(response: Response): void {
+  if (!response.ok) return;
+  const mediaType =
+    response.headers
+      .get("Content-Type")
+      ?.split(";", 1)[0]
+      .trim()
+      .toLowerCase() ?? "";
+  if (
+    mediaType !== "application/json" &&
+    mediaType !== "text/json" &&
+    !mediaType.endsWith("+json")
+  ) {
+    response.body?.cancel("non-JSON upstream response rejected");
+    throw new RelayHttpError(
+      502,
+      "Upstream returned an unsupported success content type.",
+      "upstream_content_type_denied",
+    );
+  }
+}
+
+async function fetchApiOperation(
+  request: Request,
+  env: Env,
+  spec: OperationSpec,
+  base: URL,
+  legacy: boolean,
+): Promise<Response> {
+  if (spec.requestContentType)
+    validateContentType(request, spec.requestContentType);
+  validateContentLength(request, spec.maxRequestBytes);
+  if (spec.upstreamMethod === "POST" && !request.body) {
+    throw new RelayHttpError(400, "Request body is required.", "body_required");
+  }
+  if (spec.upstreamMethod === "GET" && request.body) {
+    throw new RelayHttpError(
+      400,
+      "Models request must not have a body.",
+      "body_not_allowed",
+    );
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(operationUrl(base, spec), {
+      method: spec.upstreamMethod,
+      headers: apiRequestHeaders(request, spec),
+      body:
+        spec.upstreamMethod === "POST"
+          ? limitRequestBody(request.body, spec.maxRequestBytes)
+          : undefined,
+      redirect: "manual",
+      cache: "no-store",
+      signal: AbortSignal.any([
+        request.signal,
+        AbortSignal.timeout(spec.timeoutMs),
+      ]),
+    });
+  } catch (error) {
+    if (error instanceof RelayHttpError) throw error;
+    throw new RelayHttpError(
+      502,
+      "Upstream request failed.",
+      "upstream_unavailable",
+    );
+  }
+  if (upstream.status >= 300 && upstream.status < 400) {
+    upstream.body?.cancel("upstream redirect rejected");
+    throw new RelayHttpError(
+      502,
+      "Upstream API redirects are not allowed.",
+      "upstream_redirect_denied",
+    );
+  }
+  requireIdentityEncoding(upstream);
+  requireJsonSuccessResponse(upstream);
+  return relayResponse(
+    upstream,
+    upstream.ok
+      ? spec.maxResponseBytes
+      : Math.min(spec.maxResponseBytes, API_MAX_ERROR_RESPONSE_BYTES),
+    request,
+    env,
+    legacy,
+  );
+}
+
+async function fetchAsset(
+  request: Request,
+  env: Env,
+  initialTarget: URL,
+  legacy: boolean,
+): Promise<Response> {
+  let target = initialTarget;
+  const signal = AbortSignal.any([
+    request.signal,
+    AbortSignal.timeout(ASSET_TIMEOUT_MS),
+  ]);
+  for (let redirects = 0; redirects <= ASSET_MAX_REDIRECTS; redirects += 1) {
+    let upstream: Response;
+    try {
+      upstream = await fetch(target, {
+        method: "GET",
+        headers: {
+          Accept: "image/*, application/octet-stream;q=0.9, */*;q=0.1",
+          "Accept-Encoding": "identity",
+        },
+        redirect: "manual",
+        cache: "no-store",
+        signal,
+      });
+    } catch {
+      throw new RelayHttpError(
+        502,
+        "Asset download failed.",
+        "asset_unavailable",
+      );
+    }
+
+    if (upstream.status >= 300 && upstream.status < 400) {
+      const location = upstream.headers.get("Location");
+      upstream.body?.cancel("following validated asset redirect");
+      if (!location || redirects === ASSET_MAX_REDIRECTS) {
+        throw new RelayHttpError(
+          502,
+          "Asset redirect could not be followed safely.",
+          "asset_redirect_denied",
+        );
       }
-      total += chunk.value.byteLength;
-      if (total > maxBytes) {
-        await reader.cancel("relay response too large");
-        controller.error(new Error("Relay response exceeded size limit."));
-        return;
+      let next: URL;
+      try {
+        next = new URL(location, target);
+      } catch {
+        throw new RelayHttpError(
+          502,
+          "Asset redirect could not be followed safely.",
+          "asset_redirect_denied",
+        );
       }
-      controller.enqueue(chunk.value);
-    },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
+      try {
+        target = validateAssetTarget(next.href, new URL(request.url), env);
+      } catch {
+        throw new RelayHttpError(
+          502,
+          "Asset redirect could not be followed safely.",
+          "asset_redirect_denied",
+        );
+      }
+      continue;
+    }
+
+    requireIdentityEncoding(upstream);
+
+    if (upstream.ok) {
+      const contentType =
+        upstream.headers.get("Content-Type")?.toLowerCase() ?? "";
+      if (
+        !contentType.startsWith("image/") &&
+        !contentType.startsWith("application/octet-stream") &&
+        !contentType.startsWith("binary/octet-stream")
+      ) {
+        upstream.body?.cancel("unexpected asset content type");
+        throw new RelayHttpError(
+          502,
+          "Asset server returned an unsupported content type.",
+          "asset_content_type_denied",
+        );
+      }
+    }
+    return relayResponse(
+      upstream,
+      upstream.ok ? ASSET_MAX_RESPONSE_BYTES : ASSET_MAX_ERROR_RESPONSE_BYTES,
+      request,
+      env,
+      legacy,
+    );
+  }
+  throw new RelayHttpError(502, "Asset download failed.", "asset_unavailable");
+}
+
+function requireRelayEnabled(env: Env): void {
+  if (!relayEnabled(env)) {
+    throw new RelayHttpError(503, "Relay is disabled.", "relay_disabled");
+  }
+}
+
+function requireV2Ready(env: Env): void {
+  if (!v2Ready(env)) {
+    throw new RelayHttpError(
+      503,
+      "Relay v2 is not configured.",
+      "relay_not_configured",
+    );
+  }
+}
+
+async function handleSessionCreate(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  requireV2Ready(env);
+  const origin = requireSameOriginPost(request, env);
+  validateContentType(request, "application/json");
+  validateContentLength(request, 8 * 1024);
+  await enforceRateLimit(
+    env.RELAY_SESSION_ISSUE_RATE,
+    await rateKeyForRequest(request),
+  );
+  const payload = await readJsonLimited<{ token?: unknown }>(
+    request.body,
+    8 * 1024,
+  );
+  const token = typeof payload.token === "string" ? payload.token : "";
+  await verifyTurnstile(request, env, token, origin);
+  const issued = await createSessionCookie(env);
+  return jsonResponse(
+    201,
+    { active: true, expires_at: issued.session.expiresAt },
+    request,
+    env,
+    false,
+    { "Set-Cookie": issued.header },
+  );
+}
+
+async function handleSessionStatus(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  requireV2Ready(env);
+  requireSameOriginRead(request, env);
+  const session = await verifySession(request, env);
+  return jsonResponse(200, {
+    active: Boolean(session),
+    expires_at: session?.expiresAt ?? null,
   });
 }
 
-async function handleRelay(request: Request, env: Env) {
-  if (!boolEnv(env.RELAY_ENABLED, true)) {
-    return jsonResponse(503, "Relay is disabled.", request, env);
+async function authenticatedV2Session(request: Request, env: Env) {
+  requireV2Ready(env);
+  requireSameOriginPost(request, env);
+  const session = await verifySession(request, env);
+  if (!session) {
+    throw new RelayHttpError(
+      401,
+      "Relay session is missing or expired.",
+      "session_required",
+    );
   }
-  if (!originAllowed(request, env)) {
-    return jsonResponse(403, "Origin is not allowed.", request, env);
+  await enforceRateLimit(env.RELAY_SESSION_RATE, session.sid);
+  return session;
+}
+
+async function handleV2Operation(
+  request: Request,
+  env: Env,
+  operation: RelayOperation,
+): Promise<Response> {
+  await authenticatedV2Session(request, env);
+  if (operation === "asset") {
+    validateContentType(request, "application/json");
+    validateContentLength(request, ASSET_MAX_REQUEST_BYTES);
+    const payload = await readJsonLimited<{ url?: unknown }>(
+      request.body,
+      ASSET_MAX_REQUEST_BYTES,
+    );
+    const target = validateAssetTarget(
+      typeof payload.url === "string" ? payload.url : null,
+      new URL(request.url),
+      env,
+    );
+    return fetchAsset(request, env, target, false);
   }
 
-  const method =
-    request.headers.get(RELAY_METHOD_HEADER)?.trim().toUpperCase() ||
-    request.method.toUpperCase();
-  if (!allowedMethods(env).includes(method)) {
-    return jsonResponse(405, "Method is not allowed.", request, env);
-  }
-
-  const upstreamResult = validateUpstream(request.headers.get(RELAY_HEADER));
-  if (typeof upstreamResult === "string") {
-    return jsonResponse(400, upstreamResult, request, env);
-  }
-  const upstream = upstreamResult;
-  const requestSizeError = validateContentLength(request, env);
-  if (requestSizeError)
-    return jsonResponse(413, requestSizeError, request, env);
-
-  const mode = relayMode(env);
-  const allowlisted = allowlistDecision(upstream, method, env);
-  const reportOnly = boolEnv(env.RELAY_ALLOWLIST_REPORT_ONLY, true);
-  if (mode === "allowlist" && !allowlisted && !reportOnly) {
-    return jsonResponse(403, "Upstream is not allowlisted.", request, env);
-  }
-
-  const responseMax = numberEnv(
-    env.RELAY_MAX_RESPONSE_BYTES,
-    DEFAULT_MAX_RESPONSE_BYTES,
+  const spec = OPERATION_SPECS[operation];
+  const base = validateApiBase(
+    request.headers.get(API_BASE_HEADER),
+    new URL(request.url),
+    env,
   );
-  const upstreamContentLength = Number(
-    request.headers.get("X-GPT-Image-2-Expected-Response-Bytes") || NaN,
+  return fetchApiOperation(request, env, spec, base, false);
+}
+
+async function handleLegacy(request: Request, env: Env): Promise<Response> {
+  requireRelayEnabled(env);
+  if (env.RELAY_V1_MODE?.trim().toLowerCase() === "disabled") {
+    throw new RelayHttpError(
+      410,
+      "Legacy relay has been disabled.",
+      "legacy_relay_disabled",
+    );
+  }
+  requireLegacyRequestOrigin(request, env);
+  await enforceRateLimit(
+    env.RELAY_LEGACY_RATE,
+    await rateKeyForRequest(request),
   );
+  const method = request.headers.get(LEGACY_METHOD_HEADER) ?? "";
+  const decision = classifyLegacyRequest(
+    request.headers.get(LEGACY_UPSTREAM_HEADER),
+    method,
+    Boolean(request.headers.get("Authorization")),
+    new URL(request.url),
+    env,
+  );
+  if (decision.operation === "asset") {
+    validateContentLength(request, 0);
+    if (request.body) {
+      throw new RelayHttpError(
+        400,
+        "Asset requests must not have a body.",
+        "body_not_allowed",
+      );
+    }
+    return fetchAsset(request, env, decision.target, true);
+  }
+  return fetchApiOperation(
+    request,
+    env,
+    OPERATION_SPECS[decision.operation],
+    decision.base,
+    true,
+  );
+}
+
+function configResponse(env: Env): Response {
+  return jsonResponse(200, {
+    version: 2,
+    enabled: v2Ready(env),
+    auth_mode: "turnstile",
+    turnstile_site_key: env.TURNSTILE_SITE_KEY?.trim() || null,
+    session_ttl_seconds: sessionTtlSeconds(env),
+    operations: ["models", "generations", "edits", "asset"],
+  });
+}
+
+function methodNotAllowed(allow: string): never {
+  throw new RelayHttpError(
+    405,
+    `Method must be ${allow}.`,
+    "method_not_allowed",
+  );
+}
+
+async function route(request: Request, env: Env): Promise<Response> {
+  const path = new URL(request.url).pathname;
+  const method = request.method.toUpperCase();
+
+  if (path === `${V2_ROOT}/config`) {
+    if (method !== "GET") methodNotAllowed("GET");
+    return configResponse(env);
+  }
+  if (path === `${V2_ROOT}/session`) {
+    if (method === "GET") return handleSessionStatus(request, env);
+    if (method === "POST") return handleSessionCreate(request, env);
+    methodNotAllowed("GET or POST");
+  }
+
+  const operation = path.slice(`${V2_ROOT}/`.length) as RelayOperation;
   if (
-    Number.isFinite(upstreamContentLength) &&
-    upstreamContentLength > responseMax
+    path.startsWith(`${V2_ROOT}/`) &&
+    ["models", "generations", "edits", "asset"].includes(operation)
   ) {
-    return jsonResponse(
-      413,
-      `Relay response is too large. Limit is ${responseMax} bytes.`,
-      request,
-      env,
-    );
+    if (method !== "POST") methodNotAllowed("POST");
+    return handleV2Operation(request, env, operation);
   }
 
-  const body = method === "GET" || method === "HEAD" ? undefined : request.body;
-  let upstreamResponse: Response;
-  try {
-    upstreamResponse = await fetch(upstream, {
-      method,
-      headers: requestHeadersForUpstream(request),
-      body,
-      redirect: "manual",
-    });
-  } catch {
-    return jsonResponse(502, "Upstream request failed.", request, env);
+  if (path === RELAY_ROOT) {
+    if (method === "OPTIONS") {
+      requireLegacyRequestOrigin(request, env);
+      return new Response(null, {
+        status: 204,
+        headers: securityHeaders(legacyCorsHeaders(request, env)),
+      });
+    }
+    if (method !== "POST") methodNotAllowed("POST");
+    return handleLegacy(request, env);
   }
 
-  const contentLength = Number(upstreamResponse.headers.get("Content-Length"));
-  if (Number.isFinite(contentLength) && contentLength > responseMax) {
-    upstreamResponse.body?.cancel("relay response too large");
-    return jsonResponse(
-      413,
-      `Relay response is too large. Limit is ${responseMax} bytes.`,
-      request,
-      env,
-    );
-  }
-
-  return new Response(
-    upstreamResponse.body
-      ? limitResponseBody(upstreamResponse.body, responseMax)
-      : null,
-    {
-      status: upstreamResponse.status,
-      statusText: upstreamResponse.statusText,
-      headers: responseHeadersForBrowser(upstreamResponse, request, env, mode),
-    },
-  );
+  throw new RelayHttpError(404, "Relay route was not found.", "not_found");
 }
 
 export default {
@@ -388,15 +623,19 @@ export default {
     env: Env,
     _ctx: ExecutionContext,
   ): Promise<Response> {
-    if (request.method.toUpperCase() === "OPTIONS") {
-      if (!originAllowed(request, env)) {
-        return jsonResponse(403, "Origin is not allowed.", request, env);
+    const legacy = new URL(request.url).pathname === RELAY_ROOT;
+    try {
+      return await route(request, env);
+    } catch (error) {
+      if (error instanceof RelayHttpError) {
+        return errorResponse(error, request, env, legacy);
       }
-      return new Response(null, {
-        status: 204,
-        headers: corsHeaders(request, env),
-      });
+      return errorResponse(
+        new RelayHttpError(500, "Relay request failed.", "internal_error"),
+        request,
+        env,
+        legacy,
+      );
     }
-    return handleRelay(request, env);
   },
 };

--- a/workers/gpt-image-2-relay/src/policy.ts
+++ b/workers/gpt-image-2-relay/src/policy.ts
@@ -1,0 +1,308 @@
+import { allowedOrigins, blockedHosts } from "./config";
+import { RelayHttpError, type Env, type RelayOperation } from "./types";
+
+export const LEGACY_UPSTREAM_HEADER = "x-gpt-image-2-upstream";
+export const LEGACY_METHOD_HEADER = "x-gpt-image-2-method";
+export const API_BASE_HEADER = "x-gpt-image-2-api-base";
+export const RELAY_VERSION_HEADER = "x-gpt-image-2-relay-version";
+
+export type OperationSpec = {
+  operation: Exclude<RelayOperation, "asset">;
+  suffix: string;
+  upstreamMethod: "GET" | "POST";
+  maxRequestBytes: number;
+  maxResponseBytes: number;
+  timeoutMs: number;
+  requestContentType?: "application/json" | "multipart/form-data";
+};
+
+export const OPERATION_SPECS: Record<
+  Exclude<RelayOperation, "asset">,
+  OperationSpec
+> = {
+  models: {
+    operation: "models",
+    suffix: "/models",
+    upstreamMethod: "GET",
+    maxRequestBytes: 0,
+    maxResponseBytes: 2 * 1024 * 1024,
+    timeoutMs: 15_000,
+  },
+  generations: {
+    operation: "generations",
+    suffix: "/images/generations",
+    upstreamMethod: "POST",
+    maxRequestBytes: 1024 * 1024,
+    maxResponseBytes: 120 * 1024 * 1024,
+    timeoutMs: 300_000,
+    requestContentType: "application/json",
+  },
+  edits: {
+    operation: "edits",
+    suffix: "/images/edits",
+    upstreamMethod: "POST",
+    maxRequestBytes: 50 * 1024 * 1024,
+    maxResponseBytes: 120 * 1024 * 1024,
+    timeoutMs: 300_000,
+    requestContentType: "multipart/form-data",
+  },
+};
+
+export const ASSET_MAX_REQUEST_BYTES = 8 * 1024;
+export const ASSET_MAX_RESPONSE_BYTES = 32 * 1024 * 1024;
+export const ASSET_MAX_ERROR_RESPONSE_BYTES = 64 * 1024;
+export const API_MAX_ERROR_RESPONSE_BYTES = 2 * 1024 * 1024;
+export const ASSET_TIMEOUT_MS = 60_000;
+export const ASSET_MAX_REDIRECTS = 2;
+
+function invalidTarget(message: string): never {
+  throw new RelayHttpError(400, message, "invalid_upstream");
+}
+
+function normalizedHostname(url: URL): string {
+  return url.hostname.toLowerCase().replace(/\.$/, "");
+}
+
+function validatePublicHost(url: URL, requestUrl: URL, env: Env): void {
+  const hostname = normalizedHostname(url);
+  if (!hostname || !hostname.includes(".")) {
+    invalidTarget("Upstream must use a public DNS hostname.");
+  }
+  if (hostname.includes(":") || /^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) {
+    invalidTarget("IP literal upstreams are not allowed.");
+  }
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.endsWith(".home.arpa")
+  ) {
+    invalidTarget("Local upstreams are not allowed.");
+  }
+  const ownHost = normalizedHostname(requestUrl);
+  if (hostname === ownHost || blockedHosts(env).has(hostname)) {
+    invalidTarget("The relay cannot target itself.");
+  }
+  url.hostname = hostname;
+}
+
+function parsePublicHttpsUrl(
+  raw: string | null | undefined,
+  maxLength: number,
+  requestUrl: URL,
+  env: Env,
+): URL {
+  if (!raw || raw !== raw.trim())
+    invalidTarget("Missing or invalid upstream URL.");
+  if (raw.length > maxLength) invalidTarget("Upstream URL is too long.");
+  if (/\\|[\u0000-\u001f\u007f]/u.test(raw)) {
+    invalidTarget("Upstream URL contains forbidden characters.");
+  }
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    invalidTarget("Invalid upstream URL.");
+  }
+  if (url.protocol !== "https:") {
+    invalidTarget("Only HTTPS upstreams are allowed.");
+  }
+  if (url.username || url.password) {
+    invalidTarget("Upstream URLs must not include credentials.");
+  }
+  if (url.port && url.port !== "443") {
+    invalidTarget("Only the default HTTPS port is allowed.");
+  }
+  validatePublicHost(url, requestUrl, env);
+  return url;
+}
+
+export function validateApiBase(
+  raw: string | null | undefined,
+  requestUrl: URL,
+  env: Env,
+): URL {
+  if (/%(?:2e|2f|5c|25)/iu.test(raw ?? "")) {
+    invalidTarget("Encoded path separators are not allowed in the API base.");
+  }
+  const url = parsePublicHttpsUrl(raw, 2048, requestUrl, env);
+  if (url.search || url.hash) {
+    invalidTarget("API base URL must not contain a query or fragment.");
+  }
+  if (url.pathname.length > 512 || url.pathname.includes("//")) {
+    invalidTarget("API base path is invalid.");
+  }
+  return url;
+}
+
+export function operationUrl(base: URL, spec: OperationSpec): URL {
+  const basePath =
+    base.pathname === "/" ? "" : base.pathname.replace(/\/+$/, "");
+  return new URL(`${basePath}${spec.suffix}`, base.origin);
+}
+
+export function validateAssetTarget(
+  raw: string | null | undefined,
+  requestUrl: URL,
+  env: Env,
+): URL {
+  const url = parsePublicHttpsUrl(raw, 8192, requestUrl, env);
+  if (url.hash) invalidTarget("Asset URL must not contain a fragment.");
+  return url;
+}
+
+export type LegacyDecision =
+  | { operation: Exclude<RelayOperation, "asset">; base: URL }
+  | { operation: "asset"; target: URL };
+
+export function classifyLegacyRequest(
+  raw: string | null,
+  method: string,
+  hasAuthorization: boolean,
+  requestUrl: URL,
+  env: Env,
+): LegacyDecision {
+  const normalizedMethod = method.trim().toUpperCase();
+  if (normalizedMethod === "GET" && !hasAuthorization) {
+    return {
+      operation: "asset",
+      target: validateAssetTarget(raw, requestUrl, env),
+    };
+  }
+  if (!raw || raw.length > 2048) invalidTarget("Invalid legacy API endpoint.");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    invalidTarget("Invalid legacy API endpoint.");
+  }
+  if (parsed.search || parsed.hash) {
+    invalidTarget("Legacy API endpoints must not contain a query or fragment.");
+  }
+
+  const candidates = Object.values(OPERATION_SPECS).filter(
+    (spec) =>
+      spec.upstreamMethod === normalizedMethod &&
+      parsed.pathname.endsWith(spec.suffix),
+  );
+  if (candidates.length !== 1) {
+    throw new RelayHttpError(
+      403,
+      "Legacy relay only supports models, generations, edits, and asset downloads.",
+      "operation_not_allowed",
+    );
+  }
+  const spec = candidates[0];
+  const prefix = parsed.pathname.slice(0, -spec.suffix.length) || "/";
+  const base = validateApiBase(`${parsed.origin}${prefix}`, requestUrl, env);
+  if (operationUrl(base, spec).href !== parsed.href) {
+    invalidTarget("Invalid legacy API endpoint.");
+  }
+  return { operation: spec.operation, base };
+}
+
+export function requireAllowedOrigin(request: Request, env: Env): string {
+  const origin = request.headers.get("Origin");
+  if (
+    !origin ||
+    origin !== new URL(request.url).origin ||
+    !allowedOrigins(env).includes(origin)
+  ) {
+    throw new RelayHttpError(403, "Origin is not allowed.", "origin_denied");
+  }
+  return origin;
+}
+
+export function requireSameOriginPost(request: Request, env: Env): string {
+  const origin = requireAllowedOrigin(request, env);
+  if (request.headers.get("Sec-Fetch-Site") !== "same-origin") {
+    throw new RelayHttpError(
+      403,
+      "Cross-site relay requests are not allowed.",
+      "cross_site_denied",
+    );
+  }
+  if (request.headers.get(RELAY_VERSION_HEADER) !== "2") {
+    throw new RelayHttpError(
+      403,
+      "Relay protocol version is missing.",
+      "protocol_version_required",
+    );
+  }
+  return origin;
+}
+
+export function requireSameOriginRead(request: Request, env: Env): void {
+  const origin = request.headers.get("Origin");
+  if (
+    origin &&
+    (origin !== new URL(request.url).origin ||
+      !allowedOrigins(env).includes(origin))
+  ) {
+    throw new RelayHttpError(403, "Origin is not allowed.", "origin_denied");
+  }
+  if (request.headers.get("Sec-Fetch-Site") !== "same-origin") {
+    throw new RelayHttpError(
+      403,
+      "Cross-site relay requests are not allowed.",
+      "cross_site_denied",
+    );
+  }
+}
+
+export function requireLegacyRequestOrigin(request: Request, env: Env): void {
+  requireAllowedOrigin(request, env);
+  const fetchSite = request.headers.get("Sec-Fetch-Site");
+  if (fetchSite && fetchSite !== "same-origin") {
+    throw new RelayHttpError(
+      403,
+      "Cross-site relay requests are not allowed.",
+      "cross_site_denied",
+    );
+  }
+}
+
+export function validateContentType(
+  request: Request,
+  expected: "application/json" | "multipart/form-data",
+): void {
+  const contentType = request.headers.get("Content-Type")?.toLowerCase() ?? "";
+  const mediaType = contentType.split(";", 1)[0].trim();
+  const hasMultipartBoundary =
+    /(?:^|;)\s*boundary=(?:"[^"]{1,200}"|[^;\s]{1,200})(?:;|$)/u.test(
+      contentType,
+    );
+  if (
+    (expected === "application/json" && mediaType !== "application/json") ||
+    (expected === "multipart/form-data" &&
+      (mediaType !== "multipart/form-data" || !hasMultipartBoundary))
+  ) {
+    throw new RelayHttpError(
+      415,
+      `Relay request must use ${expected}.`,
+      "unsupported_media_type",
+    );
+  }
+}
+
+export function validateContentLength(
+  request: Request,
+  maxBytes: number,
+): void {
+  const raw = request.headers.get("Content-Length");
+  if (!raw) return;
+  if (!/^\d+$/.test(raw)) {
+    throw new RelayHttpError(400, "Invalid Content-Length.", "invalid_length");
+  }
+  const length = Number(raw);
+  if (!Number.isSafeInteger(length) || length > maxBytes) {
+    throw new RelayHttpError(
+      413,
+      `Relay request exceeds the ${maxBytes}-byte limit.`,
+      "request_too_large",
+    );
+  }
+}

--- a/workers/gpt-image-2-relay/src/session.ts
+++ b/workers/gpt-image-2-relay/src/session.ts
@@ -1,0 +1,260 @@
+import { cookieSecure, sessionTtlSeconds } from "./config";
+import { readResponseJsonLimited } from "./streams";
+import { RelayHttpError, type Env, type RateLimitBinding } from "./types";
+
+const encoder = new TextEncoder();
+const SESSION_COOKIE = "__Host-gpt2_relay";
+const DEV_SESSION_COOKIE = "gpt2_relay_dev";
+const TURNSTILE_VERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export type RelaySession = {
+  sid: string;
+  issuedAt: number;
+  expiresAt: number;
+};
+
+type TurnstileResult = {
+  success?: boolean;
+  hostname?: string;
+  action?: string;
+};
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function hmac(value: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(value),
+  );
+  return base64Url(new Uint8Array(signature));
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  let difference = left.length ^ right.length;
+  const max = Math.max(left.length, right.length);
+  for (let index = 0; index < max; index += 1) {
+    difference |=
+      (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+  return difference === 0;
+}
+
+function cookieName(env: Env): string {
+  return cookieSecure(env) ? SESSION_COOKIE : DEV_SESSION_COOKIE;
+}
+
+function sessionSecret(env: Env): string {
+  const secret = env.RELAY_SESSION_HMAC_KEY ?? "";
+  if (secret.length < 32) {
+    throw new RelayHttpError(
+      503,
+      "Relay session service is not configured.",
+      "relay_not_configured",
+    );
+  }
+  return secret;
+}
+
+function randomSid(): string {
+  return base64Url(crypto.getRandomValues(new Uint8Array(16)));
+}
+
+export async function createSessionCookie(
+  env: Env,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<{ header: string; session: RelaySession }> {
+  const session: RelaySession = {
+    sid: randomSid(),
+    issuedAt: nowSeconds,
+    expiresAt: nowSeconds + sessionTtlSeconds(env),
+  };
+  const payload = `v2.${session.issuedAt}.${session.expiresAt}.${session.sid}`;
+  const signature = await hmac(payload, sessionSecret(env));
+  const attributes = [
+    `${cookieName(env)}=${payload}.${signature}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    `Max-Age=${sessionTtlSeconds(env)}`,
+  ];
+  if (cookieSecure(env)) attributes.push("Secure");
+  return { header: attributes.join("; "), session };
+}
+
+function cookieValue(request: Request, name: string): string | undefined {
+  const raw = request.headers.get("Cookie");
+  if (!raw || raw.length > 8192) return undefined;
+  for (const part of raw.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() === name) {
+      return part.slice(separator + 1).trim();
+    }
+  }
+  return undefined;
+}
+
+export async function verifySession(
+  request: Request,
+  env: Env,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<RelaySession | undefined> {
+  const token = cookieValue(request, cookieName(env));
+  if (!token || token.length > 512) return undefined;
+  const parts = token.split(".");
+  if (parts.length !== 5 || parts[0] !== "v2") return undefined;
+  const issuedAt = Number(parts[1]);
+  const expiresAt = Number(parts[2]);
+  const sid = parts[3];
+  const signature = parts[4];
+  if (
+    !Number.isSafeInteger(issuedAt) ||
+    !Number.isSafeInteger(expiresAt) ||
+    !/^[A-Za-z0-9_-]{20,64}$/.test(sid) ||
+    !/^[A-Za-z0-9_-]{40,64}$/.test(signature) ||
+    issuedAt > nowSeconds + 60 ||
+    expiresAt <= nowSeconds ||
+    expiresAt <= issuedAt ||
+    expiresAt - issuedAt > 86_400
+  ) {
+    return undefined;
+  }
+  const payload = parts.slice(0, 4).join(".");
+  const secrets = [
+    sessionSecret(env),
+    env.RELAY_SESSION_HMAC_KEY_PREVIOUS ?? "",
+  ].filter((secret) => secret.length >= 32);
+  for (const secret of secrets) {
+    const expected = await hmac(payload, secret);
+    if (timingSafeEqual(signature, expected)) {
+      return { sid, issuedAt, expiresAt };
+    }
+  }
+  return undefined;
+}
+
+export async function rateKeyForRequest(request: Request): Promise<string> {
+  const source = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(`relay-rate:${source}`),
+  );
+  return base64Url(new Uint8Array(digest));
+}
+
+export async function enforceRateLimit(
+  binding: RateLimitBinding | undefined,
+  key: string,
+): Promise<void> {
+  if (!binding) {
+    throw new RelayHttpError(
+      503,
+      "Relay rate limiting is not configured.",
+      "relay_not_configured",
+    );
+  }
+  const outcome = await binding.limit({ key });
+  if (!outcome.success) {
+    throw new RelayHttpError(
+      429,
+      "Relay rate limit exceeded. Try again shortly.",
+      "relay_rate_limited",
+      60,
+    );
+  }
+}
+
+export async function verifyTurnstile(
+  request: Request,
+  env: Env,
+  token: string,
+  origin: string,
+): Promise<void> {
+  if (!token || token.length > 2048) {
+    throw new RelayHttpError(
+      400,
+      "Turnstile token is required.",
+      "turnstile_token_required",
+    );
+  }
+  const secret = env.TURNSTILE_SECRET_KEY?.trim();
+  if (!secret) {
+    throw new RelayHttpError(
+      503,
+      "Relay session service is not configured.",
+      "relay_not_configured",
+    );
+  }
+  const body = new URLSearchParams({ secret, response: token });
+  const remoteIp = request.headers.get("CF-Connecting-IP");
+  if (remoteIp) body.set("remoteip", remoteIp);
+
+  let response: Response;
+  try {
+    response = await fetch(TURNSTILE_VERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      redirect: "error",
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    throw new RelayHttpError(
+      503,
+      "Turnstile verification is temporarily unavailable.",
+      "relay_auth_unavailable",
+    );
+  }
+  if (!response.ok) {
+    response.body?.cancel("turnstile verification failed");
+    throw new RelayHttpError(
+      503,
+      "Turnstile verification is temporarily unavailable.",
+      "relay_auth_unavailable",
+    );
+  }
+  let result: TurnstileResult;
+  try {
+    result = await readResponseJsonLimited<TurnstileResult>(
+      response,
+      16 * 1024,
+    );
+  } catch {
+    throw new RelayHttpError(
+      503,
+      "Turnstile returned an invalid response.",
+      "relay_auth_unavailable",
+    );
+  }
+  const expectedHostname = new URL(origin).hostname
+    .toLowerCase()
+    .replace(/\.$/, "");
+  const actualHostname = result.hostname?.toLowerCase().replace(/\.$/, "");
+  if (
+    result.success !== true ||
+    result.action !== "relay_session" ||
+    actualHostname !== expectedHostname
+  ) {
+    throw new RelayHttpError(
+      403,
+      "Turnstile verification failed.",
+      "turnstile_rejected",
+    );
+  }
+}

--- a/workers/gpt-image-2-relay/src/streams.ts
+++ b/workers/gpt-image-2-relay/src/streams.ts
@@ -1,0 +1,111 @@
+import { RelayHttpError } from "./types";
+
+export function limitRequestBody(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): ReadableStream<Uint8Array> | undefined {
+  if (!body) return undefined;
+  let total = 0;
+  return body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        total += chunk.byteLength;
+        if (total > maxBytes) {
+          controller.error(
+            new RelayHttpError(
+              413,
+              `Relay request exceeds the ${maxBytes}-byte limit.`,
+              "request_too_large",
+            ),
+          );
+          return;
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+}
+
+export function limitResponseBody(
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): ReadableStream<Uint8Array> {
+  const reader = body.getReader();
+  let total = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        controller.close();
+        return;
+      }
+      total += chunk.value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel("relay response exceeded size limit");
+        controller.error(new Error("Relay response exceeded size limit."));
+        return;
+      }
+      controller.enqueue(chunk.value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+async function readBytesLimited(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  if (!body) {
+    throw new RelayHttpError(400, "Request body is required.", "body_required");
+  }
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        throw new RelayHttpError(
+          413,
+          `Relay request exceeds the ${maxBytes}-byte limit.`,
+          "request_too_large",
+        );
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    await reader.cancel("request body rejected").catch(() => undefined);
+    throw error;
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+export async function readJsonLimited<T>(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<T> {
+  const bytes = await readBytesLimited(body, maxBytes);
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return JSON.parse(text) as T;
+  } catch {
+    throw new RelayHttpError(400, "Invalid JSON body.", "invalid_json");
+  }
+}
+
+export async function readResponseJsonLimited<T>(
+  response: Response,
+  maxBytes: number,
+): Promise<T> {
+  return readJsonLimited<T>(response.body, maxBytes);
+}

--- a/workers/gpt-image-2-relay/src/types.ts
+++ b/workers/gpt-image-2-relay/src/types.ts
@@ -1,0 +1,34 @@
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+export interface Env {
+  RELAY_ENABLED?: string;
+  RELAY_V2_ENABLED?: string;
+  RELAY_V1_MODE?: string;
+  RELAY_ALLOWED_ORIGINS?: string;
+  RELAY_BLOCKED_HOSTS?: string;
+  RELAY_SESSION_TTL_SECONDS?: string;
+  RELAY_COOKIE_SECURE?: string;
+  TURNSTILE_SITE_KEY?: string;
+  TURNSTILE_SECRET_KEY?: string;
+  RELAY_SESSION_HMAC_KEY?: string;
+  RELAY_SESSION_HMAC_KEY_PREVIOUS?: string;
+  RELAY_SESSION_RATE?: RateLimitBinding;
+  RELAY_SESSION_ISSUE_RATE?: RateLimitBinding;
+  RELAY_LEGACY_RATE?: RateLimitBinding;
+}
+
+export type RelayOperation = "models" | "generations" | "edits" | "asset";
+
+export class RelayHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly code: string,
+    readonly retryAfter?: number,
+  ) {
+    super(message);
+    this.name = "RelayHttpError";
+  }
+}

--- a/workers/gpt-image-2-relay/wrangler.jsonc
+++ b/workers/gpt-image-2-relay/wrangler.jsonc
@@ -3,25 +3,42 @@
   "name": "gpt-image-2-relay",
   "main": "src/index.ts",
   "compatibility_date": "2026-04-30",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "workers_dev": false,
   "routes": [
     {
       "pattern": "image.codex-pool.com/api/relay*",
-      "zone_name": "codex-pool.com"
-    }
+      "zone_name": "codex-pool.com",
+    },
   ],
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
   },
+  "ratelimits": [
+    {
+      "name": "RELAY_SESSION_RATE",
+      "namespace_id": "983746201",
+      "simple": { "limit": 120, "period": 60 },
+    },
+    {
+      "name": "RELAY_SESSION_ISSUE_RATE",
+      "namespace_id": "983746202",
+      "simple": { "limit": 10, "period": 60 },
+    },
+    {
+      "name": "RELAY_LEGACY_RATE",
+      "namespace_id": "983746203",
+      "simple": { "limit": 80, "period": 60 },
+    },
+  ],
   "vars": {
     "RELAY_ENABLED": "true",
-    "RELAY_MODE": "open",
-    "RELAY_ALLOWLIST_REPORT_ONLY": "true",
-    "RELAY_ALLOWED_ORIGINS": "https://image.codex-pool.com,https://gpt-image-2-dpm.pages.dev",
-    "RELAY_MAX_REQUEST_BYTES": "52428800",
-    "RELAY_MAX_RESPONSE_BYTES": "125829120",
-    "RELAY_ALLOWED_METHODS": "GET,POST,OPTIONS"
-  }
+    "RELAY_V2_ENABLED": "true",
+    "RELAY_V1_MODE": "restricted",
+    "RELAY_ALLOWED_ORIGINS": "https://image.codex-pool.com",
+    "RELAY_BLOCKED_HOSTS": "image.codex-pool.com,gpt-image-2-dpm.pages.dev",
+    "RELAY_SESSION_TTL_SECONDS": "86400",
+    "RELAY_COOKIE_SECURE": "true",
+  },
 }


### PR DESCRIPTION
## Summary

- replace the open relay with operation-scoped Relay v2, Turnstile sessions, strict origin/fetch-metadata checks, rate limits, body/response limits, and SSRF-safe redirects
- keep the legacy endpoint temporarily in restricted compatibility mode so the Worker can deploy before the new Pages bundle
- add Pages/Tauri CSP, signed Docker Web sessions, patched Rust/npm dependencies, CodeQL/Dependabot, immutable Actions, and checksum-pinned cargo-dist installers

## Verification

- Worker: 19 tests, typecheck, Wrangler dry-run, npm audit 0
- Web app: 98 tests, typecheck, production build, npm audit 0
- Rust: workspace tests, Clippy with warnings denied, cargo audit 0 vulnerabilities
- CI: actionlint, immutable-action/pipe-to-shell policy, gitleaks, diff check
- Docker Web: signed-session integration probe with Secure/HttpOnly/SameSite cookie and no shared token in the cookie

## Production order

After merge: configure scoped Cloudflare token and Turnstile secrets, deploy Worker first, run negative and browser canaries, then deploy Pages. Never restore open/report-only mode.