### PR TITLE
fix(deploy): attest challenged Worker health checks

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -153,25 +153,89 @@ jobs:
           done
 
       - name: Deploy relay Worker first
-        run: npm --prefix workers/gpt-image-2-relay run deploy
+        run: |
+          npm --prefix workers/gpt-image-2-relay run deploy -- \
+            --message "git:${{ needs.verify.outputs.commit }}"
 
       - name: Require a ready relay v2 before publishing the static app
         shell: bash
         run: |
           config_file="$RUNNER_TEMP/relay-v2-config.json"
+          headers_file="$RUNNER_TEMP/relay-v2-headers.txt"
+          challenge_detected=0
           for attempt in {1..18}; do
-            if curl --fail --silent --show-error --max-time 10 \
+            http_code="$(curl --silent --show-error --max-time 10 \
               "https://image.codex-pool.com/api/relay/v2/config" \
+              --dump-header "$headers_file" \
               --output "$config_file" \
+              --write-out "%{http_code}" || true)"
+            if [[ "$http_code" == "200" ]] \
               && jq -e \
                 '.version == 2 and .enabled == true and .auth_mode == "turnstile" and (.turnstile_site_key | type == "string" and length > 0)' \
                 "$config_file" >/dev/null; then
               exit 0
             fi
+            if [[ "$http_code" == "403" ]] \
+              && grep -Eiq '^cf-mitigated:[[:space:]]*challenge([[:space:]]|$)' "$headers_file"; then
+              challenge_detected=1
+              break
+            fi
             sleep 5
           done
-          echo "::error::Relay v2 did not become ready; static deployment is blocked."
-          exit 1
+
+          if [[ "$challenge_detected" -ne 1 ]]; then
+            echo "::error::Relay v2 did not become ready; static deployment is blocked."
+            exit 1
+          fi
+
+          # Bot Fight Mode can challenge GitHub-hosted runners before the
+          # request reaches the Worker. Only that explicit Cloudflare response
+          # may use this fallback, which attests the immutable deployed version
+          # and every security-critical binding through the authenticated API.
+          wrangler="./workers/gpt-image-2-relay/node_modules/.bin/wrangler"
+          deployment_json="$($wrangler deployments status \
+            --config workers/gpt-image-2-relay/wrangler.jsonc \
+            --json)"
+          version_id="$(jq -er '
+            if .source == "wrangler"
+              and (.versions | length) == 1
+              and .versions[0].percentage == 100
+            then .versions[0].version_id
+            else error("latest Worker deployment is not a single 100% Wrangler version")
+            end
+          ' <<<"$deployment_json")"
+          version_json="$($wrangler versions view "$version_id" \
+            --config workers/gpt-image-2-relay/wrangler.jsonc \
+            --json)"
+          expected_message="git:${{ needs.verify.outputs.commit }}"
+          if ! jq -e --arg expected_message "$expected_message" '
+            def has_plain($name; $text):
+              any(.resources.bindings[]?;
+                .name == $name and .type == "plain_text" and .text == $text);
+            def has_type($name; $type):
+              any(.resources.bindings[]?;
+                .name == $name and .type == $type);
+
+            .annotations["workers/message"] == $expected_message
+              and has_plain("RELAY_ENABLED"; "true")
+              and has_plain("RELAY_V2_ENABLED"; "true")
+              and has_plain("RELAY_V1_MODE"; "restricted")
+              and has_plain("RELAY_ALLOWED_ORIGINS"; "https://image.codex-pool.com")
+              and has_plain("RELAY_COOKIE_SECURE"; "true")
+              and has_plain("RELAY_SESSION_TTL_SECONDS"; "86400")
+              and has_type("TURNSTILE_SITE_KEY"; "secret_text")
+              and has_type("TURNSTILE_SECRET_KEY"; "secret_text")
+              and has_type("RELAY_SESSION_HMAC_KEY"; "secret_text")
+              and has_type("RELAY_SESSION_RATE"; "ratelimit")
+              and has_type("RELAY_SESSION_ISSUE_RATE"; "ratelimit")
+              and has_type("RELAY_LEGACY_RATE"; "ratelimit")
+              and (.resources.script_runtime.compatibility_flags
+                | index("global_fetch_strictly_public") != null)
+          ' <<<"$version_json" >/dev/null; then
+            echo "::error::Cloudflare API could not attest the expected relay deployment."
+            exit 1
+          fi
+          echo "::warning::Public probe was challenged by Cloudflare; the exact Worker commit and security bindings were attested through the Cloudflare API."
 
       - name: Deploy to Cloudflare Pages
         shell: bash

--- a/docs/relay-security-runbook.md
+++ b/docs/relay-security-runbook.md
@@ -65,6 +65,8 @@ test -f apps/gpt-image-2-app/dist/_headers
 
 这保证新网页不会先于新 Worker 上线。Worker 部署后即使 Pages 步骤失败，旧缓存页面仍走受限 v1；不会回退到开放代理。
 
+Cloudflare Bot Fight Mode 可能在请求到达 Worker 前对 GitHub-hosted runner 返回 Managed Challenge。部署门禁只在响应明确包含 `cf-mitigated: challenge` 时允许替代验证：通过已认证的 Cloudflare API 确认最新 deployment 是本次 commit 标记的单一 100% Worker 版本，并逐项核对 restricted v1、v2、精确 Origin、Secure Cookie、3 个 Secret、3 个 rate-limit binding 与 `global_fetch_strictly_public`。普通 403、5xx、网络错误或任一绑定不符仍必须阻止 Pages 发布。
+
 首次上线不要直接发正式 Pages。先单独部署 Worker并验证旧页面，再安排静态页面 canary：
 
 ```bash


### PR DESCRIPTION
Cloudflare Bot Fight Mode challenges GitHub-hosted curl probes before requests reach the Worker. Keep the public JSON probe as the primary gate, but for an explicit `cf-mitigated: challenge` only, attest the exact commit-tagged 100% Worker version and every security-critical binding through the authenticated Cloudflare API. All other failures remain fail-closed.