### PR TITLE
fix(security): close new dependency and CodeQL alerts

### DIFF
--- a/apps/gpt-image-2-app/package-lock.json
+++ b/apps/gpt-image-2-app/package-lock.json
@@ -2920,9 +2920,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.21",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
-      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2979,11 +2979,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3027,9 +3027,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001790",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
-      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -3191,9 +3191,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3791,11 +3791,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4038,9 +4041,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4712,9 +4715,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/crates/gpt-image-2-core/src/image_requests/image_sources.rs
+++ b/crates/gpt-image-2-core/src/image_requests/image_sources.rs
@@ -93,7 +93,12 @@ pub(crate) fn local_path_to_data_url(path: &Path) -> Result<String, AppError> {
 pub(crate) fn resolve_ref_image(value: &str) -> Result<String, AppError> {
     match Url::parse(value) {
         Ok(url) => match url.scheme() {
-            "http" | "https" | "data" => Ok(value.to_string()),
+            "http" => Err(AppError::new(
+                "image_url_insecure",
+                "Remote reference image URLs must use HTTPS.",
+            )
+            .with_detail(json!({ "scheme": "http", "url": redact_url_for_log(value) }))),
+            "https" | "data" => Ok(value.to_string()),
             "file" => {
                 let path = url
                     .to_file_path()
@@ -183,7 +188,7 @@ fn read_capped(
     Ok(buf)
 }
 
-/// Fetch an **untrusted, user-supplied** reference image over http(s). Always
+/// Fetch an **untrusted, user-supplied** reference image over HTTPS. Always
 /// direct-connect so the SSRF validation and address pinning actually hold — a
 /// remote-resolving proxy (http/socks5h, or a `no_proxy` miss) would resolve
 /// the host itself and defeat the pin. A URL only reachable through a proxy
@@ -192,7 +197,7 @@ pub(crate) fn download_reference_image_bytes(url: &str) -> Result<Vec<u8>, AppEr
     download_http_image_bytes(url, None)
 }
 
-/// Fetch a **trusted, provider-returned** result image URL (e.g. the `url` in
+/// Fetch a **trusted, provider-returned** HTTPS result image URL (e.g. the `url` in
 /// an OpenAI image response). The URL comes from the provider's authenticated
 /// TLS response, so we honor the proxy the user configured to reach that
 /// provider's CDN; pinning can't apply through a resolving proxy, which is
@@ -215,7 +220,18 @@ fn download_http_image_bytes(url: &str, proxy: Option<&ProxyConfig>) -> Result<V
     // Every body read is bounded.
     let mut current = url.to_string();
     for _ in 0..=MAX_REDIRECT_HOPS {
-        let (_, host_label, addrs) = validate_remote_http_target(&current, "Image download")?;
+        let current_url = Url::parse(&current).map_err(|error| {
+            AppError::new("image_url_invalid", "Image download URL is invalid.")
+                .with_detail(json!({ "error": error.to_string(), "url": redacted }))
+        })?;
+        if current_url.scheme() != "https" {
+            return Err(
+                AppError::new("image_url_insecure", "Remote image URLs must use HTTPS.")
+                    .with_detail(json!({ "scheme": current_url.scheme(), "url": redacted })),
+            );
+        }
+        let (_, host_label, addrs) =
+            validate_remote_http_target(current_url.as_str(), "Image download")?;
         let builder = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT))
             .redirect(reqwest::redirect::Policy::none())
@@ -233,7 +249,7 @@ fn download_http_image_bytes(url: &str, proxy: Option<&ProxyConfig>) -> Result<V
             AppError::new("network_error", "Unable to build download client.")
                 .with_detail(json!({ "error": error.to_string() }))
         })?;
-        let response = client.get(&current).send().map_err(|error| {
+        let response = client.get(current_url.clone()).send().map_err(|error| {
             AppError::new("network_error", "Unable to download image bytes.")
                 .with_detail(json!({ "error": error.to_string(), "url": redacted }))
         })?;
@@ -249,12 +265,10 @@ fn download_http_image_bytes(url: &str, proxy: Option<&ProxyConfig>) -> Result<V
                 })?;
             // Resolve relative redirects against the current URL. The next loop
             // iteration validates and pins this target before connecting.
-            let next = Url::parse(&current)
-                .and_then(|base| base.join(location))
-                .map_err(|error| {
-                    AppError::new("network_error", "Invalid redirect target.")
-                        .with_detail(json!({ "error": error.to_string() }))
-                })?;
+            let next = current_url.join(location).map_err(|error| {
+                AppError::new("network_error", "Invalid redirect target.")
+                    .with_detail(json!({ "error": error.to_string() }))
+            })?;
             current = next.to_string();
             continue;
         }
@@ -353,9 +367,9 @@ mod download_ssrf_tests {
     #[test]
     fn rejects_loopback_and_link_local_targets() {
         for url in [
-            "http://127.0.0.1/x.png",
-            "http://[::1]/x.png",
-            "http://169.254.169.254/latest/meta-data/",
+            "https://127.0.0.1/x.png",
+            "https://[::1]/x.png",
+            "https://169.254.169.254/latest/meta-data/",
         ] {
             let err = download_reference_image_bytes(url).unwrap_err();
             assert_ne!(
@@ -363,5 +377,30 @@ mod download_ssrf_tests {
                 "{url} should be rejected by the SSRF guard, not attempted"
             );
         }
+    }
+
+    #[test]
+    fn rejects_plaintext_image_urls_before_network_access() {
+        let err = download_reference_image_bytes("http://images.example.com/x.png").unwrap_err();
+        assert_eq!(err.code, "image_url_insecure");
+
+        let err = download_result_image_bytes(
+            "http://cdn.example.com/result.png",
+            &ProxyConfig::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, "image_url_insecure");
+    }
+
+    #[test]
+    fn rejects_plaintext_reference_urls_before_provider_dispatch() {
+        let err = resolve_ref_image("http://images.example.com/ref.png").unwrap_err();
+        assert_eq!(err.code, "image_url_insecure");
+
+        let secure = "https://images.example.com/ref.png";
+        assert_eq!(resolve_ref_image(secure).unwrap(), secure);
+
+        let inline = "data:image/png;base64,iVBORw0KGgo=";
+        assert_eq!(resolve_ref_image(inline).unwrap(), inline);
     }
 }

--- a/crates/gpt-image-2-core/src/storage/types.rs
+++ b/crates/gpt-image-2-core/src/storage/types.rs
@@ -435,7 +435,10 @@ impl StorageConfig {
                     (false, false) => match self.fallback_policy {
                         StorageFallbackPolicy::Never => primary.clone(),
                         StorageFallbackPolicy::OnFailure | StorageFallbackPolicy::Always => {
-                            let mut out = Vec::with_capacity(primary.len() + fallback.len());
+                            // These legacy lists come from serialized configuration. Avoid
+                            // deriving an eager allocation size from untrusted lengths; the
+                            // vector grows incrementally as deduplicated entries are copied.
+                            let mut out = Vec::new();
                             for name in primary.iter().chain(fallback.iter()) {
                                 if !out.iter().any(|existing: &String| existing == name) {
                                     out.push(name.clone());


### PR DESCRIPTION
## Summary
- require HTTPS for every remote reference/result image hop without restricting domains or provider API base URLs
- remove untrusted legacy storage-list length preallocation while preserving merge semantics
- update the transitive frontend build dependencies `browserslist` and `postcss-selector-parser` to patched versions

## Security invariants
- plaintext image URLs fail before provider dispatch or local network access
- redirects are revalidated and cannot downgrade to HTTP
- local files, data URLs, arbitrary HTTPS image domains, and custom API relay domains remain supported

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- app: `npm audit --audit-level=high`, typecheck, 98 tests, production build
- relay: `npm audit --audit-level=high`, typecheck, 19 tests
- workflow supply-chain check and skill wrapper security tests
- `cargo audit`: 0 vulnerabilities